### PR TITLE
Added g++ and make to readthedocs build requirements.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
     os: ubuntu-22.04
     tools:
         python: '3.9'
+    apt_packages:
+      - g++
+      - make
 
 sphinx:
     configuration: doc/sphinx/source/conf.py


### PR DESCRIPTION
Fixes #161 

The readthedocs web page for our python API did not have all of the modules properly listed because the C++ libraries failed to load and thus caused failed imports on some python modules. This just adds the C++ build requirements to the readthedocs build configuration. The fix also involved adding the `PPAFM_RECOMPILE` environment variable, but this had to be done separately in the readthedocs.com web interface.