### PR TITLE
Fix to OpenCL compilation paths.

### DIFF
--- a/ppafm/ocl/field.py
+++ b/ppafm/ocl/field.py
@@ -30,7 +30,7 @@ oclu       = None
 def init(env):
     global cl_program
     global oclu
-    cl_program = env.loadProgram(env.CL_PATH+"/FF.cl")
+    cl_program = env.loadProgram(env.CL_PATH / 'FF.cl')
     oclu = env
 
 verbose    = 0

--- a/ppafm/ocl/oclUtils.py
+++ b/ppafm/ocl/oclUtils.py
@@ -21,8 +21,13 @@ class OCLEnvironment:
         self.queue        = cl.CommandQueue(self.ctx)
 
     def loadProgram(self,fname):
+        cl_path = str(self.CL_PATH)
+        if self.platform.name != 'Portable Computing Language':
+            # Older versions of pocl don't handle quotes and spaces properly. This is kind of ugly, but
+            # this is needed for the version of pocl running on Github Actions at the moment of writing.
+            cl_path = f'"{cl_path}"'
         with open(fname) as f:
-            program = cl.Program(self.ctx, f.read()).build(options=['-I', f'"{self.CL_PATH}"'])
+            program = cl.Program(self.ctx, f.read()).build(options=['-I', cl_path])
         return program
 
     def updateBuffer(self, buff, cl_buff, access=cl.mem_flags ):

--- a/ppafm/ocl/oclUtils.py
+++ b/ppafm/ocl/oclUtils.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import numpy as np
 import pyopencl as cl
@@ -15,15 +15,14 @@ class OCLEnvironment:
         self.platform     = platforms[i_platform]
         print(f"Initializing an OpenCL environment on {self.platform.name}")
 
-        self.PACKAGE_PATH = os.path.dirname( os.path.realpath( __file__ ) )
-        self.CL_PATH      = os.path.normpath( self.PACKAGE_PATH + '/cl' )
+        self.PACKAGE_PATH = Path(__file__).resolve().parent
+        self.CL_PATH      = self.PACKAGE_PATH / 'cl'
         self.ctx          = cl.Context(properties=[(cl.context_properties.PLATFORM, self.platform)], devices=None)
         self.queue        = cl.CommandQueue(self.ctx)
 
     def loadProgram(self,fname):
-        f       = open(fname)
-        fstr    = "".join(f.readlines())
-        program = cl.Program(self.ctx, fstr ).build(options=['-I', self.CL_PATH])
+        with open(fname) as f:
+            program = cl.Program(self.ctx, f.read()).build(options=['-I', f'"{self.CL_PATH}"'])
         return program
 
     def updateBuffer(self, buff, cl_buff, access=cl.mem_flags ):

--- a/ppafm/ocl/relax.py
+++ b/ppafm/ocl/relax.py
@@ -23,7 +23,7 @@ verbose = 0
 def init(env):
     global cl_program
     global oclu
-    cl_program  = env.loadProgram(env.CL_PATH+"/relax.cl")
+    cl_program = env.loadProgram(env.CL_PATH / 'relax.cl')
     oclu = env
 
 def mat3x3to4f( M ):


### PR DESCRIPTION
The compilation of the OpenCL code was not taking into account that there may be spaces in the source path. Thanks to @alexriss for pointing this out in https://github.com/Probe-Particle/ppafm/issues/110#issuecomment-1516538754.

There is one edge case that needed to be taken into account, namely that the OpenCL platform that we use for the automated tests on Github, `pocl`, doesn't handle quotes or spaces in the file path properly. This is actually fixed in the latest versions (https://github.com/pocl/pocl/issues/962), but the version in Ubuntu 22.04 doesn't seem to have this fix.

I also took the opportunity to switch from using `os.path` to using `pathlib.Path` for the paths, which should be more general.
