### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
                   pip install .[dev]
 
             - name: Run pytest
-              run: pytest tests -v --cov
+              run: pytest tests -v --cov --ignore tests/human_eye

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
             - name: Install package and its dependencies
               run: |
-                  pip install -e .[dev]
+                  pip install .[dev]
 
             - name: Run pytest
               run: pytest tests -v --cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,10 @@ jobs:
                   pip install .[dev]
 
             - name: Run pytest
-              run: pytest tests -v --cov --ignore tests/human_eye
+              run: pytest tests -v --cov
+
+            - name: Save test images
+              uses: actions/upload-artifact@v3
+              with:
+                  name: test-images
+                  path: ./*.png

--- a/tests/human_eye/test_TipForce.py
+++ b/tests/human_eye/test_TipForce.py
@@ -1,13 +1,10 @@
 #!/usr/bin/python -u
 
-import os
-import sys
-from io import StringIO 
+from io import StringIO
+
 import matplotlib.pyplot as plt
 import numpy as np
 
-sys.path.append(os.path.split(sys.path[0])[0]) #;print(sys.path[-1])
-#import ppafm               as PPU
 import ppafm.core as PPC
 
 spline_ini = """
@@ -47,4 +44,5 @@ plt.plot(xs, fs[:,2] )
 #print "fs:", fs
 
 plt.grid()
+plt.savefig('tip_force.png')
 plt.show()

--- a/tests/human_eye/test_splines.py
+++ b/tests/human_eye/test_splines.py
@@ -1,13 +1,9 @@
 #!/usr/bin/python -u
 
-import os
-import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-sys.path.append(os.path.split(sys.path[0])[0]) #;print(sys.path[-1])
-#import ppafm                as PPU
 import ppafm.core as PPC
 
 # =========== uniform spline
@@ -28,6 +24,8 @@ plt.plot( xs,  ys+0.1*dys , '.'  );
 plt.plot( xs_, ys_, '-' );
 plt.grid()
 
+plt.savefig('splines1.png')
+
 # =========== non-uniform spline
 
 xs  = np.array   ( [ -0.9, -0.6,  0.4,  0.6 ] )
@@ -46,5 +44,7 @@ plt.grid()
 
 #print "xs_", xs_
 #print "ys_", ys_
+
+plt.savefig('splines2.png')
 
 plt.show()

--- a/tests/human_eye/test_vdwDamping.py
+++ b/tests/human_eye/test_vdwDamping.py
@@ -1,26 +1,25 @@
 #!/usr/bin/python -u
 
-import os
 import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-sys.path.append(os.path.split(sys.path[0])[0]) #;print(sys.path[-1])
 import ppafm.common as PPU
-import ppafm.core   as PPC
-
-
-
+import ppafm.core as PPC
 
 # ======== Setup
 iPP   = 8
-iZs   = [1,6,7,8] 
-#iZs   = [1] 
+iZs   = [1,6,7,8]
+#iZs   = [1]
 iAtom =  3
 
 iVdWModel=3
-if len(sys.argv)>1: iVdWModel=int(sys.argv[1])
+if len(sys.argv)>1:
+    try:
+        iVdWModel=int(sys.argv[1])
+    except ValueError:
+        print(f'Invalid input argument {sys.argv[1]}')
 
 ADamps = [ 180.0, 0.5, 0.5, 0.03, 0.01 ]
 
@@ -39,9 +38,9 @@ model_names = [
 # ======== Functions
 
 def plotDecor( x0, vmax ):
-    plt.axvline( x0, ls=':', c='k'); 
-    plt.axhline( 0, ls='-' , c='k'); 
-    plt.ylim(vmax*-2,vmax) 
+    plt.axvline( x0, ls=':', c='k');
+    plt.axhline( 0, ls='-' , c='k');
+    plt.ylim(vmax*-2,vmax)
     plt.grid()
 
 def deriv( xs, Es, d=None ):
@@ -66,12 +65,12 @@ Es_LJ,Fs_LJ = PPC.evalRadialFF( xs, REs[iAtom,:], kind=-3 ) #;print( "Es_LJ", Es
 #Es_LJ,Fs_LJ = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=-2 ) ;print( "Es_LJ", Es_LJ )  # LJ  -C6/r^6 + C12/r^12
 Es_r6,Fs_r6 = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=0 ) #;print( "Es_r6", Es_r6 )   # vdW -C6/r^6
 
-Es,Fs       = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=0  )   
-#Es,Fs       = PPC.evalRadialFF( xs, REs [iAtom,:], kind=0  )   
+Es,Fs       = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=0  )
+#Es,Fs       = PPC.evalRadialFF( xs, REs [iAtom,:], kind=0  )
 
 plt.figure(figsize=(8,16))
-plt.subplot(2,1,1);    plt.plot(xs,Es_LJ   ,':k'); plt.plot(xs,Es_r6   ,'--k'); plt.plot(xs,Es   );       plotDecor( R0, E0*2 )       
-plt.subplot(2,1,2);    plt.plot(xs,Fs_LJ*-1,':k'); plt.plot(xs,Fs_r6*-1,'--k'); plt.plot(xs,Fs*-1);       plotDecor( R0, E0*5 ) 
+plt.subplot(2,1,1);    plt.plot(xs,Es_LJ   ,':k'); plt.plot(xs,Es_r6   ,'--k'); plt.plot(xs,Es   );       plotDecor( R0, E0*2 )
+plt.subplot(2,1,2);    plt.plot(xs,Fs_LJ*-1,':k'); plt.plot(xs,Fs_r6*-1,'--k'); plt.plot(xs,Fs*-1);       plotDecor( R0, E0*5 )
 '''
 
 coefs = REs
@@ -90,13 +89,13 @@ for i in range(nz):
     #Es_LJ,Fs_LJ = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=-2 ) ;print( "Es_LJ", Es_LJ )  # LJ  -C6/r^6 + C12/r^12
     Es_r6,Fs_r6 = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=-1 ) #;print( "Es_r6", Es_r6 )   # vdW -C6/r^6
     ADamp = ADamps[iVdWModel]
-    #Es,Fs      = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=iVdWModel  )   
-    Es,Fs       = PPC.evalRadialFF( xs, coefs[iAtom,:], kind=iVdWModel, ADamp=ADamp )   
+    #Es,Fs      = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=iVdWModel  )
+    Es,Fs       = PPC.evalRadialFF( xs, coefs[iAtom,:], kind=iVdWModel, ADamp=ADamp )
 
     Fs_num,xs_  = deriv( xs, Es )
 
     plt.subplot(2,nz,i   +1);    plt.plot(xs,Es_LJ   ,':k'); plt.plot(xs,Es_r6   ,'--k'); plt.plot(xs,Es   );                                   plotDecor( R0, E0*5 );  plt.title("%s(Adamp=%5.2f) %s-%s" %(name,ADamp, (FFparams[iZs[i]-1][4]).decode(), (FFparams[iPP-1][4]).decode() ) ) #; plt.title("Interaction %i-%i" %(iZs[i], iPP) )
-    plt.subplot(2,nz,i+nz+1);    plt.plot(xs,Fs_LJ*-1,':k'); plt.plot(xs,Fs_r6*-1,'--k'); plt.plot(xs,Fs*-1);  plt.plot(xs_,Fs_num*-1, ':r');   plotDecor( R0, E0*7 ); 
+    plt.subplot(2,nz,i+nz+1);    plt.plot(xs,Fs_LJ*-1,':k'); plt.plot(xs,Fs_r6*-1,'--k'); plt.plot(xs,Fs*-1);  plt.plot(xs_,Fs_num*-1, ':r');   plotDecor( R0, E0*7 );
 
 plt.subplot(2,nz,  +1); plt.ylabel("Energy [eV]");
 plt.subplot(2,nz,nz+1); plt.ylabel("Force  [eV/A]");


### PR DESCRIPTION
According to the discussion in https://github.com/Probe-Particle/ppafm/pull/123#issuecomment-1480731196, the CI test workflow is not properly building the package because of an editable install. 
- Change the editable install to a regular pip install.
- Don't run the test for the `tests/human_eye` scripts because at least one of them relies on a correct input argument and those scripts were not meant for automatic testing in the first place.