### PR TITLE
Implement tip density resampling.

### DIFF
--- a/examples/pyridineDensOverlap/run_gpu.py
+++ b/examples/pyridineDensOverlap/run_gpu.py
@@ -23,11 +23,9 @@ rho_sample, _, _, = FFcl.ElectronDensity.from_file('sample/CHGCAR.xsf')
 rho_tip_delta = rho_tip.subCores(xyzs_tip, Zs_tip, Rcore=0.7)
 
 # Construct the simulator
-pixPerAngstrome = round(pot.shape[0] / (pot.lvec[1, 0] - pot.lvec[0, 0]))
 afmulator = AFMulator(
-    pixPerAngstrome=pixPerAngstrome,        # The force field pixel density and the
-    lvec=rho_tip.lvec,                      # lattice vectors have to match the input files for now
-    scan_dim=(201, 201, 50),                # Output scan dimensions (z dimension gets reduced by df_steps)
+    pixPerAngstrome=10,                     # Force field grid density
+    scan_dim=(201, 201, 50),                # Output scan dimensions (z dimension gets reduced by df_steps - 1)
     scan_window=((0, 0, 5), (20, 20, 10)),  # Physical limits of the scan
     rho=rho_tip,                            # Tip charge density (used for calculating Pauli repulsion)
     rho_delta=rho_tip_delta,                # Tip delta charge density (used for calculating electrostatic force)

--- a/ppafm/ocl/cl/FF.cl
+++ b/ppafm/ocl/cl/FF.cl
@@ -860,7 +860,7 @@ __kernel void interp_tip_at(
     float4 T_A,             // Rows of the transformation matrix for input array lattice coordinates
     float4 T_B,
     float4 T_C,
-    float4 vec_in_inv_A,        // Rows of the inverse of the input array lattice vector matrix
+    float4 vec_in_inv_A,    // Rows of the inverse of the input array lattice vector matrix
     float4 vec_in_inv_B,
     float4 vec_in_inv_C,
     int4   nGrid_out,       // Size of target grid


### PR DESCRIPTION
Fixes #138

Implements tip density resampling for use with the density overlap model. This enables the use of an arbitrary force field grid, and the grids for the sample density and hartree potentials do not need to match the tip density grid either. So the tip density has to be only calculated once, and can then be easily reused.

Due to reduced force field grid size, this results in quite a significant reduction in the run time for the pyridine example, ~7x on my laptop, and also reduces required device memory.