### PR TITLE
Fix for deprecated use of numpy data types.

### DIFF
--- a/dev/test_PolyCycles2.py
+++ b/dev/test_PolyCycles2.py
@@ -235,10 +235,10 @@ if __name__ == "__main__":
 
     ring_bonds  = ch.findBonds(ring_pos,ring_Rs,fR=1.0)
     ring_neighs = ch.bonds2neighs(ring_bonds,Nring)
-    ring_nngs   = np.array([ len(ng) for ng in ring_neighs ],dtype=np.int)
+    ring_nngs   = np.array([ len(ng) for ng in ring_neighs ],dtype=int)
 
     tris,bonds_ = ch.findTris(ring_bonds,ring_neighs)
-    atom2ring   = np.array( list(tris), dtype=np.int )
+    atom2ring   = np.array( list(tris), dtype=int )
     #print "atom2ring ", atom2ring
 
     atom_pos = ( ring_pos[atom2ring[:,0]] + ring_pos[atom2ring[:,1]] + ring_pos[atom2ring[:,2]] )/3.0
@@ -281,9 +281,9 @@ if __name__ == "__main__":
     #tris_ = ch.tris2num(tris)
     #print "tris_ ", tris_
 
-    nngs  = np.array([ len(ngs) for ngs in neighs ],dtype=np.int)
+    nngs  = np.array([ len(ngs) for ngs in neighs ],dtype=int)
 
-    #atypes=np.zeros(len(nngs),dtype=np.int)
+    #atypes=np.zeros(len(nngs),dtype=int)
     atypes=nngs.copy()-1
     #atypes[atom_N6mask]=0
     atypes[atom_N6mask]=3
@@ -331,7 +331,7 @@ if __name__ == "__main__":
 
     # --- groups -> atoms
     groupDict = ch.makeGroupLevels(groupDict)
-    aoi = np.round(ao).astype(np.int)
+    aoi = np.round(ao).astype(int)
     groups = ch.selectRandomGroups( nngs, aoi, groupDict )
 
     #for i in range(len(groups)):

--- a/ppafm/chemistry.py
+++ b/ppafm/chemistry.py
@@ -114,7 +114,7 @@ def findTris_(bonds,neighs):
 
 def getRingNatom(atom2ring,nr):
     #nr = len(ringNeighs)
-    nra=np.zeros(nr,dtype=np.int)
+    nra=np.zeros(nr,dtype=int)
     for r1,r2,r3 in atom2ring:
         nra[r1]+=1
         nra[r2]+=1
@@ -162,10 +162,10 @@ def ringsToMolecule( ring_pos, ring_Rs, Lrange=6.0 ):
     cog = np.sum(ring_pos,axis=0)/Nring
     ring_bonds  = findBonds(ring_pos,ring_Rs,fR=1.0)
     ring_neighs = bonds2neighs(ring_bonds,Nring)
-    ring_nngs   = np.array([ len(ng) for ng in ring_neighs ],dtype=np.int)
+    ring_nngs   = np.array([ len(ng) for ng in ring_neighs ],dtype=int)
 
     tris,bonds_ = findTris(ring_bonds,ring_neighs)
-    atom2ring   = np.array( list(tris), dtype=np.int )
+    atom2ring   = np.array( list(tris), dtype=int )
 
     atom_pos = ( ring_pos[atom2ring[:,0]] + ring_pos[atom2ring[:,1]] + ring_pos[atom2ring[:,2]] )/3.0
     bonds,_  = tris2num_(tris, bonds_)
@@ -181,7 +181,7 @@ def ringsToMolecule( ring_pos, ring_Rs, Lrange=6.0 ):
                                  ring_N6mask[atom2ring[:,2]]  ) )
 
     neighs  = bonds2neighs( bonds, len(atom_pos) )    # ;print neighs
-    nngs    = np.array([ len(ngs) for ngs in neighs ],dtype=np.int)
+    nngs    = np.array([ len(ngs) for ngs in neighs ],dtype=int)
 
     atypes=nngs.copy()-1
     atypes[atom_N6mask]=3
@@ -451,7 +451,7 @@ def assignAtomBOFF(atypes, typeEs):
     from scipy.interpolate import Akima1DInterpolator
     nt=len(typeEs)
     na=len(atypes)
