### PR TITLE
Implemented DFT-D3 in the CPU code.

### DIFF
--- a/examples/pyridineDensOverlap/run.sh
+++ b/examples/pyridineDensOverlap/run.sh
@@ -25,9 +25,9 @@ mkdir tip
 mv CHGCAR.xsf tip
 
 echo "======= STEP 1 : Generate force-field grid "
-python ${PPAFM_DIR}/conv_rho.py     -s sample/CHGCAR.xsf -t tip/CHGCAR.xsf --Bpower 1.0 -E
-python ${PPAFM_DIR}/generateElFF.py -i sample/LOCPOT.xsf --tip_dens tip/CHGCAR.xsf --Rcore 0.7 -E --doDensity
-ppafm-generate-ljff -i sample/CHGCAR.xsf --ffModel vdW  -E
+python ${PPAFM_DIR}/conv_rho.py      -s sample/CHGCAR.xsf -t tip/CHGCAR.xsf --Bpower 1.0 -E
+python ${PPAFM_DIR}/generateElFF.py  -i sample/LOCPOT.xsf --tip_dens tip/CHGCAR.xsf --Rcore 0.7 -E --doDensity
+python ${PPAFM_DIR}/generateDFTD3.py -i sample/LOCPOT.xsf --df_name PBE
 
 echo "======= STEP 2 : Relax Probe Particle using that force-field grid "
 python ${PPAFM_DIR}/relaxed_scan_PVE.py -k 0.25 -q 1.0 --Apauli 18.0 --bDebugFFtot

--- a/ppafm/cli/generateDFTD3.py
+++ b/ppafm/cli/generateDFTD3.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import sys
+from argparse import ArgumentParser
+
+import numpy as np
+
+import ppafm as PPU
+import ppafm.fieldFFT as fFFT
+import ppafm.HighLevel as PPH
+from ppafm import elements
+from ppafm.defaults import d3
+
+
+def main():
+
+    parser = ArgumentParser(
+        prog='generateDFTD3',
+        description='Generate Grimme DFT-D3 vdW force field using the Becke-Johnson damping function. '
+            'The generated force field is saved to FFvdW_{x,y,z}.[ext].'
+    )
+
+    parser.add_argument('-i', '--input',       action='store',
+        help='Input file. Mandatory. Supported formats are: .xyz, .cube, .xsf.')
+    parser.add_argument('-f', '--data_format', action='store', default='xsf',
+        help='Specify the output format of the force field. Supported formats are: xsf, npy')
+    parser.add_argument(      '--noPBC',       action='store_false', dest='PBC', default=None,
+        help='No periodic boundary conditions.')
+    parser.add_argument('-E', '--energy',      action='store_true', default=False,
+        help='Compute potential energy in addition to force.')
+    parser.add_argument(      '--df_name',     action='store', default='PBE',
+        help='Which density functional-specific scaling parameters (s6, s8, a1, a2) to use. Give the name of the functional. '
+            'The following functionals are available: PBE, B1B95, B2GPPLYP, B3PW91, BHLYP, BMK, BOP, BPBE, CAMB3LYP, LCwPBE, '
+            'MPW1B95, MPWB1K, mPWLYP, OLYP, OPBE, oTPSS, PBE38, PBEsol, PTPSS, PWB6K, revSSB, SSB, TPSSh, HCTH120, B2PLYP, '
+            'B3LYP, B97D, BLYP, BP86, DSDBLYP, PBE0, PBE, PW6B95, PWPB95, revPBE0, revPBE38, revPBE, rPW86PBE, TPSS0, TPSS.')
+    parser.add_argument(      '--df_params',   action='store', default=None, nargs=4, type=float, metavar=('s6', 's8', 'a1', 'a2'),
+        help='Manually specify scaling parameters s6, s8, a1, a2. Overwrites --df_name.')
+    args = parser.parse_args()
+
+    if args.input is None:
+        parser.print_help()
+        print('\nMissing input file (-i, --input)!\n')
+        sys.exit(1)
+
+    try:
+        # Try overwriting global parameters with params.ini file
+        PPU.loadParams('params.ini')
+    except:
+        print("No params.ini provided => using default parameters.")
+
+    # Overwrite global parameters with command line arguments
+    PPU.apply_options(vars(args))
+
+    if args.df_params is not None:
+        p = args.df_params
+        df_params = {'s6': p[0], 's8': p[1], 'a1': p[2], 'a2': p[3]}
+    else:
+        if args.df_name not in d3.DF_DEFAULT_PARAMS:
+            print(f'Unknown functional name `{args.df_name}`!')
+            sys.exit(1)
+        df_params = args.df_name
+
+    PPH.computeDFTD3(args.input, df_params=df_params, save_format=args.data_format, compute_energy=args.energy)
+
+
+if __name__ == "__main__":
+    main()

--- a/ppafm/core.py
+++ b/ppafm/core.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python
 
-import ctypes
 from ctypes import c_double, c_int
 
 import numpy as np
 
 from . import common as PPU
 from . import cpp_utils
+from .defaults import d3
+from .io import bohrRadius2angstroem
 
 # ==============================
 # ============================== interface to C++ core
