### PR TITLE
Fixed run.bat for the graphene example.

### DIFF
--- a/examples/Graphene/run.bat
+++ b/examples/Graphene/run.bat
@@ -1,17 +1,14 @@
 
-set PPPATH="../.."
-set PPAFM_RECOMPILE=1
-
 : ======= STEP 1 : Generate force-field grid
 
 : calculation without DFT electrostatics using atomic charges
-python %PPPATH%/generateLJFF.py -i Gr6x6N3hole.xyz
-python %PPPATH%/generateElFF_point_charges.py -i Gr6x6N3hole.xyz --tip s
+ppafm-generate-ljff -i Gr6x6N3hole.xyz
+ppafm-generate-elff-point-charges -i Gr6x6N3hole.xyz --tip s
 
 : ======= STEP 2 : Relax Probe Particle using that force-field grid
 
-python %PPPATH%/relaxed_scan.py -k 0.5 -q -0.05
+ppafm-relaxed-scan -k 0.5 -q -0.05
 
 : ======= STEP 3 : Plot the results
 
-python %PPPATH%/plot_results.py -k 0.5 -q -0.05 -a 2.0 --df
+ppafm-plot-results -k 0.5 -q -0.05 -a 2.0 --df


### PR DESCRIPTION
Fix for the graphene example `run.bat` for Windows. Noticed this while looking into #110.