-    typeMasks = np.empty((nt,na),dtype=np.bool)
+    typeMasks = np.empty((nt,na),dtype=bool)
     typeFFs = []
     Xs = np.array([-1,0,1,2,3,4])
     for it in range(nt):

--- a/ppafm/common.py
+++ b/ppafm/common.py
@@ -17,7 +17,7 @@ CoulombConst         = -14.3996448915;
 params={
     'PBC': True,
     'nPBC' :       np.array( [      1,        1,        1 ] ),
-    'gridN':       np.array( [ -1,     -1,   -1   ] ).astype(np.int),
+    'gridN':       np.array( [ -1,     -1,   -1   ] ).astype(int),
     'gridA':       np.array( [ 12.798,  -7.3889,  0.00000 ] ),
     'gridB':       np.array( [ 12.798,   7.3889,  0.00000 ] ),
     'gridC':       np.array( [      0,        0,      5.0 ] ),
@@ -195,10 +195,10 @@ def loadParams( fname ):
                     params[key] = words[1]
                     if(verbose>0): print(key, params[key], words[1])
                 elif isinstance(val, np.ndarray ):
-                    if val.dtype == np.float:
+                    if val.dtype == float:
                         params[key] = np.array([ float(words[1]), float(words[2]), float(words[3]) ])
                         if(verbose>0): print(key, params[key], words[1], words[2], words[3])
-                    elif val.dtype == np.int:
+                    elif val.dtype == int:
                         if(verbose>0): print(key)
                         params[key] = np.array([ int(words[1]), int(words[2]), int(words[3]) ])
                         if(verbose>0): print(key, params[key], words[1], words[2], words[3])
@@ -235,8 +235,8 @@ def loadSpecies( fname=None ):
         if(verbose>0): print("WARRNING: loadSpecies(None) => load default atomtypes.ini")
         fname = cpp_utils.PACKAGE_PATH / 'defaults' / 'atomtypes.ini'
     if(verbose>0): print(" loadSpecies from ", fname)
-    #FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('atom',np.int),('symbol', '|S10')],usecols=[0,1,2,3])
-    FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('alpha',np.float64),('atom',np.int),('symbol', '|S10')],usecols=(0,1,2,3,4))
+    #FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('atom',int),('symbol', '|S10')],usecols=[0,1,2,3])
+    FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('alpha',np.float64),('atom',int),('symbol', '|S10')],usecols=(0,1,2,3,4))
     return FFparams
 
 # load atoms species parameters form a file ( currently used to load Lenard-Jones parameters )
@@ -247,7 +247,7 @@ def loadSpeciesLines( lines ):
         if len(l) >= 5:
             # print l
             params.append( ( float(l[0]), float(l[1]), float(l[2]), int(l[3]), l[4] ) )
-    return np.array( params, dtype=[('rmin',np.float64),('epsilon',np.float64),('alpha',np.float64),('atom',np.int),('symbol', '|S10')])
+    return np.array( params, dtype=[('rmin',np.float64),('epsilon',np.float64),('alpha',np.float64),('atom',int),('symbol', '|S10')])
 
 def autoGeom( Rs, shiftXY=False, fitCell=False, border=3.0 ):
     '''

--- a/ppafm/dev/Multipoles.py
+++ b/ppafm/dev/Multipoles.py
@@ -93,7 +93,7 @@ cpp_utils.make("MP")
 lib    = ctypes.CDLL(  cpp_utils.CPP_PATH + "/" + cpp_name + cpp_utils.lib_ext )    # load dynamic librady object using ctypes
 
 # define used numpy array types for interfacing with C++
-array1b  = np.ctypeslib.ndpointer(dtype=np.bool  , ndim=1, flags='CONTIGUOUS')
+array1b  = np.ctypeslib.ndpointer(dtype=bool     , ndim=1, flags='CONTIGUOUS')
 array1i  = np.ctypeslib.ndpointer(dtype=np.int32 , ndim=1, flags='CONTIGUOUS')
 array1ui = np.ctypeslib.ndpointer(dtype=np.uint32, ndim=1, flags='CONTIGUOUS')
 array1d  = np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags='CONTIGUOUS')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">=3.6"
 dependencies = [
     "matplotlib",
-    "numpy<=1.21.6", # Remove upper limit when #76 is fixed.
+    "numpy",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes #76 

Replace deprecated numpy data types such as `np.int` with identical built-in data types according to https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.