### PR TITLE
Fixed API docs for AFMulator.

### DIFF
--- a/doc/sphinx/source/ppafm.ocl.rst
+++ b/doc/sphinx/source/ppafm.ocl.rst
@@ -9,10 +9,10 @@ Submodules
 ppafm.ocl.AFMulator module
 ------------------------------------
 
-.. autoclass:: ppafm.ocl.AFMulator.AFMulator
-   :members: __call__, eval, setLvec, setScanWindow, setRho, setQs, prepareFF, prepareScanner, evalAFM
+.. automodule:: ppafm.ocl.AFMulator
+   :members:
+   :undoc-members:
    :show-inheritance:
-.. autofunction:: ppafm.ocl.AFMulator.quick_afm
 
 ppafm.ocl.field module
 --------------------------------


### PR DESCRIPTION
The API documentation page for `AFMulator` was missing items.