### PR TITLE
Temporary disable wheel build.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
             - name: Install build
               run: python -m pip install --upgrade build
 
-            - name: Build a binary wheel and a source tarball
-              run: python -m build --sdist --wheel --outdir dist/
+            - name: Build a source tarball
+              run: python -m build --sdist --outdir dist/
 
             - name: Upload distribution artifacts
               uses: actions/upload-artifact@v2


### PR DESCRIPTION
Otherwise, the wheel that is created cannot be uploaded on PyPI.