### PR TITLE
Removed locale change in ReadNumsUpTo that was causing trouble.

### DIFF
--- a/ppafm/cpp/GridUtils.cpp
+++ b/ppafm/cpp/GridUtils.cpp
@@ -31,10 +31,6 @@ extern "C" {
 
     DLLEXPORT int ReadNumsUpTo_C (char *fname, double *numbers, int * dims, int noline) {
 
-        setlocale( LC_ALL, "C" ); // https://msdn.microsoft.com/en-us/library/x99tb11d(v=vs.71).aspx
-        //setlocale( LC_ALL, "" );
-        //setlocale( LC_ALL, "En_US" );  // to sove problem with ',' vs '.' caused by PyQt
-
         FILE *f;
         char line[5000]; // define a length which is long enough to store a line
         char *waste;


### PR DESCRIPTION
Fixes #113

Manipulating the locale inside the C++ data reading function was causing subsequent regular file reads in Python to fail with a `UnicodeDecodeError`. This deletes the offending lines. It seems this was originally a fix for some incompatible interpretation of decimal separators (`,` vs. `.`), but this could not replicated for the moment.