### PR TITLE
Set fixed locale during array read.

### DIFF
--- a/ppafm/cpp/GridUtils.cpp
+++ b/ppafm/cpp/GridUtils.cpp
@@ -31,6 +31,9 @@ extern "C" {
 
     DLLEXPORT int ReadNumsUpTo_C (char *fname, double *numbers, int * dims, int noline) {
 
+        // Temporarily set fixed locale so that . (dot) is definitely the decimal separator
+        setlocale(LC_NUMERIC, "C");
+
         FILE *f;
         char line[5000]; // define a length which is long enough to store a line
         char *waste;
@@ -64,6 +67,10 @@ extern "C" {
 //       printf ("%lf %lf %lf %lf %lf\n", numbers[tot-1], numbers[tot-2], numbers[tot-3], numbers[tot-4], numbers[tot-5]);
         printf("Reading DONE\n");
         fclose(f);
+
+        // Set locale back to the default locale
+        setlocale(LC_NUMERIC, "");
+
         return 0;
     }
 


### PR DESCRIPTION
Fixes #167 

The locale change was previously removed because it was causing trouble with file reading in Python. However, the removal caused the array read in C++ to fail when using the GUI, because pyqt seems to set a different environment locale, which on some systems uses , (comma) as a decimal separator. This sets a fixed locale temporarily during the array read and then sets it back so that everything should work as intended.