### PR TITLE
Temporarily disable flake8 pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,20 +24,20 @@ repos:
       hooks:
           - id: pyupgrade
             args: [--py36-plus]
-    - repo: https://github.com/PyCQA/flake8
-      rev: 6.0.0
-      hooks:
-          - id: flake8
-            args: [--count, --show-source, --statistics]
-            additional_dependencies:
-                - flake8-bugbear
-                - flake8-builtins
-                - flake8-comprehensions
-                - flake8-debugger
-                - flake8-logging-format
-                - pep8-naming
-                - pyflakes
-                - tryceratops
+    # - repo: https://github.com/PyCQA/flake8
+    #   rev: 6.0.0
+    #   hooks:
+    #       - id: flake8
+    #         args: [--count, --show-source, --statistics]
+    #         additional_dependencies:
+    #             - flake8-bugbear
+    #             - flake8-builtins
+    #             - flake8-comprehensions
+    #             - flake8-debugger
+    #             - flake8-logging-format
+    #             - pep8-naming
+    #             - pyflakes
+    #             - tryceratops
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v0.961
       hooks:


### PR DESCRIPTION
I'm suggesting that we temporarily disable the `flake8` pre-commit hook, since there has been no consensus on whether `black` should be enabled or not (#96). At the moment the pre-commit never succeeds because of all the code style problems, so it's mostly just an annoyance since in practice you have to use the `--no-verify` option every time or manually disable the check locally.