@@ -166,6 +167,34 @@ lib.getVdWFF_RE.restype   = None
 def getVdWFF_RE( Rs, REs, kind=0, ADamp=-1. ):
     natom = len(Rs)
     lib.getVdWFF_RE( natom, Rs, REs, kind, ADamp )
+
+# void getDFTD3FF(int natoms_, double * Ratoms_, double *d3_coeffs)
+lib.getDFTD3FF.argtypes  = [c_int, array2d, array2d]
+lib.getDFTD3FF.restype   = None
+def getDFTD3FF(Rs, d3_coeffs):
+    natom = len(Rs)
+    lib.getDFTD3FF(natom, Rs, d3_coeffs)
+
+# void computeD3Coeffs(
+#    const int natoms_, const double *rs, const double *elems, const double *r_cov, const double *r_cut, const double *ref_cn,
+#    const double *ref_c6, const double *r4r2, const double *k, const double *params, const int elem_pp, double *coeffs
+#)
+lib.computeD3Coeffs.argtypes = [c_int, array2d, array1i, array1d, array1d, array1d, array1d, array1d, array1d, array1d, c_int, array1d]
+lib.computeD3Coeffs.restype  = None
+def computeD3Coeffs(Rs, iZs, iZPP, df_params):
+    natom = len(Rs)
+    Rs = np.array(Rs, dtype=np.float64)
+    iZs = np.array(iZs, dtype=np.int32)
+    r_cov = d3.R_COV.astype(np.float64)
+    r_cut = d3.load_R0().astype(np.float64).flatten()
+    ref_cn = d3.REF_CN.astype(np.float64).flatten()
+    r4r2 = d3.R4R2.astype(np.float64)
+    ref_c6 = d3.load_ref_c6().astype(np.float64).flatten()
+    k = np.array([d3.K1, d3.K2, d3.K3], dtype=np.float64)
+    df_params = np.array([df_params['s6'], df_params['s8'], df_params['a1'], df_params['a2'] * bohrRadius2angstroem], dtype=np.float64)
+    coeffs = np.empty(4 * natom, dtype=np.float64)
+    lib.computeD3Coeffs(natom, Rs, iZs, r_cov, r_cut, ref_cn, ref_c6, r4r2, k, df_params, iZPP, coeffs)
+    return coeffs.reshape((natom, 4))
 
 # void getClassicalFF       (    int natom,   double * Rs_, double * cLJs )
 lib.getMorseFF.argtypes  = [ c_int,       array2d,      array2d, c_double ]

