### PR TITLE
Making KPFM work

### DIFF
--- a/ppafm/PPPlot.py
+++ b/ppafm/PPPlot.py
@@ -81,18 +81,19 @@ def plotImages(
     atoms=None,
     bonds=None,
     atomSize=default_atom_size,
-    symetric_map=False,
+    symmetric_map=False,
     V0=0.0,
 ):
     for ii, i in enumerate(slices):
         # print(" plotting ", i)
         write_plotting_slice(i)
-        if symetric_map:
+        if symmetric_map:
             limit = max(abs(np.min(F[i] - V0)), abs(np.max(F[i] - V0)))
             vmin = -limit + V0
             vmax = limit + V0
         plt.figure(figsize=figsize)
         plt.imshow(F[i], origin="lower", interpolation=interpolation, cmap=cmap, extent=extent, vmin=vmin, vmax=vmax)
+
         if cbar:
             plt.colorbar()
         plotGeom(atoms, bonds, atomSize=atomSize)

--- a/ppafm/cli/plot_results.py
+++ b/ppafm/cli/plot_results.py
@@ -333,7 +333,7 @@ def main(argv=None):
                 bonds=bonds,
                 atomSize=atom_size,
                 cbar=opt_dict["cbar"],
-                symetric_map=True,
+                symmetric_map=True,
                 V0=args.V0,
             )
             PPPlot.plotImages(
@@ -347,10 +347,10 @@ def main(argv=None):
                 bonds=bonds,
                 atomSize=atom_size,
                 cbar=opt_dict["cbar"],
-                symetric_map=False,
+                symmetric_map=False,
             )
             io.save_scal_field(
-                "./LCPD_HzperV",
+                "./LCPD",
                 lcpd,
                 lvec_df,
                 data_format=args.output_format,

--- a/ppafm/cli/plot_results.py
+++ b/ppafm/cli/plot_results.py
@@ -191,7 +191,7 @@ def main(argv=None):
                     cbar=opt_dict["cbar"],
                 )
 
-            if opt_dict["df"] or opt_dict["save_df"] or opt_dict["WSxM"]:
+            if opt_dict["df"] or opt_dict["save_df"] or opt_dict["WSxM"] or opt_dict["LCPD_maps"]:
                 for amplitude in amplitudes:
                     common.params["Amplitude"] = amplitude
                     amp_string = f"/Amp{amplitude:2.2f}"
@@ -350,7 +350,7 @@ def main(argv=None):
                 symetric_map=False,
             )
             io.save_scal_field(
-                "./LCDP_HzperV",
+                "./LCPD_HzperV",
                 lcpd,
                 lvec_df,
                 data_format=args.output_format,


### PR DESCRIPTION
This PR partially addresses issue #133, but we should at least review the KPFM documentation before we close the issue. The KPFM actually already worked after PR #188. Here, I just made sure the `--WSxM` option is not needed if the WSxM format is not required and I renamed the `LCPD_HzperV.xsf` output file to just `LCPD.xsf`, because the LCPD should actually be expressed in volts, not in Hz/V. I wonder, was the `LCPD_HzperV.xsf` name a vestige of some older setup in which `LCPD_b` was written out insted of `LCPD`? (`LCPD_b` is a map of the linear coefficients _b_ in the Kelvin parabola expansion) @aureliojgc , do you know?
I would like to implement more improvements to the KPFM part of the code but I should probably open new issue(s) about it.