--- a/ppafm/defaults/d3.py
+++ b/ppafm/defaults/d3.py
@@ -263,3 +263,14 @@ DF_DEFAULT_PARAMS = {
 Default Grimme-D3 scaling parameters for a variety of density functionals using Becke-Johnson damping.
 Values taken from `<https://www.chemiebn.uni-bonn.de/pctc/mulliken-center/software/dft-d3/functionalsbj>`_.
 '''
+
+def get_df_params(params):
+    if isinstance(params, str):
+        if params not in DF_DEFAULT_PARAMS:
+            raise ValueError(f'Default parameters not available for functional `{params}`. See the available '
+                'default parameters in ppafm.defaults.d3.DF_DEFAULT_PARAMS.')
+        params = DF_DEFAULT_PARAMS[params]
+    for key in ['s6', 's8', 'a1', 'a2']:
+        if key not in params:
+            raise ValueError(f'DFT-D3 parameter dictionary is missing entry for `{key}`')
+    return params

--- a/ppafm/ocl/cl/FF.cl
+++ b/ppafm/ocl/cl/FF.cl
@@ -11,7 +11,6 @@
 #define MAX_REF_CN 5
 #define MAX_D3_ELEM 94
 #define R2_D3_CUTOFF 400.0f
-#define IR2_D3_CUTOFF 1.0f / R2_D3_CUTOFF
 
 #include "splines.cl"
 

--- a/ppafm/ocl/field.py
+++ b/ppafm/ocl/field.py
@@ -1133,13 +1133,10 @@ class ForceField_LJC:
 
         if not hasattr(self, 'iZPP'):
             raise RuntimeError('Probe particle atomic number not set. Set it before DFT-D3 calculation using setPP()')
+        if not hasattr(self, 'cl_Zs') or not hasattr(self, 'nAtoms'):
+            raise RuntimeError('Atom positions or elements not set. Set them before DFT-D3 calculation using prepareBuffers(atoms=..., Zs=...)')
 
-        if isinstance(params, str):
-            if params not in d3.DF_DEFAULT_PARAMS:
-                raise ValueError(f'Default parameters not available for functional `{params}`. See the available '
-                    'default parameters in ppafm.defaults.d3.DF_DEFAULT_PARAMS.')
-            params = d3.DF_DEFAULT_PARAMS[params]
-
+        params = d3.get_df_params(params)
         params = np.array([params['s6'], params['s8'], params['a1'], params['a2'] * io.bohrRadius2angstroem], dtype=np.float32)
         k = np.array([d3.K1, d3.K2, d3.K3, 0.0], dtype=np.float32)
 

--- a/tests/test_vdw.py
+++ b/tests/test_vdw.py
@@ -99,6 +99,7 @@ def test_dftd3():
     cl.enqueue_copy(forcefield.queue, coeffs_ocl, forcefield.cl_cD3)
 
     coeffs_cpp = PPC.computeD3Coeffs(xyzs, Zs, Z_pp, params)
+    PPU.params['gridN'] = forcefield.nDim
     PPU.params['gridA'] = lvec[1]
     PPU.params['gridB'] = lvec[2]
     PPU.params['gridC'] = lvec[3]

--- a/tests/test_vdw.py
+++ b/tests/test_vdw.py
@@ -4,11 +4,12 @@
 Compare the C++ and OpenCL implementations of the vdW calculation and check that they are consistent.
 '''
 
-
 import numpy as np
+import pyopencl as cl
 
 import ppafm.common as PPU
 import ppafm.core as PPC
+import ppafm.HighLevel as PPH
 import ppafm.ocl.field as FFcl
 import ppafm.ocl.oclUtils as oclu
 
@@ -23,9 +24,9 @@ def test_vdw():
     x_FF = np.arange(x_min, x_max, step)
     atoms = np.zeros((1, 4))
     lvec = np.array([
-        [     x_min ,    0,   0],
-        [x_max-x_min,    0,   0],
-        [          0, step,   0],
+        [     x_min ,    0,    0],
+        [x_max-x_min,    0,    0],
+        [          0, step,    0],
         [          0,    0, step]
     ])
     pixPerAngstrome = round(1 / step)
@@ -56,3 +57,58 @@ def test_vdw():
 
             assert np.allclose(Fx_ocl, Fx_cpp, atol=1e-6, rtol=1e-4)
             assert np.allclose(E_ocl, E_cpp, atol=1e-6, rtol=1e-4)
+
+def test_dftd3():
+
+    oclu.init_env(i_platform=0)
+
+    Z_pp = 8
+    Zs = np.array([1, 1, 1, 1, 1, 6, 6, 6, 6, 6, 7])
+    xyzs = np.array([
+        [12.503441, 10.00046 ,  0.0],
+        [11.21048 , 12.163759,  0.0],
+        [11.21132 ,  7.83666 ,  0.0],
+        [ 8.71074 , 12.06802 ,  0.0],
+        [ 8.71154 ,  7.93144 ,  0.0],
+        [11.41128 , 10.000239,  0.0],
+        [10.69736 , 11.2     ,  0.0],
+        [10.697821,  8.800241,  0.0],
+        [ 9.300119, 11.145101,  0.0],
+        [ 9.30056 ,  8.85458 ,  0.0],
+        [ 8.59812 ,  9.999701,  0.0]]
+    )
+    lvec = np.array([
+        [ 0,  0,  0],
+        [20,  0,  0],
+        [ 0, 20,  0],
+        [ 0,  0, 20]
+    ])
+    pixPerAngstrome = 10
+    params = {'s6': 1.000, 's8': 0.7875, 'a1':  0.4289, 'a2': 4.4407}
+
+    forcefield = FFcl.ForceField_LJC()
+    forcefield.initSampling(lvec, pixPerAngstrome=pixPerAngstrome)
+    forcefield.prepareBuffers(atoms=np.concatenate([xyzs, np.zeros((len(Zs), 1))], axis=1), Zs=Zs)
+    forcefield.setPP(Z_pp)
+
+    forcefield.initialize()
+    forcefield.add_dftd3(params)
+    FF_ocl = forcefield.downloadFF()
+
+    coeffs_ocl = np.empty((forcefield.nAtoms, 4), dtype=np.float32)
+    cl.enqueue_copy(forcefield.queue, coeffs_ocl, forcefield.cl_cD3)
+
+    coeffs_cpp = PPC.computeD3Coeffs(xyzs, Zs, Z_pp, params)
+    PPU.params['gridA'] = lvec[1]
+    PPU.params['gridB'] = lvec[2]
+    PPU.params['gridC'] = lvec[3]
+    FF_cpp, E_cpp = PPH.prepareArrays(None, True)
+    PPC.setFF_shape(np.shape(FF_cpp), lvec)
+    PPC.getDFTD3FF(xyzs, coeffs_cpp)
+
+    FF_cpp = FF_cpp.transpose((2, 1, 0, 3))
+    E_cpp = E_cpp.transpose((2, 1, 0))
+
+    assert np.allclose(coeffs_ocl, coeffs_cpp)
+    assert np.allclose(FF_ocl[..., :3], FF_cpp, rtol=1e-4, atol=1e-6)
+    assert np.allclose(FF_ocl[..., 3], E_cpp, rtol=1e-4, atol=1e-6)


### PR DESCRIPTION
Fixes #165 

I went ahead and also implemented the DFT-D3 calculation in the CPU code now that it's still fresh in my mind. I added a new script `generateDFTD3.py` for accessing this feature. It replaces the old LJ script in the pyridine example run script. Also added a test to make sure that the CPU and GPU versions return the same result for the force field.