### PR TITLE
Create automatic lattice vectors if none are specified in the input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:22.04
 
 # build-essential is needed for building the C++ code in the PPAFM package
 

--- a/ppafm/HighLevel.py
+++ b/ppafm/HighLevel.py
@@ -18,177 +18,290 @@ Vmax_DEFAULT = 10.0
 
 # ==== PP Relaxation
 
+
 def Gauss(Evib, E0, w):
-    return np.exp( -0.5*((Evib - E0)/w)**2);
+    return np.exp(-0.5 * ((Evib - E0) / w) ** 2)
 
-def symGauss( Evib, E0, w):
-    return Gauss(Evib, E0, w) - Gauss(Evib, -E0, w);
 
-def meshgrid3d(xs,ys,zs):
-    Xs,Ys,Zs = np.zeros()
-    Xs,Ys = np.meshgrid(xs,ys)
+def symGauss(Evib, E0, w):
+    return Gauss(Evib, E0, w) - Gauss(Evib, -E0, w)
 
-def trjByDir( n, d=[0.0,0.0,PPU.params['scanStep'][2]], p0=[0,0,PPU.params['scanMin'][2]] ):
-    trj = np.zeros( (n,3) )
-    trj[:,0] = p0[0] + (np.arange( n )[::-1])*d[0]
-    trj[:,1] = p0[1] + (np.arange( n )[::-1])*d[1]
-    trj[:,2] = p0[2] + (np.arange( n )[::-1])*d[2]
+
+def meshgrid3d(xs, ys, zs):
+    Xs, Ys, Zs = np.zeros()
+    Xs, Ys = np.meshgrid(xs, ys)
+
+
+def trjByDir(
+    n, d=[0.0, 0.0, PPU.params["scanStep"][2]], p0=[0, 0, PPU.params["scanMin"][2]]
+):
+    trj = np.zeros((n, 3))
+    trj[:, 0] = p0[0] + (np.arange(n)[::-1]) * d[0]
+    trj[:, 1] = p0[1] + (np.arange(n)[::-1]) * d[1]
+    trj[:, 2] = p0[2] + (np.arange(n)[::-1]) * d[2]
     return trj
 
-def relaxedScan3D( xTips, yTips, zTips, trj=None, bF3d=False ):
-    if(verbose>0): print(">>BEGIN: relaxedScan3D()")
-    if(verbose>0): print(" zTips : ",zTips)
-    ntips = len(zTips);
-    rTips = np.zeros((ntips,3))
-    rs    = np.zeros((ntips,3))
-    fs    = np.zeros((ntips,3))
-    nx = len(zTips); ny = len(yTips ); nz = len(xTips);
-    if( bF3d ):
-        fzs    = np.zeros( ( nx,ny,nz,3) );
+
+def relaxedScan3D(xTips, yTips, zTips, trj=None, bF3d=False):
+    if verbose > 0:
+        print(">>BEGIN: relaxedScan3D()")
+    if verbose > 0:
+        print(" zTips : ", zTips)
+    ntips = len(zTips)
+    rTips = np.zeros((ntips, 3))
+    rs = np.zeros((ntips, 3))
+    fs = np.zeros((ntips, 3))
+    nx = len(zTips)
+    ny = len(yTips)
+    nz = len(xTips)
+    if bF3d:
+        fzs = np.zeros((nx, ny, nz, 3))
     else:
-        fzs    = np.zeros( ( nx,ny,nz   ) );
-    PPpos  = np.zeros( ( nx,ny,nz,3 ) );
+        fzs = np.zeros((nx, ny, nz))
+    PPpos = np.zeros((nx, ny, nz, 3))
     if trj is None:
-        trj=np.zeros((ntips,3))
-        trj[:,2]=zTips[::-1]
-    for ix,x in enumerate( xTips  ):
-        sys.stdout.write('\033[K')
+        trj = np.zeros((ntips, 3))
+        trj[:, 2] = zTips[::-1]
+    for ix, x in enumerate(xTips):
+        sys.stdout.write("\033[K")
         sys.stdout.flush()
         sys.stdout.write(f"\rrelax ix: {ix}")
         sys.stdout.flush()
-        for iy,y in enumerate( yTips  ):
-            rTips[:,0] = trj[:,0] + x
-            rTips[:,1] = trj[:,1] + y
-            rTips[:,2] = trj[:,2]
-            core.relaxTipStroke( rTips, rs, fs )
-            if( bF3d ):
-                fzs[:,iy,ix,0] = (fs[:,0].copy()) [::-1]
-                fzs[:,iy,ix,1] = (fs[:,1].copy()) [::-1]
-                fzs[:,iy,ix,2] = (fs[:,2].copy()) [::-1]
+        for iy, y in enumerate(yTips):
+            rTips[:, 0] = trj[:, 0] + x
+            rTips[:, 1] = trj[:, 1] + y
+            rTips[:, 2] = trj[:, 2]
+            core.relaxTipStroke(rTips, rs, fs)
+            if bF3d:
+                fzs[:, iy, ix, 0] = (fs[:, 0].copy())[::-1]
+                fzs[:, iy, ix, 1] = (fs[:, 1].copy())[::-1]
+                fzs[:, iy, ix, 2] = (fs[:, 2].copy())[::-1]
             else:
-                fzs[:,iy,ix] = (fs[:,2].copy()) [::-1]
-            PPpos[:,iy,ix,0] = rs[::-1,0]
-            PPpos[:,iy,ix,1] = rs[::-1,1]
-            PPpos[:,iy,ix,2] = rs[::-1,2]
-    if(verbose>0): print("<<<END: relaxedScan3D()")
-    return fzs,PPpos
+                fzs[:, iy, ix] = (fs[:, 2].copy())[::-1]
+            PPpos[:, iy, ix, 0] = rs[::-1, 0]
+            PPpos[:, iy, ix, 1] = rs[::-1, 1]
+            PPpos[:, iy, ix, 2] = rs[::-1, 2]
+    if verbose > 0:
+        print("<<<END: relaxedScan3D()")
+    return fzs, PPpos
 
-def perform_relaxation (lvec,FFLJ,FFel=None, FFpauli=None, FFboltz=None,FFkpfm_t0sV=None,FFkpfm_tVs0=None,tipspline=None,bPPdisp=False,bFFtotDebug=False):
-    if(verbose>0): print(">>>BEGIN: perform_relaxation()")
-    if tipspline is not None :
+
+def perform_relaxation(
+    lvec,
+    FFLJ,
+    FFel=None,
+    FFpauli=None,
+    FFboltz=None,
+    FFkpfm_t0sV=None,
+    FFkpfm_tVs0=None,
+    tipspline=None,
+    bPPdisp=False,
+    bFFtotDebug=False,
+):
+    if verbose > 0:
+        print(">>>BEGIN: perform_relaxation()")
+    if tipspline is not None:
         try:
-            if(verbose>0): print(" loading tip spline from "+tipspline)
-            S    = np.genfromtxt(tipspline )
-            xs   = S[:,0].copy();
-            if(verbose>0): print("xs: ",   xs)
-            ydys = S[:,1:].copy();
-            if(verbose>0): print("ydys: ", ydys)
-            core.setTipSpline( xs, ydys )
+            if verbose > 0:
+                print(" loading tip spline from " + tipspline)
+            S = np.genfromtxt(tipspline)
+            xs = S[:, 0].copy()
+            if verbose > 0:
+                print("xs: ", xs)
+            ydys = S[:, 1:].copy()
+            if verbose > 0:
+                print("ydys: ", ydys)
+            core.setTipSpline(xs, ydys)
         except:
-            if(verbose>0): print("cannot load tip spline from "+tipspline)
+            if verbose > 0:
+                print("cannot load tip spline from " + tipspline)
             sys.exit()
-    xTips,yTips,zTips,lvecScan = PPU.prepareScanGrids( )
+    xTips, yTips, zTips, lvecScan = PPU.prepareScanGrids()
     FF = FFLJ.copy()
-    if ( FFel is not None):
-        FF += FFel * PPU.params['charge']
-        if(verbose>0): print("adding charge:", PPU.params['charge'])
-    if ( FFkpfm_t0sV is not None and FFkpfm_tVs0 is not None ):
-
-        FF += (np.sign(PPU.params['charge'])*FFkpfm_t0sV - FFkpfm_tVs0) * abs(PPU.params['charge']) * PPU.params['Vbias']
-        if(verbose>0): print("adding charge:", PPU.params['charge'], "and bias:", PPU.params['Vbias'], "V")
-    if ( FFpauli is not None ):
-        FF += FFpauli * PPU.params['Apauli']
-    if FFboltz != None :
+    if FFel is not None:
+        FF += FFel * PPU.params["charge"]
+        if verbose > 0:
+            print("adding charge:", PPU.params["charge"])
+    if FFkpfm_t0sV is not None and FFkpfm_tVs0 is not None:
+        FF += (
+            (np.sign(PPU.params["charge"]) * FFkpfm_t0sV - FFkpfm_tVs0)
+            * abs(PPU.params["charge"])
+            * PPU.params["Vbias"]
+        )
+        if verbose > 0:
+            print(
+                "adding charge:",
+                PPU.params["charge"],
+                "and bias:",
+                PPU.params["Vbias"],
+                "V",
+            )
+    if FFpauli is not None:
+        FF += FFpauli * PPU.params["Apauli"]
+    if FFboltz != None:
         FF += FFboltz
     if bFFtotDebug:
-        io.save_vec_field( 'FFtotDebug', FF, lvec )
-    core.setFF_shape( np.shape(FF), lvec )
-    core.setFF_Fpointer( FF )
-    if (PPU.params['stiffness'] < 0.0).any():
-        PPU.params['stiffness'] = np.array([PPU.params['klat'], PPU.params['klat'], PPU.params['krad']])
-    if(verbose>0): print("stiffness:", PPU.params['stiffness'])
-    core.setTip(kSpring=np.array((PPU.params['stiffness'][0], PPU.params['stiffness'][1], 0.0)) / -PPU.eVA_Nm,
-        kRadial=PPU.params['stiffness'][2] / -PPU.eVA_Nm)
-    trj=None
-    if PPU.params['tiltedScan']:
-        trj = trjByDir( len(zTips), d=PPU.params['scanTilt'], p0=PPU.params['scanMin'] )
-    fzs,PPpos = relaxedScan3D( xTips, yTips, zTips, trj=trj, bF3d=PPU.params['tiltedScan'] )
+        io.save_vec_field("FFtotDebug", FF, lvec)
+    core.setFF_shape(np.shape(FF), lvec)
+    core.setFF_Fpointer(FF)
+    if (PPU.params["stiffness"] < 0.0).any():
+        PPU.params["stiffness"] = np.array(
+            [PPU.params["klat"], PPU.params["klat"], PPU.params["krad"]]
+        )
+    if verbose > 0:
+        print("stiffness:", PPU.params["stiffness"])
+    core.setTip(
+        kSpring=np.array((PPU.params["stiffness"][0], PPU.params["stiffness"][1], 0.0))
+        / -PPU.eVA_Nm,
+        kRadial=PPU.params["stiffness"][2] / -PPU.eVA_Nm,
+    )
+    trj = None
+    if PPU.params["tiltedScan"]:
+        trj = trjByDir(len(zTips), d=PPU.params["scanTilt"], p0=PPU.params["scanMin"])
+    fzs, PPpos = relaxedScan3D(
+        xTips, yTips, zTips, trj=trj, bF3d=PPU.params["tiltedScan"]
+    )
     if bPPdisp:
-        PPdisp=PPpos.copy()
-        init_pos=np.array(np.meshgrid(xTips,yTips,zTips)).transpose(3,1,2,0)+np.array([PPU.params['r0Probe'][0],PPU.params['r0Probe'][1],-PPU.params['r0Probe'][2]])
-        PPdisp-=init_pos
+        PPdisp = PPpos.copy()
+        init_pos = np.array(np.meshgrid(xTips, yTips, zTips)).transpose(
+            3, 1, 2, 0
+        ) + np.array(
+            [
+                PPU.params["r0Probe"][0],
+                PPU.params["r0Probe"][1],
+                -PPU.params["r0Probe"][2],
+            ]
+        )
+        PPdisp -= init_pos
     else:
         PPdisp = None
-    if(verbose>0): print("<<<END: perform_relaxation()")
-    return fzs,PPpos,PPdisp,lvecScan
+    if verbose > 0:
+        print("<<<END: perform_relaxation()")
+    return fzs, PPpos, PPdisp, lvecScan
+
 
 # ==== Forcefield grid generation
 
-def prepareArrays( FF, Vpot ):
-    if (PPU.params["gridN"][0]<=0):
+
+def prepareArrays(FF, Vpot):
+    if PPU.params["gridN"][0] <= 0:
         PPU.autoGridN()
-    if ( FF is None ):
-        gridN = PPU.params['gridN']
-        FF    = np.zeros( (gridN[2],gridN[1],gridN[0],3)    )
+    if FF is None:
+        gridN = PPU.params["gridN"]
+        FF = np.zeros((gridN[2], gridN[1], gridN[0], 3))
     else:
-        PPU.params['gridN'] = np.shape( FF )
-    core.setFF_Fpointer( FF )
-    if ( Vpot ):
-        V = np.zeros( (gridN[2],gridN[1],gridN[0])    )
-        core.setFF_Epointer( V )
+        PPU.params["gridN"] = np.shape(FF)
+    core.setFF_Fpointer(FF)
+    if Vpot:
+        V = np.zeros((gridN[2], gridN[1], gridN[0]))
+        core.setFF_Epointer(V)
     else:
-        V=None
+        V = None
     return FF, V
 
-def computeLJ( geomFile, speciesFile, geometry_format=None, save_format=None, computeVpot=False, Fmax=Fmax_DEFAULT, Vmax=Vmax_DEFAULT, ffModel="LJ" ):
-    if(verbose>0): print(">>>BEGIN: computeLJ()")
+
+def computeLJ(
+    geomFile,
+    speciesFile,
+    geometry_format=None,
+    save_format=None,
+    computeVpot=False,
+    Fmax=Fmax_DEFAULT,
+    Vmax=Vmax_DEFAULT,
+    ffModel="LJ",
+):
+    if verbose > 0:
+        print(">>>BEGIN: computeLJ()")
+        print(PPU.params["gridN"])
     # --- load species (LJ potential)
-    FFparams            = PPU.loadSpecies( speciesFile )
-    elem_dict           = PPU.getFFdict(FFparams); # print elem_dict
+    FFparams = PPU.loadSpecies(speciesFile)
+    elem_dict = PPU.getFFdict(FFparams)
+    # print elem_dict
     # --- load atomic geometry
-    atoms,nDim,lvec     = io.loadGeometry( geomFile, format=geometry_format, params=PPU.params )
-    atomstring          = io.primcoords2Xsf( PPU.atoms2iZs( atoms[0],elem_dict ), [atoms[1],atoms[2],atoms[3]], lvec );
-    PPU      .params['gridN'] = nDim; PPU.params['gridA'] = lvec[1]; PPU.params['gridB'] = lvec[2]; PPU.params['gridC'] = lvec[3] # must be before parseAtoms
-    if(verbose>0): print(PPU.params['gridN'],        PPU.params['gridA'],           PPU.params['gridB'],           PPU.params['gridC'])
-    iZs,Rs,Qs           = PPU.parseAtoms(atoms, elem_dict, autogeom=False, PBC = PPU.params['PBC'] )
+    atoms, nDim, lvec = io.loadGeometry(
+        geomFile, format=geometry_format, params=PPU.params
+    )
+    atomstring = io.primcoords2Xsf(
+        PPU.atoms2iZs(atoms[0], elem_dict), [atoms[1], atoms[2], atoms[3]], lvec
+    )
+    PPU.params["gridN"] = nDim
+    PPU.params["gridA"] = lvec[1]
+    PPU.params["gridB"] = lvec[2]
+    PPU.params["gridC"] = lvec[3]  # must be before parseAtoms
+    if verbose > 0:
+        print(
+            PPU.params["gridN"],
+            PPU.params["gridA"],
+            PPU.params["gridB"],
+            PPU.params["gridC"],
+        )
+    iZs, Rs, Qs = PPU.parseAtoms(
+        atoms, elem_dict, autogeom=False, PBC=PPU.params["PBC"]
+    )
     # --- prepare LJ parameters
-    iPP                 = PPU.atom2iZ( PPU.params['probeType'], elem_dict )
+    iPP = PPU.atom2iZ(PPU.params["probeType"], elem_dict)
     # --- prepare arrays and compute
-    FF,V                = prepareArrays( None, computeVpot )
-    if(verbose>0): print("FFLJ.shape",FF.shape)
-    core.setFF_shape( np.shape(FF), lvec )
-    if ffModel=="Morse":
-        REs = PPU.getAtomsRE( iPP, iZs, FFparams )
-        core.getMorseFF( Rs, REs )     # THE MAIN STUFF HERE
-    elif ffModel=="vdW":
-        vdWDampKind=PPU.params['vdWDampKind']
-        if(vdWDampKind==0):
-            cLJs = PPU.getAtomsLJ( iPP, iZs, FFparams )
-            core.getVdWFF( Rs, cLJs )      # THE MAIN STUFF HERE
+    FF, V = prepareArrays(None, computeVpot)
+    if verbose > 0:
+        print("FFLJ.shape", FF.shape)
+    core.setFF_shape(np.shape(FF), lvec)
+    if ffModel == "Morse":
+        REs = PPU.getAtomsRE(iPP, iZs, FFparams)
+        core.getMorseFF(Rs, REs)  # THE MAIN STUFF HERE
+    elif ffModel == "vdW":
+        vdWDampKind = PPU.params["vdWDampKind"]
+        if vdWDampKind == 0:
+            cLJs = PPU.getAtomsLJ(iPP, iZs, FFparams)
+            core.getVdWFF(Rs, cLJs)  # THE MAIN STUFF HERE
         else:
-            REs = PPU.getAtomsRE( iPP, iZs, FFparams )
-            core.getVdWFF_RE( Rs, REs, kind=vdWDampKind )    # THE MAIN STUFF HERE
+            REs = PPU.getAtomsRE(iPP, iZs, FFparams)
+            core.getVdWFF_RE(Rs, REs, kind=vdWDampKind)  # THE MAIN STUFF HERE
     else:
-        cLJs = PPU.getAtomsLJ( iPP, iZs, FFparams )
-        core.getLenardJonesFF( Rs, cLJs ) # THE MAIN STUFF HERE
+        cLJs = PPU.getAtomsLJ(iPP, iZs, FFparams)
+        core.getLennardJonesFF(Rs, cLJs)  # THE MAIN STUFF HERE
     # --- post porces FFs
-    if Fmax is not  None:
-        if(verbose>0): print("Clamp force >", Fmax)
-        io.limit_vec_field( FF, Fmax=Fmax )
+    if Fmax is not None:
+        if verbose > 0:
+            print("Clamp force >", Fmax)
+        io.limit_vec_field(FF, Fmax=Fmax)
     if (Vmax is not None) and computeVpot:
-        if(verbose>0): print("Clamp potential >", Vmax)
-        V[ V > Vmax ] =  Vmax # remove too large values
+        if verbose > 0:
+            print("Clamp potential >", Vmax)
+        V[V > Vmax] = Vmax  # remove too large values
     # --- save to files ?
     if save_format is not None:
-        if(verbose>0): print("computeLJ Save ", save_format)
-        io.save_vec_field( 'FF'+ffModel, FF, lvec,  data_format=save_format, head=atomstring , atomic_info = (atoms[:4],lvec))
+        if verbose > 0:
+            print("computeLJ Save ", save_format)
+        io.save_vec_field(
+            "FF" + ffModel,
+            FF,
+            lvec,
+            data_format=save_format,
+            head=atomstring,
+            atomic_info=(atoms[:4], lvec),
+        )
         if computeVpot:
-            io.save_scal_field( 'E'+ffModel, V, lvec,  data_format=save_format, head=atomstring , atomic_info = (atoms[:4],lvec))
-    if(verbose>0): print("<<<END: computeLJ()")
+            io.save_scal_field(
+                "E" + ffModel,
+                V,
+                lvec,
+                data_format=save_format,
+                head=atomstring,
+                atomic_info=(atoms[:4], lvec),
+            )
+    if verbose > 0:
+        print("<<<END: computeLJ()")
     return FF, V, nDim, lvec
 
-def computeDFTD3(input_file, df_params='PBE', geometry_format=None, save_format=None, compute_energy=False):
-    '''
+
+def computeDFTD3(
+    input_file,
+    df_params="PBE",
+    geometry_format=None,
+    save_format=None,
+    compute_energy=False,
+):
+    """
     Compute the Grimme DFT-D3 force field and optionally save to a file. See also :meth:`.add_dftd3`.
 
     Arguments:
@@ -204,14 +317,19 @@ def computeDFTD3(input_file, df_params='PBE', geometry_format=None, save_format=
         FF: np.ndarray of shape (nx, ny, nz, 3). Force field.
         V: np.ndarray of shape (nx, ny, nz) or None. Energy, if compute_energy == True.
         lvec: np.ndarray of shape (4, 3). Origin and lattice vectors of the force field.
-    '''
+    """
 
     # Load atomic geometry
-    atoms, nDim, lvec = io.loadGeometry(input_file, format=geometry_format, params=PPU.params)
-    PPU.params['gridN'] = nDim; PPU.params['gridA'] = lvec[1]; PPU.params['gridB'] = lvec[2]; PPU.params['gridC'] = lvec[3]
+    atoms, nDim, lvec = io.loadGeometry(
+        input_file, format=geometry_format, params=PPU.params
+    )
+    PPU.params["gridN"] = nDim
+    PPU.params["gridA"] = lvec[1]
+    PPU.params["gridB"] = lvec[2]
+    PPU.params["gridC"] = lvec[3]
     elem_dict = PPU.getFFdict(PPU.loadSpecies())
-    iZs, Rs, _ = PPU.parseAtoms(atoms, elem_dict, autogeom=False, PBC=PPU.params['PBC'])
-    iPP = PPU.atom2iZ(PPU.params['probeType'], elem_dict)
+    iZs, Rs, _ = PPU.parseAtoms(atoms, elem_dict, autogeom=False, PBC=PPU.params["PBC"])
+    iPP = PPU.atom2iZ(PPU.params["probeType"], elem_dict)
 
     # Compute coefficients for each atom
     df_params = d3.get_df_params(df_params)
@@ -224,127 +342,245 @@ def computeDFTD3(input_file, df_params='PBE', geometry_format=None, save_format=
 
     # Save to file
     if save_format is not None:
-        atom_string = io.primcoords2Xsf(PPU.atoms2iZs(atoms[0], elem_dict), atoms[1:4], lvec)
-        io.save_vec_field('FFvdW', FF, lvec, data_format=save_format, head=atom_string, atomic_info = (atoms[:4], lvec))
+        atom_string = io.primcoords2Xsf(
+            PPU.atoms2iZs(atoms[0], elem_dict), atoms[1:4], lvec
+        )
+        io.save_vec_field(
+            "FFvdW",
+            FF,
+            lvec,
+            data_format=save_format,
+            head=atom_string,
+            atomic_info=(atoms[:4], lvec),
+        )
         if compute_energy:
-            io.save_scal_field('EvdW', V, lvec, data_format=save_format, head=atom_string, atomic_info = (atoms[:4], lvec))
+            io.save_scal_field(
+                "EvdW",
+                V,
+                lvec,
+                data_format=save_format,
+                head=atom_string,
+                atomic_info=(atoms[:4], lvec),
+            )
 
     return FF, V, lvec
 
-def computeELFF_pointCharge( geomFile, geometry_format = None, tip='s', save_format=None, computeVpot=False, Fmax=Fmax_DEFAULT, Vmax=Vmax_DEFAULT ):
 
-    if(verbose>0): print(">>>BEGIN: computeELFF_pointCharge()")
-    tipKinds = {'s':0,'pz':1,'dz2':2}
-    tipKind  = tipKinds[tip]
-    if(verbose>0): print(" ========= get electrostatic forcefiled from the point charges tip=%s %i " %(tip,tipKind))
+def computeELFF_pointCharge(
+    geomFile,
+    geometry_format=None,
+    tip="s",
+    save_format=None,
+    computeVpot=False,
+    Fmax=Fmax_DEFAULT,
+    Vmax=Vmax_DEFAULT,
+):
+    if verbose > 0:
+        print(">>>BEGIN: computeELFF_pointCharge()")
+    tipKinds = {"s": 0, "pz": 1, "dz2": 2}
+    tipKind = tipKinds[tip]
+    if verbose > 0:
+        print(
+            " ========= get electrostatic forcefiled from the point charges tip=%s %i "
+            % (tip, tipKind)
+        )
     # --- load atomic geometry
-    FFparams            = PPU.loadSpecies( )
-    elem_dict           = PPU.getFFdict(FFparams); # print elem_dict
+    FFparams = PPU.loadSpecies()
+    elem_dict = PPU.getFFdict(FFparams)
+    # print elem_dict
 
-    atoms,nDim,lvec     = io.loadGeometry( geomFile, format=geometry_format, params=PPU.params )
-    atomstring          = io.primcoords2Xsf( PPU.atoms2iZs( atoms[0],elem_dict ), [atoms[1],atoms[2],atoms[3]], lvec );
-    iZs,Rs,Qs=PPU.parseAtoms(atoms, elem_dict=elem_dict, autogeom=False, PBC=PPU.params['PBC'] )
+    atoms, nDim, lvec = io.loadGeometry(
+        geomFile, format=geometry_format, params=PPU.params
+    )
+    atomstring = io.primcoords2Xsf(
+        PPU.atoms2iZs(atoms[0], elem_dict), [atoms[1], atoms[2], atoms[3]], lvec
+    )
+    iZs, Rs, Qs = PPU.parseAtoms(
+        atoms, elem_dict=elem_dict, autogeom=False, PBC=PPU.params["PBC"]
+    )
     # --- prepare arrays and compute
-    PPU.params['gridN'] = nDim; PPU.params['gridA'] = lvec[1]; PPU.params['gridB'] = lvec[2]; PPU.params['gridC'] = lvec[3]
-    if(verbose>0): print(PPU.params['gridN'], PPU.params['gridA'], PPU.params['gridB'], PPU.params['gridC'])
-    FF,V = prepareArrays( None, computeVpot )
-    core.setFF_shape( np.shape(FF), lvec )
-    core.getCoulombFF( Rs, Qs*PPU.CoulombConst, kind=tipKind ) # THE MAIN STUFF HERE
+    PPU.params["gridN"] = nDim
+    PPU.params["gridA"] = lvec[1]
+    PPU.params["gridB"] = lvec[2]
+    PPU.params["gridC"] = lvec[3]
+    if verbose > 0:
+        print(
+            PPU.params["gridN"],
+            PPU.params["gridA"],
+            PPU.params["gridB"],
+            PPU.params["gridC"],
+        )
+    FF, V = prepareArrays(None, computeVpot)
+    core.setFF_shape(np.shape(FF), lvec)
+    core.getCoulombFF(Rs, Qs * PPU.CoulombConst, kind=tipKind)  # THE MAIN STUFF HERE
     # --- post porces FFs
-    if Fmax is not  None:
-        if(verbose>0): print("Clamp force >", Fmax)
-        io.limit_vec_field( FF, Fmax=Fmax )
+    if Fmax is not None:
+        if verbose > 0:
+            print("Clamp force >", Fmax)
+        io.limit_vec_field(FF, Fmax=Fmax)
     if (Vmax is not None) and computeVpot:
-        if(verbose>0): print("Clamp potential >", Vmax)
-        V[ V > Vmax ] =  Vmax # remove too large values
+        if verbose > 0:
+            print("Clamp potential >", Vmax)
+        V[V > Vmax] = Vmax  # remove too large values
     # --- save to files ?
     if save_format is not None:
-        if(verbose>0): print("computeLJ Save ", save_format)
-        io.save_vec_field( 'FFel',FF,lvec,data_format=save_format, head=atomstring , atomic_info = (atoms[:4],lvec))
+        if verbose > 0:
+            print("computeLJ Save ", save_format)
+        io.save_vec_field(
+            "FFel",
+            FF,
+            lvec,
+            data_format=save_format,
+            head=atomstring,
+            atomic_info=(atoms[:4], lvec),
+        )
         if computeVpot:
-            io.save_scal_field( 'Vel',V,lvec,data_format=save_format, head=atomstring , atomic_info = (atoms[:4],lvec) )
-    if(verbose>0): print("<<<END: computeELFF_pointCharge()")
+            io.save_scal_field(
+                "Vel",
+                V,
+                lvec,
+                data_format=save_format,
+                head=atomstring,
+                atomic_info=(atoms[:4], lvec),
+            )
+    if verbose > 0:
+        print("<<<END: computeELFF_pointCharge()")
     return FF, V, nDim, lvec
 
-def computeElFF(V,lvec,nDim,tip,computeVpot=False, tilt=0.0,sigma=None ):
-    if(verbose>0): print(" ========= get electrostatic forcefiled from hartree ")
+
+def computeElFF(V, lvec, nDim, tip, computeVpot=False, tilt=0.0, sigma=None):
+    if verbose > 0:
+        print(" ========= get electrostatic forcefiled from hartree ")
     rho = None
     multipole = None
     if sigma is None:
-        sigma=PPU.params['sigma']
+        sigma = PPU.params["sigma"]
     if type(tip) is np.ndarray:
         rho = tip
     elif type(tip) is dict:
         multipole = tip
     else:
-        if tip in {'s','px','py','pz','dx2','dy2','dz2','dxy','dxz','dyz'}:
+        if tip in {"s", "px", "py", "pz", "dx2", "dy2", "dz2", "dxy", "dxz", "dyz"}:
             rho = None
-            multipole={tip:1.0}
+            multipole = {tip: 1.0}
         elif tip.endswith(".xsf"):
             rho, lvec_tip, nDim_tip, tiphead = io.loadXSF(tip)
             if any(nDim_tip != nDim):
-                sys.exit("Error: Input file for tip charge density has been specified, but the dimensions are incompatible with the Hartree potential file!")
-    if(verbose>0): print(" computing convolution with tip by FFT ")
-    Fel_x,Fel_y,Fel_z, Vout = fFFT.potential2forces_mem( V, lvec, nDim, rho=rho, sigma=sigma, multipole = multipole, doPot=computeVpot, tilt=tilt )
-    FFel = io.packVecGrid(Fel_x,Fel_y,Fel_z)
-    del Fel_x,Fel_y,Fel_z
+                sys.exit(
+                    "Error: Input file for tip charge density has been specified, but the dimensions are incompatible with the Hartree potential file!"
+                )
+    if verbose > 0:
+        print(" computing convolution with tip by FFT ")
+    Fel_x, Fel_y, Fel_z, Vout = fFFT.potential2forces_mem(
+        V,
+        lvec,
+        nDim,
+        rho=rho,
+        sigma=sigma,
+        multipole=multipole,
+        doPot=computeVpot,
+        tilt=tilt,
+    )
+    FFel = io.packVecGrid(Fel_x, Fel_y, Fel_z)
+    del Fel_x, Fel_y, Fel_z
     return FFel, Vout
+
 
 def loadValenceElectronDict():
     valElDict_ = None
     namespace = {}
     try:
-        fname_valelec_dict = 'valelec_dict.py'
+        fname_valelec_dict = "valelec_dict.py"
         namespace = {}
-        exec( open(fname_valelec_dict).read(), namespace )
-        print("   : ", namespace['valElDict'] )
-        valElDict_ = namespace['valElDict']
+        exec(open(fname_valelec_dict).read(), namespace)
+        print("   : ", namespace["valElDict"])
+        valElDict_ = namespace["valElDict"]
         print("Valence electrons loaded from local file : ", fname_valelec_dict)
     except:
         pass
     if valElDict_ is None:
         namespace = {}
-        fname_valelec_dict = cpp_utils.PACKAGE_PATH / 'defaults' / 'valelec_dict.py'
-        exec(open(fname_valelec_dict).read(), namespace )
-        valElDict_ = namespace['valElDict']
+        fname_valelec_dict = cpp_utils.PACKAGE_PATH / "defaults" / "valelec_dict.py"
+        exec(open(fname_valelec_dict).read(), namespace)
+        valElDict_ = namespace["valElDict"]
         print("Valence electrons loaded from default location : ", fname_valelec_dict)
-    if(verbose>0): print(" Valence Electron Dict : \n", valElDict_)
+    if verbose > 0:
+        print(" Valence Electron Dict : \n", valElDict_)
     return valElDict_
 
-def _getAtomsWhichTouchPBCcell( Rs, elems, nDim, lvec, Rcut, bSaveDebug, fname=None ):
-    inds, Rs_ = PPU.findPBCAtoms3D_cutoff( Rs, np.array(lvec[1:]), Rcut=Rcut )  # find periodic images of PBC images of atom of radius Rcut which touch our cell
-    elems = [ elems[i] for i in inds ]   # atomic number of all relevant peridic images of atoms
+
+def _getAtomsWhichTouchPBCcell(Rs, elems, nDim, lvec, Rcut, bSaveDebug, fname=None):
+    inds, Rs_ = PPU.findPBCAtoms3D_cutoff(
+        Rs, np.array(lvec[1:]), Rcut=Rcut
+    )  # find periodic images of PBC images of atom of radius Rcut which touch our cell
+    elems = [
+        elems[i] for i in inds
+    ]  # atomic number of all relevant peridic images of atoms
     if bSaveDebug:
-        io.saveGeomXSF( fname+"_TouchCell_debug.xsf",elems,Rs_, lvec[1:], convvec=lvec[1:], bTransposed=True )    # for debugging - mapping PBC images of atoms to the cell
+        io.saveGeomXSF(
+            fname + "_TouchCell_debug.xsf",
+            elems,
+            Rs_,
+            lvec[1:],
+            convvec=lvec[1:],
+            bTransposed=True,
+        )  # for debugging - mapping PBC images of atoms to the cell
     Rs_ = Rs_.transpose().copy()
     return Rs_, elems
 
-def getAtomsWhichTouchPBCcell( fname, Rcut=1.0, bSaveDebug=True, geometry_format=None ):
-    atoms, nDim, lvec = io.loadGeometry( fname, format=geometry_format, params=PPU.params )
-    Rs = np.array(atoms[1:4]) # get just positions x,y,z
+
+def getAtomsWhichTouchPBCcell(fname, Rcut=1.0, bSaveDebug=True, geometry_format=None):
+    atoms, nDim, lvec = io.loadGeometry(
+        fname, format=geometry_format, params=PPU.params
+    )
+    Rs = np.array(atoms[1:4])  # get just positions x,y,z
     elems = np.array(atoms[0])
-    Rs, elems = _getAtomsWhichTouchPBCcell(Rs, elems, nDim, lvec, Rcut, bSaveDebug, fname)
+    Rs, elems = _getAtomsWhichTouchPBCcell(
+        Rs, elems, nDim, lvec, Rcut, bSaveDebug, fname
+    )
     return Rs, elems
 
-def subtractCoreDensities( rho, lvec_, elems=None, Rs=None, fname=None, valElDict=None, Rcore=0.7, bSaveDebugDens=False, bSaveDebugGeom=True, head=io.XSF_HEAD_DEFAULT ):
+
+def subtractCoreDensities(
+    rho,
+    lvec_,
+    elems=None,
+    Rs=None,
+    fname=None,
+    valElDict=None,
+    Rcore=0.7,
+    bSaveDebugDens=False,
+    bSaveDebugGeom=True,
+    head=io.XSF_HEAD_DEFAULT,
+):
     lvec = lvec_[1:]
     nDim = rho.shape
     if fname is not None:
-        elems,Rs = getAtomsWhichTouchPBCcell( fname, Rcut=Rcore, bSaveDebug=bSaveDebugDens )
+        elems, Rs = getAtomsWhichTouchPBCcell(
+            fname, Rcut=Rcore, bSaveDebug=bSaveDebugDens
+        )
     if valElDict is None:
         valElDict = loadValenceElectronDict()
     print("subtractCoreDensities valElDict ", valElDict)
     print("subtractCoreDensities elems ", elems)
-    cRAs = np.array( [ (-valElDict[elem],Rcore) for elem in elems ] )
-    V  = np.linalg.det( lvec )   # volume of triclinic cell
-    N  = nDim[0]*nDim[1]*nDim[2]
-    dV = (V/N)  # volume of one voxel
-    if(verbose>0): print("V : ",V," N: ",N," dV: ", dV)
-    if(verbose>0): print("sum(RHO): ",rho.sum()," Nelec: ",rho.sum()*dV," voxel volume: ", dV)   # check sum
-    core.setFF_shape   ( rho.shape, lvec )     # set grid sampling dimension and shape
-    core.setFF_Epointer( rho )                  # set pointer to array with density data (to write into)
-    if(verbose>0): print(">>> Projecting Core Densities ... ")
-    core.getDensityR4spline( Rs, cRAs.copy() )  # Do the job ( the Projection of atoms onto grid )
-    if(verbose>0): print("sum(RHO), Nelec: ",  rho.sum(),  rho.sum()*dV)   # check sum
+    cRAs = np.array([(-valElDict[elem], Rcore) for elem in elems])
+    V = np.linalg.det(lvec)  # volume of triclinic cell
+    N = nDim[0] * nDim[1] * nDim[2]
+    dV = V / N  # volume of one voxel
+    if verbose > 0:
+        print("V : ", V, " N: ", N, " dV: ", dV)
+    if verbose > 0:
+        print(
+            "sum(RHO): ", rho.sum(), " Nelec: ", rho.sum() * dV, " voxel volume: ", dV
+        )  # check sum
+    core.setFF_shape(rho.shape, lvec)  # set grid sampling dimension and shape
+    core.setFF_Epointer(rho)  # set pointer to array with density data (to write into)
+    if verbose > 0:
+        print(">>> Projecting Core Densities ... ")
+    core.getDensityR4spline(
+        Rs, cRAs.copy()
+    )  # Do the job ( the Projection of atoms onto grid )
+    if verbose > 0:
+        print("sum(RHO), Nelec: ", rho.sum(), rho.sum() * dV)  # check sum
     if bSaveDebugDens:
-        io.saveXSF( "rho_subCoreChg.xsf", rho, lvec_, head=head )
+        io.saveXSF("rho_subCoreChg.xsf", rho, lvec_, head=head)

--- a/ppafm/HighLevel.py
+++ b/ppafm/HighLevel.py
@@ -212,7 +212,6 @@ def computeLJ(
 ):
     if verbose > 0:
         print(">>>BEGIN: computeLJ()")
-        print(PPU.params["gridN"])
     # --- load species (LJ potential)
     FFparams = PPU.loadSpecies(speciesFile)
     elem_dict = PPU.getFFdict(FFparams)
@@ -395,10 +394,6 @@ def computeELFF_pointCharge(
     atomstring = io.primcoords2Xsf(
         PPU.atoms2iZs(atoms[0], elem_dict), [atoms[1], atoms[2], atoms[3]], lvec
     )
-    iZs, Rs, Qs = PPU.parseAtoms(
-        atoms, elem_dict=elem_dict, autogeom=False, PBC=PPU.params["PBC"]
-    )
-    # --- prepare arrays and compute
     PPU.params["gridN"] = nDim
     PPU.params["gridA"] = lvec[1]
     PPU.params["gridB"] = lvec[2]
@@ -410,6 +405,10 @@ def computeELFF_pointCharge(
             PPU.params["gridB"],
             PPU.params["gridC"],
         )
+    iZs, Rs, Qs = PPU.parseAtoms(
+        atoms, elem_dict=elem_dict, autogeom=False, PBC=PPU.params["PBC"]
+    )
+    # --- prepare arrays and compute
     FF, V = prepareArrays(None, computeVpot)
     core.setFF_shape(np.shape(FF), lvec)
     core.getCoulombFF(Rs, Qs * PPU.CoulombConst, kind=tipKind)  # THE MAIN STUFF HERE

--- a/ppafm/cli/gui/ppafm_gui.py
+++ b/ppafm/cli/gui/ppafm_gui.py
@@ -11,6 +11,7 @@ import traceback
 from argparse import ArgumentParser
 from enum import Enum
 
+import matplotlib
 import numpy as np
 from PyQt5 import QtCore, QtGui, QtWidgets
 
@@ -22,99 +23,126 @@ from ppafm import PPPlot, io
 from ppafm.ocl.AFMulator import AFMulator
 from ppafm.ocl.field import ElectronDensity, HartreePotential, TipDensity
 
-import matplotlib; matplotlib.use('Qt5Agg')
+matplotlib.use("Qt5Agg")
 
 
-Multipoles = Enum('Multipoles', 's pz dz2')
+Multipoles = Enum("Multipoles", "s pz dz2")
 
 Presets = {
-    'CO (Z8, dz2, Q-0.1, K0.25)': {
-        'Z': 8,
-        'Multipole': 'dz2',
-        'Q': -0.1,
-        'Sigma': 0.71,
-        'K': [0.25, 0.25, 30.0],
-        'EqPos': [0.0, 0.0, 3.0]
+    "CO (Z8, dz2, Q-0.1, K0.25)": {
+        "Z": 8,
+        "Multipole": "dz2",
+        "Q": -0.1,
+        "Sigma": 0.71,
+        "K": [0.25, 0.25, 30.0],
+        "EqPos": [0.0, 0.0, 3.0],
     },
-    'Xe (Z54, s, Q0.3, K0.25)': {
-        'Z': 54,
-        'Multipole': 's',
-        'Q': 0.3,
-        'Sigma': 0.71,
-        'K': [0.25, 0.25, 30.0],
-        'EqPos': [0.0, 0.0, 3.0]
+    "Xe (Z54, s, Q0.3, K0.25)": {
+        "Z": 54,
+        "Multipole": "s",
+        "Q": 0.3,
+        "Sigma": 0.71,
+        "K": [0.25, 0.25, 30.0],
+        "EqPos": [0.0, 0.0, 3.0],
     },
-    'Cl (Z17, s, Q-0.3, K0.50)': {
-        'Z': 17,
-        'Multipole': 's',
-        'Q': -0.3,
-        'Sigma': 0.71,
-        'K': [0.50, 0.50, 30.0],
-        'EqPos': [0.0, 0.0, 3.0]
-    }
+    "Cl (Z17, s, Q-0.3, K0.50)": {
+        "Z": 17,
+        "Multipole": "s",
+        "Q": -0.3,
+        "Sigma": 0.71,
+        "K": [0.50, 0.50, 30.0],
+        "EqPos": [0.0, 0.0, 3.0],
+    },
 }
 
 TTips = {
-    'Preset': 'Preset: Apply a probe parameter preset.',
-    'Z': 'Z: Probe atomic number. Determines the Lennard-Jones parameters of the force field.',
-    'Multipole': 'Multipole: Probe charge multipole type:\ns: monopole\npz: dipole\ndz2: quadrupole.',
-    'Q': 'Q: Probe charge/multipole magnitude.',
-    'Sigma': 'Sigma: Probe charge distribution width.',
-    'point_charge': 'Use point-charge approximation for probe charge distribution. Faster but less accurate.',
-    'K': 'K: Force constants for harmonic force holding the probe to the tip in x, y, and radial directions.',
-    'EqPos': 'Eq. Pos: Probe equilibrium position with respect to the tip in x, y, and radial directions. Non-zero values for x and y models asymmetry in tip adsorption.',
-    'ScanStep': 'Scan step: Size of pixels in x and y directions and size of oscillation step in z direction.',
-    'ScanSize': 'Scan size: Total size of scan region in x and y directions.',
-    'ScanStart': 'Scan start: bottom left position of scan region in x and y directions.',
-    'Distance': 'Distance: Average tip distance from the nucleus of the closest atom.',
-    'Amplitude': 'Amplitude: Peak-to-peak oscillation amplitude for the tip.',
-    'Rotation': 'Rotation: Set sample counter-clockwise rotation angle around center of atom coordinates.',
-    'fdbm_V0': 'FDBM V0: Prefactor in Pauli interaction integral in the full-density based model.',
-    'fdbm_alpha': 'FDBM alpha: Exponent in Pauli interaction integral in the full-density based model.',
-    'PBCz': 'z periodicity: When checked, the lattice is also periodic in z direction. This is usually not required, since the scan is aligned with the xy direction.',
-    'PBC': 'Periodic Boundaries: Lattice vectors for periodic images of atoms. Does not affect electrostatics calculated from a Hartree potential file, which is always assumed to be periodic.',
-    'k': 'k: Cantilever spring constant. Only appears as a scaling constant.',
-    'f0': 'f0: Cantilever eigenfrequency. Only appears as a scaling constant.',
-    'z_steps': 'z steps: Number of steps in the df approach curve in z direction when clicking on image.',
-    'df_colorbar': 'Colorbar: Add a colorbar of df values to plot.',
-    'df_range': 'df range: Minimum and maximum df value in colorbar.',
-    'df_reset': 'Reset Range: Reset df colorbar range.',
-    'view_geom': 'View Geometry: Show system geometry in ASE GUI.',
-    'edit_geom': 'Edit Geometry: Edit the positions, atomic numbers, and charges of atoms.',
-    'view_ff': 'View Forcefield: View forcefield components in a separate window.',
-    'edit_ff': 'Edit Forcefield: Edit Lennard-Jones parameters of forcefield.'
+    "Preset": "Preset: Apply a probe parameter preset.",
+    "Z": "Z: Probe atomic number. Determines the Lennard-Jones parameters of the force field.",
+    "Multipole": "Multipole: Probe charge multipole type:\ns: monopole\npz: dipole\ndz2: quadrupole.",
+    "Q": "Q: Probe charge/multipole magnitude.",
+    "Sigma": "Sigma: Probe charge distribution width.",
+    "point_charge": "Use point-charge approximation for probe charge distribution. Faster but less accurate.",
+    "K": "K: Force constants for harmonic force holding the probe to the tip in x, y, and radial directions.",
+    "EqPos": "Eq. Pos: Probe equilibrium position with respect to the tip in x, y, and radial directions. Non-zero values for x and y models asymmetry in tip adsorption.",
+    "ScanStep": "Scan step: Size of pixels in x and y directions and size of oscillation step in z direction.",
+    "ScanSize": "Scan size: Total size of scan region in x and y directions.",
+    "ScanStart": "Scan start: bottom left position of scan region in x and y directions.",
+    "Distance": "Distance: Average tip distance from the nucleus of the closest atom.",
+    "Amplitude": "Amplitude: Peak-to-peak oscillation amplitude for the tip.",
+    "Rotation": "Rotation: Set sample counter-clockwise rotation angle around center of atom coordinates.",
+    "fdbm_V0": "FDBM V0: Prefactor in Pauli interaction integral in the full-density based model.",
+    "fdbm_alpha": "FDBM alpha: Exponent in Pauli interaction integral in the full-density based model.",
+    "PBCz": "z periodicity: When checked, the lattice is also periodic in z direction. This is usually not required, since the scan is aligned with the xy direction.",
+    "PBC": "Periodic Boundaries: Lattice vectors for periodic images of atoms. Does not affect electrostatics calculated from a Hartree potential file, which is always assumed to be periodic.",
+    "k": "k: Cantilever spring constant. Only appears as a scaling constant.",
+    "f0": "f0: Cantilever eigenfrequency. Only appears as a scaling constant.",
+    "z_steps": "z steps: Number of steps in the df approach curve in z direction when clicking on image.",
+    "df_colorbar": "Colorbar: Add a colorbar of df values to plot.",
+    "df_range": "df range: Minimum and maximum df value in colorbar.",
+    "df_reset": "Reset Range: Reset df colorbar range.",
+    "view_geom": "View Geometry: Show system geometry in ASE GUI.",
+    "edit_geom": "Edit Geometry: Edit the positions, atomic numbers, and charges of atoms.",
+    "view_ff": "View Forcefield: View forcefield components in a separate window.",
+    "edit_ff": "Edit Forcefield: Edit Lennard-Jones parameters of forcefield.",
 }
 
-def parse_args():
 
-    parser = ArgumentParser(description='Probe Particle Model graphical user interface')
-    parser.add_argument("input", nargs='*',
+def parse_args():
+    parser = ArgumentParser(description="Probe Particle Model graphical user interface")
+    parser.add_argument(
+        "input",
+        nargs="*",
         help="Optional input file(s). The first file is the main input file containing the xyz geometry or Hartree potential. The subsequent"
-            "optional files, in order, are the sample electron density, tip electron density, and tip electron delta density."
+        "optional files, in order, are the sample electron density, tip electron density, and tip electron delta density.",
     )
-    parser.add_argument("-d", "--device", action="store", type=int, default=0, help="Choose OpenCL device.")
-    parser.add_argument("-l", "--list-devices", action="store_true", help="List available OpenCL devices and exit.")
-    parser.add_argument("-v", '--verbosity', action="store", type=int, default=0, help="Set verbosity level (0-2).")
+    parser.add_argument(
+        "-d",
+        "--device",
+        action="store",
+        type=int,
+        default=0,
+        help="Choose OpenCL device.",
+    )
+    parser.add_argument(
+        "-l",
+        "--list-devices",
+        action="store_true",
+        help="List available OpenCL devices and exit.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        action="store",
+        type=int,
+        default=0,
+        help="Set verbosity level (0-2).",
+    )
 
     args = parser.parse_args()
     if args.input:
-        inputs = {'main_input': args.input[0]}
-        if len(args.input) > 1: inputs['rho_sample'] = args.input[1]
-        if len(args.input) > 2: inputs['rho_tip'] = args.input[2]
-        if len(args.input) > 3: inputs['rho_tip_delta'] = args.input[3]
+        inputs = {"main_input": args.input[0]}
+        if len(args.input) > 1:
+            inputs["rho_sample"] = args.input[1]
+        if len(args.input) > 2:
+            inputs["rho_tip"] = args.input[2]
+        if len(args.input) > 3:
+            inputs["rho_tip_delta"] = args.input[3]
         args.input = inputs
 
     return args
 
-class ApplicationWindow(QtWidgets.QMainWindow):
 
-    sw_pad = 4.0 # Default padding for scan window on each side of the molecule in xy plane
-    zoom_step = 1.0 # How much to increase/reduce scan size on zoom
-    df_range = (-1, 1) # min and max df value in colorbar
-    fixed_df_range = False # Keep track if df range was fixed by user or should be set automatically
+class ApplicationWindow(QtWidgets.QMainWindow):
+    sw_pad = (
+        4.0  # Default padding for scan window on each side of the molecule in xy plane
+    )
+    zoom_step = 1.0  # How much to increase/reduce scan size on zoom
+    df_range = (-1, 1)  # min and max df value in colorbar
+    fixed_df_range = (
+        False  # Keep track if df range was fixed by user or should be set automatically
+    )
 
     def __init__(self, input_files=None, device=0, verbose=0):
-
         self.df = None
         self.xyzs = None
         self.Zs = None
@@ -131,7 +159,8 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self.afmulator = AFMulator()
 
         # Set verbosity level to same value everywhere
-        if verbose > 0: print(f'Verbosity level = {verbose}')
+        if verbose > 0:
+            print(f"Verbosity level = {verbose}")
         self.verbose = verbose
         self.afmulator.verbose = verbose
         self.afmulator.forcefield.verbose = verbose
@@ -144,9 +173,16 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self.setWindowTitle("Probe Particle Model")
         self.main_widget = QtWidgets.QWidget(self)
         l00 = QtWidgets.QHBoxLayout(self.main_widget)
-        l1 = QtWidgets.QVBoxLayout(self.main_widget); l00.addLayout(l1, 2)
-        self.figCan = guiw.FigImshow( parentWiget=self.main_widget, parentApp=self, width=5, height=4,
-            dpi=100, verbose=verbose)
+        l1 = QtWidgets.QVBoxLayout(self.main_widget)
+        l00.addLayout(l1, 2)
+        self.figCan = guiw.FigImshow(
+            parentWiget=self.main_widget,
+            parentApp=self,
+            width=5,
+            height=4,
+            dpi=100,
+            verbose=verbose,
+        )
         l1.addWidget(self.figCan)
         self.resize(1200, 600)
         self.main_widget.setFocus()
@@ -155,12 +191,13 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         # -------- Status Bar
         self.status_bar = QtWidgets.QStatusBar()
         self.status_bar.setSizeGripEnabled(False)
-        self.dim_label = QtWidgets.QLabel('')
+        self.dim_label = QtWidgets.QLabel("")
         self.status_bar.addPermanentWidget(self.dim_label)
         l1.addWidget(self.status_bar)
 
         # -------- Settings
-        self.l0 = QtWidgets.QVBoxLayout(self.main_widget); l00.addLayout(self.l0, 1)
+        self.l0 = QtWidgets.QVBoxLayout(self.main_widget)
+        l00.addLayout(self.l0, 1)
         self._create_probe_settings_ui()
         _separator_line(self.l0)
         self._create_scan_settings_ui()
@@ -182,16 +219,19 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self.status_bar.repaint()
 
     def setScanWindow(self, scan_size, scan_start, step, distance, amplitude):
-        '''Set scan window in AFMulator and update input fields'''
+        """Set scan window in AFMulator and update input fields"""
 
-        if self.xyzs is None: return
+        if self.xyzs is None:
+            return
 
         # Make scan size and amplitude multiples of the step size
-        scan_dim = np.round([
-            scan_size[0] / step[0] + 1,
-            scan_size[1] / step[1] + 1,
-            amplitude    / step[2]
-        ]).astype(np.int32)
+        scan_dim = np.round(
+            [
+                scan_size[0] / step[0] + 1,
+                scan_size[1] / step[1] + 1,
+                amplitude / step[2],
+            ]
+        ).astype(np.int32)
         scan_size = (scan_dim[:2] - 1) * step[:2]
         amplitude = scan_dim[2] * step[2]
         z_extra_steps = self.bxdfst.value() - 1
@@ -200,12 +240,13 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         z_min = z - amplitude / 2
         z_max = z + amplitude / 2 + z_extra_steps * step[2]
         scan_window = (
-            (scan_start[0]               , scan_start[1]               , z_min),
-            (scan_start[0] + scan_size[0], scan_start[1] + scan_size[1], z_max)
+            (scan_start[0], scan_start[1], z_min),
+            (scan_start[0] + scan_size[0], scan_start[1] + scan_size[1], z_max),
         )
         self.afmulator.kCantilever = self.bxCant_K.value() * 1000
         self.afmulator.f0Cantilever = self.bxCant_f0.value() * 1000
-        if self.verbose > 0: print("setScanWindow", step, scan_size, scan_start, scan_dim, scan_window)
+        if self.verbose > 0:
+            print("setScanWindow", step, scan_size, scan_start, scan_dim, scan_window)
 
         # Set new values to the fields
         guiw.set_widget_value(self.bxSSx, scan_size[0])
@@ -221,53 +262,72 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self.bxA.setSingleStep(step[2])
 
         # Set new scan window and dimension in AFMulator, and infer FF lvec from the scan window
-        self.afmulator.setScanWindow(scan_window, tuple(scan_dim), scan_dim[2] - z_extra_steps)
+        self.afmulator.setScanWindow(
+            scan_window, tuple(scan_dim), scan_dim[2] - z_extra_steps
+        )
         self.afmulator.setLvec()
 
         # Update status bar info
         ff_dim = self.afmulator.forcefield.nDim
-        self.dim_label.setText(f'Scan dim: {scan_dim[0]}x{scan_dim[1]}x{scan_dim[2]} | '
-            f'FF dim: {ff_dim[0]}x{ff_dim[1]}x{ff_dim[2]}')
+        self.dim_label.setText(
+            f"Scan dim: {scan_dim[0]}x{scan_dim[1]}x{scan_dim[2]} | "
+            f"FF dim: {ff_dim[0]}x{ff_dim[1]}x{ff_dim[2]}"
+        )
 
-        if self.verbose > 0: print('lvec:\n', self.afmulator.forcefield.nDim, self.afmulator.lvec)
+        if self.verbose > 0:
+            print("lvec:\n", self.afmulator.forcefield.nDim, self.afmulator.lvec)
 
     def scanWindowFromGeom(self):
-        '''Infer and set scan window from current geometry'''
-        if self.xyzs is None: return
-        scan_size = self.xyzs[:, :2].max(axis=0) - self.xyzs[:, :2].min(axis=0) + 2 * self.sw_pad
-        scan_size = np.minimum(scan_size, [25, 25]) # Let's not make it automatically too large, so that we don't run out of memory
-        scan_start = (self.xyzs[:, :2].max(axis=0) + self.xyzs[:, :2].min(axis=0)) / 2 - scan_size / 2
-        step = np.array([self.bxStepX.value(), self.bxStepY.value(), self.bxStepZ.value()])
+        """Infer and set scan window from current geometry"""
+        if self.xyzs is None:
+            return
+        scan_size = (
+            self.xyzs[:, :2].max(axis=0)
+            - self.xyzs[:, :2].min(axis=0)
+            + 2 * self.sw_pad
+        )
+        scan_size = np.minimum(
+            scan_size, [25, 25]
+        )  # Let's not make it automatically too large, so that we don't run out of memory
+        scan_start = (
+            self.xyzs[:, :2].max(axis=0) + self.xyzs[:, :2].min(axis=0)
+        ) / 2 - scan_size / 2
+        step = np.array(
+            [self.bxStepX.value(), self.bxStepY.value(), self.bxStepZ.value()]
+        )
         distance = self.bxD.value()
         amplitude = self.bxA.value()
         self.setScanWindow(scan_size, scan_start, step, distance, amplitude)
 
     def updateScanWindow(self):
-        '''Get scan window from input fields and update'''
-        if self.xyzs is None: return
+        """Get scan window from input fields and update"""
+        if self.xyzs is None:
+            return
         scan_size = np.array([self.bxSSx.value(), self.bxSSy.value()])
         scan_start = np.array([self.bxSCx.value(), self.bxSCy.value()])
-        step = np.array([self.bxStepX.value(), self.bxStepY.value(), self.bxStepZ.value()])
+        step = np.array(
+            [self.bxStepX.value(), self.bxStepY.value(), self.bxStepZ.value()]
+        )
         distance = self.bxD.value()
         amplitude = self.bxA.value()
         self.setScanWindow(scan_size, scan_start, step, distance, amplitude)
         self.update()
 
     def updateRotation(self):
-        '''Get rotation from input field and update'''
+        """Get rotation from input field and update"""
         a = self.bxRot.value() / 180 * np.pi
-        self.rot = np.array([
-            [np.cos(a), -np.sin(a), 0],
-            [np.sin(a),  np.cos(a), 0],
-            [        0,          0, 1]
-        ])
-        if self.verbose > 0: print('updateRotation', a, self.rot)
+        self.rot = np.array(
+            [[np.cos(a), -np.sin(a), 0], [np.sin(a), np.cos(a), 0], [0, 0, 1]]
+        )
+        if self.verbose > 0:
+            print("updateRotation", a, self.rot)
         self.update()
 
     def updateParams(self, preset_none=True):
-        '''Get parameter values from input fields and update'''
+        """Get parameter values from input fields and update"""
 
-        if self.xyzs is None: return
+        if self.xyzs is None:
+            return
 
         if preset_none:
             guiw.set_widget_value(self.slPreset, -1)
@@ -281,61 +341,77 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         A_pauli = self.bxV0.value()
         B_pauli = self.bxAlpha.value() if (self.rho_sample is not None) else 1.0
 
-        if multipole == 's':
+        if multipole == "s":
             Qs = [Q, 0, 0, 0]
             QZs = [0, 0, 0, 0]
-        elif multipole == 'pz':
+        elif multipole == "pz":
             Qs = [Q, -Q, 0, 0]
             QZs = [sigma, -sigma, 0, 0]
-        elif multipole == 'dz2':
-            Qs = [Q, -2*Q, Q, 0]
+        elif multipole == "dz2":
+            Qs = [Q, -2 * Q, Q, 0]
             QZs = [sigma, 0, -sigma, 0]
 
-        if self.verbose > 0: print('updateParams', Q, sigma, multipole, tipStiffness, tipR0,
-            use_point_charge, A_pauli, B_pauli, type(self.qs))
+        if self.verbose > 0:
+            print(
+                "updateParams",
+                Q,
+                sigma,
+                multipole,
+                tipStiffness,
+                tipR0,
+                use_point_charge,
+                A_pauli,
+                B_pauli,
+                type(self.qs),
+            )
 
         self.afmulator.iZPP = int(self.bxZPP.value())
-        if self.rho_sample is not None: # Use FDBM
+        if self.rho_sample is not None:  # Use FDBM
             if self.afmulator.B_pauli != B_pauli:
                 self.afmulator.setRho(self.rho_tip, B_pauli=B_pauli)
         else:
-            if self.rho_tip is None: # else we just keep the tip density loaded from file
+            if (
+                self.rho_tip is None
+            ):  # else we just keep the tip density loaded from file
                 if use_point_charge:
                     self.afmulator.setQs(Qs, QZs)
                     self.afmulator.setRho(None, sigma)
                 elif isinstance(self.qs, HartreePotential):
                     self.afmulator.setRho({multipole: Q}, sigma)
-        self.afmulator.scanner.stiffness = np.array(tipStiffness, dtype=np.float32) / -PPU.eVA_Nm
+        self.afmulator.scanner.stiffness = (
+            np.array(tipStiffness, dtype=np.float32) / -PPU.eVA_Nm
+        )
         self.afmulator.tipR0 = tipR0
         self.afmulator.A_pauli = A_pauli
 
         self.update()
 
     def setDfRange(self, df_range):
-        '''Set df range in input boxes'''
+        """Set df range in input boxes"""
         guiw.set_widget_value(self.bxDfMin, df_range[0])
         guiw.set_widget_value(self.bxDfMax, df_range[1])
 
     def dfRangeFromData(self):
-        '''Set colorbar df range from current df data'''
-        if self.df is None: return
+        """Set colorbar df range from current df data"""
+        if self.df is None:
+            return
         self.df_range = (self.df[:, :, -1].min(), self.df[:, :, -1].max())
         self.setDfRange(self.df_range)
 
     def updateDfRange(self):
-        '''Get df range from input field and update plot'''
+        """Get df range from input field and update plot"""
         self.fixed_df_range = True
-        self.df_range = (self.bxDfMin.value(),  self.bxDfMax.value())
+        self.df_range = (self.bxDfMin.value(), self.bxDfMax.value())
         self.updateDataView()
 
     def resetDfRange(self):
-        '''Reset df range to min-max values in current image and update plot'''
+        """Reset df range to min-max values in current image and update plot"""
         self.fixed_df_range = False
         self.dfRangeFromData()
         self.updateDataView()
 
     def updateDfColorbar(self):
-        '''Get colorbar state and update plot'''
+        """Get colorbar state and update plot"""
         if self.bxDfCbar.isChecked():
             self.bxDfMin.setDisabled(False)
             self.bxDfMax.setDisabled(False)
@@ -349,9 +425,10 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self.updateDataView()
 
     def setPBC(self, lvec, enabled):
-        '''Set periodic boundary condition lattice'''
+        """Set periodic boundary condition lattice"""
 
-        if self.verbose > 0: print('setPBC', lvec, enabled)
+        if self.verbose > 0:
+            print("setPBC", lvec, enabled)
 
         if enabled:
             self.sample_lvec = lvec
@@ -380,70 +457,97 @@ class ApplicationWindow(QtWidgets.QMainWindow):
 
         # Disable lattice vector boxes if PBC not enabled
         for bx in [
-            self.bxPBCAx, self.bxPBCAy, self.bxPBCAz,
-            self.bxPBCBx, self.bxPBCBy, self.bxPBCBz,
-            self.bxPBCCx, self.bxPBCCy, self.bxPBCCz
-            ]:
+            self.bxPBCAx,
+            self.bxPBCAy,
+            self.bxPBCAz,
+            self.bxPBCBx,
+            self.bxPBCBy,
+            self.bxPBCBz,
+            self.bxPBCCx,
+            self.bxPBCCy,
+            self.bxPBCCz,
+        ]:
             bx.setDisabled(not enabled)
 
     def updatePBC(self):
-        '''Get PBC lattice from from input fields and update'''
-        lvec = np.array([
-            [self.bxPBCAx.value(), self.bxPBCAy.value(), self.bxPBCAz.value()],
-            [self.bxPBCBx.value(), self.bxPBCBy.value(), self.bxPBCBz.value()],
-            [self.bxPBCCx.value(), self.bxPBCCy.value(), self.bxPBCCz.value()]
-        ])
+        """Get PBC lattice from from input fields and update"""
+        lvec = np.array(
+            [
+                [self.bxPBCAx.value(), self.bxPBCAy.value(), self.bxPBCAz.value()],
+                [self.bxPBCBx.value(), self.bxPBCBy.value(), self.bxPBCBz.value()],
+                [self.bxPBCCx.value(), self.bxPBCCy.value(), self.bxPBCCz.value()],
+            ]
+        )
         toggle = self.bxPBC.isChecked()
         self.setPBC(lvec, toggle)
         self.update()
 
     def applyPreset(self, update=True):
-        '''Get current preset, apply parameters, and update'''
+        """Get current preset, apply parameters, and update"""
         preset = Presets[self.slPreset.currentText()]
-        if 'Z' in preset: guiw.set_widget_value(self.bxZPP, preset['Z'])
-        if 'Q' in preset: guiw.set_widget_value(self.bxQ, preset['Q'])
-        if 'Sigma' in preset: guiw.set_widget_value(self.bxS, preset['Sigma'])
-        if 'K' in preset:
-            guiw.set_widget_value(self.bxKx, preset['K'][0])
-            guiw.set_widget_value(self.bxKy, preset['K'][1])
-            guiw.set_widget_value(self.bxKr, preset['K'][2])
-        if 'EqPos' in preset:
-            guiw.set_widget_value(self.bxP0x, preset['EqPos'][0])
-            guiw.set_widget_value(self.bxP0y, preset['EqPos'][1])
-            guiw.set_widget_value(self.bxP0r, preset['EqPos'][2])
-        if 'Multipole' in preset:
-            guiw.set_widget_value(self.slMultipole, self.slMultipole.findText(preset['Multipole']))
+        if "Z" in preset:
+            guiw.set_widget_value(self.bxZPP, preset["Z"])
+        if "Q" in preset:
+            guiw.set_widget_value(self.bxQ, preset["Q"])
+        if "Sigma" in preset:
+            guiw.set_widget_value(self.bxS, preset["Sigma"])
+        if "K" in preset:
+            guiw.set_widget_value(self.bxKx, preset["K"][0])
+            guiw.set_widget_value(self.bxKy, preset["K"][1])
+            guiw.set_widget_value(self.bxKr, preset["K"][2])
+        if "EqPos" in preset:
+            guiw.set_widget_value(self.bxP0x, preset["EqPos"][0])
+            guiw.set_widget_value(self.bxP0y, preset["EqPos"][1])
+            guiw.set_widget_value(self.bxP0r, preset["EqPos"][2])
+        if "Multipole" in preset:
+            guiw.set_widget_value(
+                self.slMultipole, self.slMultipole.findText(preset["Multipole"])
+            )
         if update:
             self.updateParams(preset_none=False)
 
     def update(self):
-        '''Run simulation, and show the result'''
-        if self.xyzs is None: return
-        if self.verbose > 1: t0 = time.perf_counter()
-        self.status_message('Running simulation...')
+        """Run simulation, and show the result"""
+        if self.xyzs is None:
+            return
+        if self.verbose > 1:
+            t0 = time.perf_counter()
+        self.status_message("Running simulation...")
         try:
-            self.df = self.afmulator(self.xyzs, self.Zs, self.qs, rho_sample=self.rho_sample, sample_lvec=self.sample_lvec, rot=self.rot)
+            self.df = self.afmulator(
+                self.xyzs,
+                self.Zs,
+                self.qs,
+                rho_sample=self.rho_sample,
+                sample_lvec=self.sample_lvec,
+                rot=self.rot,
+            )
         except Exception:
             traceback.print_exc()
-            guiw.show_warning(self, f'Error during simulation! Error message:\n{traceback.format_exc()}', 'Simulation error!')
-        if self.verbose > 1: print(f'AFMulator total time [s]: {time.perf_counter() - t0}')
-        self.status_message('Updating plot...')
+            guiw.show_warning(
+                self,
+                f"Error during simulation! Error message:\n{traceback.format_exc()}",
+                "Simulation error!",
+            )
+        if self.verbose > 1:
+            print(f"AFMulator total time [s]: {time.perf_counter() - t0}")
+        self.status_message("Updating plot...")
         self.updateDataView()
         if self.FFViewer.isVisible():
-            self.status_message('Updating Force field viewer...')
+            self.status_message("Updating Force field viewer...")
             self.FFViewer.updateFF()
             self.FFViewer.updateView()
-        self.status_message('Ready')
+        self.status_message("Ready")
 
     def loadInput(self, main_input, rho_sample=None, rho_tip=None, rho_tip_delta=None):
-        '''Load input file(s) and show the result
+        """Load input file(s) and show the result
 
         Arguments:
             main_input: str. Main input file containing xyz geometry or Hartree potential. xyz, POSCAR, in, xsf, or cube format.
             rho_sample: str. Optional sample electron density. xsf format.
             rho_tip: str. Optional tip electron density. xsf format.
             rho_tip_delta: str. Optional tip delta electron density. xsf format.
-        '''
+        """
 
         # If there are existing arrays in memory, release them
         if isinstance(self.qs, HartreePotential):
@@ -458,24 +562,25 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         # Load input file
         file_name = os.path.split(main_input)[1].lower()
         ext = os.path.splitext(file_name)[1]
-        if self.verbose > 0: print(f'loadInput: {main_input}, {file_name}, {ext}')
-        if file_name in ['poscar', 'contcar']:
+        if self.verbose > 0:
+            print(f"loadInput: {main_input}, {file_name}, {ext}")
+        if file_name in ["poscar", "contcar"]:
             xyzs, Zs, lvec = io.loadPOSCAR(main_input)
             qs = np.zeros(len(Zs))
             lvec = lvec[1:]
-        elif ext == '.in':
+        elif ext == ".in":
             xyzs, Zs, lvec = io.loadGeometryIN(main_input)
             qs = np.zeros(len(Zs))
             lvec = lvec[1:] if len(lvec) > 0 else None
-        elif ext in ['.xsf', '.cube']:
+        elif ext in [".xsf", ".cube"]:
             # Scale=-1.0 for correct units of potential (V) instead of energy (eV)
             qs, xyzs, Zs = HartreePotential.from_file(main_input, scale=-1.0)
             lvec = qs.lvec[1:]
-        elif ext == '.xyz':
-            xyzs, Zs, qs, _ = io.loadXYZ(main_input)
-            lvec = None
+        elif ext == ".xyz":
+            xyzs, Zs, qs, comment = io.loadXYZ(main_input)
+            lvec = io.parseLvecASE(comment)
         else:
-            raise ValueError(f'Unsupported file format for file `{main_input}`.')
+            raise ValueError(f"Unsupported file format for file `{main_input}`.")
 
         # Load auxiliary files (if any)
         if rho_sample:
@@ -487,11 +592,15 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         else:
             self.rho_tip = None
         if rho_tip_delta:
-            self.rho_tip_delta, self.xyzs_tip, self.Zs_tip = TipDensity.from_file(rho_tip_delta)
+            self.rho_tip_delta, self.xyzs_tip, self.Zs_tip = TipDensity.from_file(
+                rho_tip_delta
+            )
         else:
             self.rho_tip_delta = None
             if self.rho_tip is not None:
-                self.rho_tip_delta = self.rho_tip.subCores(self.xyzs_tip, self.Zs_tip, Rcore=0.7)
+                self.rho_tip_delta = self.rho_tip.subCores(
+                    self.xyzs_tip, self.Zs_tip, Rcore=0.7
+                )
                 if self.rho_sample is None:
                     # Not FDBM, no need for full tip electron density
                     self.rho_tip.release()
@@ -514,23 +623,29 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self.df_points = []
 
         if self.rho_tip is not None:
-
             # Pick the probe particle type from the lowest atom in the tip density geometry
             lowest_ind = np.argmin(self.xyzs_tip[:, 2])
             Zpp = int(self.Zs_tip[lowest_ind])
 
-            if Zpp != 0: # Zs_tip can be just [0] if the file does not contain a geometry
-
+            if (
+                Zpp != 0
+            ):  # Zs_tip can be just [0] if the file does not contain a geometry
                 self.afmulator.iZPP = Zpp
 
-                for name, preset in Presets.items(): # Try to find a matching preset
-                    if preset['Z'] == Zpp:
-                        if self.verbose > 0: print(f'Setting preset `{name}` based on tip density file geometry.')
+                for name, preset in Presets.items():  # Try to find a matching preset
+                    if preset["Z"] == Zpp:
+                        if self.verbose > 0:
+                            print(
+                                f"Setting preset `{name}` based on tip density file geometry."
+                            )
                         self.slPreset.setCurrentText(name)
                         self.applyPreset(update=False)
                         break
                 else:
-                    if self.verbose > 0: print(f'Setting probe particle type `{Zpp}` based on tip density file geometry.')
+                    if self.verbose > 0:
+                        print(
+                            f"Setting probe particle type `{Zpp}` based on tip density file geometry."
+                        )
                     guiw.set_widget_value(self.bxZPP, Zpp)
 
         self.bxPC.blockSignals(True)
@@ -569,29 +684,33 @@ class ApplicationWindow(QtWidgets.QMainWindow):
 
         # Set current file path to window title
         self.file_path = main_input
-        if len(main_input) > 80: main_input = f'...{main_input[-80:]}'
-        self.setWindowTitle(f'{main_input} - Probe Particle Model')
+        if len(main_input) > 80:
+            main_input = f"...{main_input[-80:]}"
+        self.setWindowTitle(f"{main_input} - Probe Particle Model")
 
     def _toggleTipControls(self, enabled):
         for widget in [self.slMultipole, self.bxQ, self.bxS, self.bxPC]:
             widget.setDisabled(not enabled)
 
     def createGeomEditor(self):
-        '''Create a new geometry editor. Replace old one if it exists.'''
+        """Create a new geometry editor. Replace old one if it exists."""
         if self.geomEditor:
             self.geomEditor.deleteLater()
             self.geomEditor = None
         enable_qs = not isinstance(self.qs, HartreePotential)
-        self.geomEditor = guiw.GeomEditor(len(self.xyzs), enable_qs=enable_qs, parent=self,
-            title="Geometry Editor")
+        self.geomEditor = guiw.GeomEditor(
+            len(self.xyzs), enable_qs=enable_qs, parent=self, title="Geometry Editor"
+        )
 
     def showGeomEditor(self):
-        if self.xyzs is None: return
+        if self.xyzs is None:
+            return
         self.geomEditor.updateValues()
         self.geomEditor.show()
 
     def showFFViewer(self):
-        if self.xyzs is None: return
+        if self.xyzs is None:
+            return
         self.FFViewer.updateFF()
         self.FFViewer.updateView()
         self.FFViewer.show()
@@ -601,67 +720,88 @@ class ApplicationWindow(QtWidgets.QMainWindow):
             from ase import Atoms
             from ase.visualize import view
         except ModuleNotFoundError:
-            print('No ase installation detected. Cannot show molecule geometry.')
-            if self.verbose > 1: traceback.print_exc()
+            print("No ase installation detected. Cannot show molecule geometry.")
+            if self.verbose > 1:
+                traceback.print_exc()
             return
-        atoms = Atoms(positions=self.xyzs, numbers=self.Zs, cell=self.sample_lvec, pbc=self.afmulator.npbc)
+        atoms = Atoms(
+            positions=self.xyzs,
+            numbers=self.Zs,
+            cell=self.sample_lvec,
+            pbc=self.afmulator.npbc,
+        )
         view(atoms)
 
     def openFile(self):
         self.openFileDialog.exec()
         file_paths = self.openFileDialog.paths
-        if self.verbose > 0: print('openFile', file_paths)
-        if file_paths is None: return
-        self.status_message('Opening file(s)...')
+        if self.verbose > 0:
+            print("openFile", file_paths)
+        if file_paths is None:
+            return
+        self.status_message("Opening file(s)...")
         try:
             self.loadInput(**file_paths)
         except:
             traceback.print_exc()
-            guiw.show_warning(self, f'Ran into an error while opening a file! Error message:\n{traceback.format_exc()}', 'File open error!')
-            self.status_message('Ready')
+            guiw.show_warning(
+                self,
+                f"Ran into an error while opening a file! Error message:\n{traceback.format_exc()}",
+                "File open error!",
+            )
+            self.status_message("Ready")
 
     def saveFig(self):
-        if self.xyzs is None: return
-        default_path = os.path.join(os.path.split(self.file_path)[0], 'df.png')
-        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save image", default_path,
-            "Image files (*.png)")
+        if self.xyzs is None:
+            return
+        default_path = os.path.join(os.path.split(self.file_path)[0], "df.png")
+        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save image", default_path, "Image files (*.png)"
+        )
         if fileName:
-            self.status_message('Saving image...')
-            fileName = guiw.correct_ext( fileName, ".png" )
-            if self.verbose > 0: print("Saving image to :", fileName)
-            self.figCan.fig.savefig( fileName,bbox_inches='tight')
-            self.status_message('Ready')
+            self.status_message("Saving image...")
+            fileName = guiw.correct_ext(fileName, ".png")
+            if self.verbose > 0:
+                print("Saving image to :", fileName)
+            self.figCan.fig.savefig(fileName, bbox_inches="tight")
+            self.status_message("Ready")
 
     def saveDataW(self):
-        if self.df is None: return
-        default_path = os.path.join(os.path.split(self.file_path)[0], 'df.xsf')
-        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save df", default_path,
-            "XCrySDen files (*.xsf);; WSxM files (*.xyz)")
-        if not fileName: return
-        ext = os.path.splitext(fileName)[1]
-        if ext not in ['.xyz', '.xsf']:
-            self.status_message('Unsupported file type in df save file path')
-            print(f'Unsupported file type in df save file path `{fileName}`')
+        if self.df is None:
             return
-        self.status_message('Saving data...')
-        if self.verbose > 0: print(f'Saving df data to {fileName}...')
-        if ext == '.xyz':
+        default_path = os.path.join(os.path.split(self.file_path)[0], "df.xsf")
+        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save df", default_path, "XCrySDen files (*.xsf);; WSxM files (*.xyz)"
+        )
+        if not fileName:
+            return
+        ext = os.path.splitext(fileName)[1]
+        if ext not in [".xyz", ".xsf"]:
+            self.status_message("Unsupported file type in df save file path")
+            print(f"Unsupported file type in df save file path `{fileName}`")
+            return
+        self.status_message("Saving data...")
+        if self.verbose > 0:
+            print(f"Saving df data to {fileName}...")
+        if ext == ".xyz":
             data = self.df[:, :, -1].T
             xs = np.linspace(0, self.bxSSx.value(), data.shape[1], endpoint=False)
             ys = np.linspace(0, self.bxSSy.value(), data.shape[0], endpoint=False)
-            Xs, Ys = np.meshgrid(xs,ys)
+            Xs, Ys = np.meshgrid(xs, ys)
             io.saveWSxM_2D(fileName, data, Xs, Ys)
-        elif ext == '.xsf':
+        elif ext == ".xsf":
             data = self.df.transpose(2, 1, 0)[::-1]
             sw = self.afmulator.scan_window
             size = np.array(sw[1]) - np.array(sw[0])
             size[2] -= self.afmulator.amplitude - self.bxStepZ.value()
-            lvecScan = np.array([
-                [sw[0][0], sw[0][1], sw[0][2] - self.bxP0r.value()],
-                [size[0],       0,       0],
-                [      0, size[1],       0],
-                [      0,       0, size[2]],
-            ])
+            lvecScan = np.array(
+                [
+                    [sw[0][0], sw[0][1], sw[0][2] - self.bxP0r.value()],
+                    [size[0], 0, 0],
+                    [0, size[1], 0],
+                    [0, 0, size[2]],
+                ]
+            )
             if self.sample_lvec is not None:
                 lvec = np.append([[0, 0, 0]], self.sample_lvec, axis=0)
                 atomstring = io.primcoords2Xsf(self.Zs, self.xyzs.T, lvec)
@@ -669,19 +809,19 @@ class ApplicationWindow(QtWidgets.QMainWindow):
                 atomstring = io.XSF_HEAD_DEFAULT
             io.saveXSF(fileName, data, lvecScan, head=atomstring, verbose=0)
         else:
-            raise RuntimeError('This should not happen. Missing file format check?')
-        if self.verbose > 0: print("Done saving df data.")
-        self.status_message('Ready')
+            raise RuntimeError("This should not happen. Missing file format check?")
+        if self.verbose > 0:
+            print("Done saving df data.")
+        self.status_message("Ready")
 
     def updateDataView(self):
-
-        if self.df is None: return
+        if self.df is None:
+            return
 
         t1 = time.perf_counter()
 
         # Plot df
         try:
-
             data = self.df.transpose(2, 1, 0)
 
             # Colorbar
@@ -691,33 +831,46 @@ class ApplicationWindow(QtWidgets.QMainWindow):
 
             # Title
             z = self.afmulator.scan_window[0][2] + self.afmulator.amplitude / 2
-            title = f'z = {z:.2f}Å'
+            title = f"z = {z:.2f}Å"
             if not isinstance(self.qs, HartreePotential) and np.allclose(self.qs, 0):
-                title += ' (No electrostatics)'
+                title += " (No electrostatics)"
 
             # xy limits
             sw = self.afmulator.scan_window
             extent = (sw[0][0], sw[1][0], sw[0][1], sw[1][1])
 
             # Plot
-            self.figCan.plotSlice(data, -1, title=title, points=self.df_points, cbar_range=cbar_range,
-                extent=extent)
+            self.figCan.plotSlice(
+                data,
+                -1,
+                title=title,
+                points=self.df_points,
+                cbar_range=cbar_range,
+                extent=extent,
+            )
 
         except Exception:
             print(f"Failed to plot df slice.\n{traceback.format_exc()}")
-            guiw.show_warning(self, f'Ran into an error while plotting! Error message:\n{traceback.format_exc()}', 'Plot error!')
+            guiw.show_warning(
+                self,
+                f"Ran into an error while plotting! Error message:\n{traceback.format_exc()}",
+                "Plot error!",
+            )
 
-        if self.verbose > 1: print(f"plotSlice time {time.perf_counter() - t1:.5f} [s]")
+        if self.verbose > 1:
+            print(f"plotSlice time {time.perf_counter() - t1:.5f} [s]")
 
     def clickImshow(self, x, y):
-        if self.df is None: return
+        if self.df is None:
+            return
 
         # Find closest index corresponding to x and y coordinates
         x_min, y_min = self.afmulator.scan_window[0][:2]
         x_step, y_step = self.bxStepX.value(), self.bxStepY.value()
         ix = int(round((x - x_min) / x_step))
         iy = int(round((y - y_min) / y_step))
-        if self.verbose > 0: print('clickImshow', ix, iy, x, y)
+        if self.verbose > 0:
+            print("clickImshow", ix, iy, x, y)
 
         # Remember coordinates in case scan_start changes
         self.df_points.append((x, y))
@@ -729,26 +882,26 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         zs = np.linspace(z_max, z_min, df_steps)
         ys = self.df[ix, iy, :]
         self.figCurv.show()
-        self.figCurv.figCan.plotDatalines(zs, ys, f'{x:.02f}, {y:.02f}')
+        self.figCurv.figCan.plotDatalines(zs, ys, f"{x:.02f}, {y:.02f}")
 
     def clearPoints(self):
         self.df_points = []
         self.updateDataView()
 
     def zoomTowards(self, x, y, zoom_direction):
-
-        if self.verbose > 0: print('zoomTowards', x, y, zoom_direction)
+        if self.verbose > 0:
+            print("zoomTowards", x, y, zoom_direction)
 
         scan_size = np.array([self.bxSSx.value(), self.bxSSy.value()])
         scan_start = np.array([self.bxSCx.value(), self.bxSCy.value()])
         frac_coord = (np.array([x, y]) - scan_start) / scan_size
         offset = self.zoom_step * frac_coord
 
-        if zoom_direction == 'in':
+        if zoom_direction == "in":
             if scan_size[0] > 1.0 and scan_size[1] > 1.0:
                 scan_size -= self.zoom_step
                 scan_start += offset
-        elif zoom_direction == 'out':
+        elif zoom_direction == "out":
             scan_size += self.zoom_step
             scan_start -= offset
 
@@ -760,34 +913,40 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self.updateScanWindow()
 
     def saveParams(self):
-        '''
+        """
         Save all current parameters to a params.ini file. Bring up a file dialog to decide
         the file location.
-        '''
-        if hasattr(self, 'file_path'):
-            default_path = os.path.join(os.path.split(self.file_path)[0], 'params.ini')
+        """
+        if hasattr(self, "file_path"):
+            default_path = os.path.join(os.path.split(self.file_path)[0], "params.ini")
         else:
-            default_path = 'params.ini'
-        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save parameters", default_path, "(*.ini)")
-        if not fileName: return
-        if self.verbose > 0: print(f'Saving current parameters to `{fileName}`')
+            default_path = "params.ini"
+        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save parameters", default_path, "(*.ini)"
+        )
+        if not fileName:
+            return
+        if self.verbose > 0:
+            print(f"Saving current parameters to `{fileName}`")
         self.afmulator.save_params(fileName)
-        self.status_message('Saved parameters')
+        self.status_message("Saved parameters")
 
     def loadParams(self):
-        '''
+        """
         Load all current parameters from a params.ini file. Bring up a file dialog to decide
         the file location.
-        '''
+        """
 
-        if hasattr(self, 'file_path'):
-            default_path = os.path.join(os.path.split(self.file_path)[0], 'params.ini')
+        if hasattr(self, "file_path"):
+            default_path = os.path.join(os.path.split(self.file_path)[0], "params.ini")
         else:
-            default_path = 'params.ini'
+            default_path = "params.ini"
         default_path = default_path if os.path.exists(default_path) else None
-        file_path, _ = QtWidgets.QFileDialog.getOpenFileName(self, 'Open parameters file', default_path,
-            '(*.ini)')
-        if not file_path: return
+        file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Open parameters file", default_path, "(*.ini)"
+        )
+        if not file_path:
+            return
         self.afmulator.load_params(file_path)
 
         # Set preset to nothing
@@ -800,27 +959,35 @@ class ApplicationWindow(QtWidgets.QMainWindow):
             guiw.set_widget_value(self.slMultipole, tip)
             guiw.set_widget_value(self.bxQ, self.afmulator._rho[tip])
             guiw.set_widget_value(self.bxS, self.afmulator.sigma)
-        guiw.set_widget_value(self.bxKx, self.afmulator.scanner.stiffness[0] * -PPU.eVA_Nm)
-        guiw.set_widget_value(self.bxKy, self.afmulator.scanner.stiffness[1] * -PPU.eVA_Nm)
-        guiw.set_widget_value(self.bxKr, self.afmulator.scanner.stiffness[3] * -PPU.eVA_Nm)
+        guiw.set_widget_value(
+            self.bxKx, self.afmulator.scanner.stiffness[0] * -PPU.eVA_Nm
+        )
+        guiw.set_widget_value(
+            self.bxKy, self.afmulator.scanner.stiffness[1] * -PPU.eVA_Nm
+        )
+        guiw.set_widget_value(
+            self.bxKr, self.afmulator.scanner.stiffness[3] * -PPU.eVA_Nm
+        )
         guiw.set_widget_value(self.bxP0x, self.afmulator.tipR0[0])
         guiw.set_widget_value(self.bxP0y, self.afmulator.tipR0[1])
         guiw.set_widget_value(self.bxP0r, self.afmulator.tipR0[2])
-        if self.rho_sample is not None: # Using FDBM
+        if self.rho_sample is not None:  # Using FDBM
             guiw.set_widget_value(self.bxV0, self.afmulator.A_pauli)
             guiw.set_widget_value(self.bxAlpha, self.afmulator.B_pauli)
         else:
-            self.afmulator.setBPauli(B_pauli=1.0) # Not using the FDBM so make sure the tip density is not being raised to the power
+            self.afmulator.setBPauli(
+                B_pauli=1.0
+            )  # Not using the FDBM so make sure the tip density is not being raised to the power
 
         # Set scan settings
         scan_size = (
             self.afmulator.scan_window[1][0] - self.afmulator.scan_window[0][0],
-            self.afmulator.scan_window[1][1] - self.afmulator.scan_window[0][1]
+            self.afmulator.scan_window[1][1] - self.afmulator.scan_window[0][1],
         )
         scan_step = (
             (scan_size[0]) / (self.afmulator.scan_dim[0] - 1),
             (scan_size[1]) / (self.afmulator.scan_dim[1] - 1),
-            self.afmulator.dz
+            self.afmulator.dz,
         )
         guiw.set_widget_value(self.bxStepX, scan_step[0])
         guiw.set_widget_value(self.bxStepY, scan_step[1])
@@ -830,308 +997,488 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         guiw.set_widget_value(self.bxSCx, self.afmulator.scan_window[0][0])
         guiw.set_widget_value(self.bxSCy, self.afmulator.scan_window[0][1])
         if self.xyzs is not None:
-            d = self.afmulator.scan_window[0][2] + self.afmulator.amplitude / 2 - self.xyzs[:, 2].max()
+            d = (
+                self.afmulator.scan_window[0][2]
+                + self.afmulator.amplitude / 2
+                - self.xyzs[:, 2].max()
+            )
             guiw.set_widget_value(self.bxD, d)
         guiw.set_widget_value(self.bxA, self.afmulator.amplitude)
 
         # Set PBC settings
-        guiw.set_widget_value(self.bxPBCz, False) # The CPU code actually never uses periodic copies in the z direction
+        guiw.set_widget_value(
+            self.bxPBCz, False
+        )  # The CPU code actually never uses periodic copies in the z direction
         if isinstance(self.qs, HartreePotential):
             # To be consistent with the CPU scripts, we should always prioritize the sample lattice vectors
             # from the .xsf/.cube files
             self.afmulator.sample_lvec = self.qs.lvec[1:]
-        self.setPBC(self.afmulator.sample_lvec, enabled=not (np.array(self.afmulator.npbc) == 0).all())
+        self.setPBC(
+            self.afmulator.sample_lvec,
+            enabled=not (np.array(self.afmulator.npbc) == 0).all(),
+        )
 
         # Set df settings
         guiw.set_widget_value(self.bxCant_K, self.afmulator.kCantilever / 1000)
         guiw.set_widget_value(self.bxCant_f0, self.afmulator.f0Cantilever / 1000)
-        guiw.set_widget_value(self.bxdfst, self.afmulator.scan_dim[2] - self.afmulator.df_steps + 1)
+        guiw.set_widget_value(
+            self.bxdfst, self.afmulator.scan_dim[2] - self.afmulator.df_steps + 1
+        )
 
         self.update()
 
     def _create_probe_settings_ui(self):
-
         # Title
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("Probe settings"); lb.setAlignment(QtCore.Qt.AlignCenter)
-        font = lb.font(); font.setPointSize(12); lb.setFont(font); lb.setMaximumHeight(50)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("Probe settings")
+        lb.setAlignment(QtCore.Qt.AlignCenter)
+        font = lb.font()
+        font.setPointSize(12)
+        lb.setFont(font)
+        lb.setMaximumHeight(50)
         vb.addWidget(lb)
 
         # Presets
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("Preset"); lb.setToolTip(TTips['Preset']); vb.addWidget(lb, 1)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("Preset")
+        lb.setToolTip(TTips["Preset"])
+        vb.addWidget(lb, 1)
         self.slPreset = QtWidgets.QComboBox()
         self.slPreset.addItems(Presets.keys())
         self.slPreset.currentIndexChanged.connect(self.applyPreset)
-        self.slPreset.setToolTip(TTips['Preset'])
+        self.slPreset.setToolTip(TTips["Preset"])
         vb.addWidget(self.slPreset, 6)
 
         # Tip type
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("Z"); lb.setToolTip(TTips['Z']); vb.addWidget(lb, 1)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("Z")
+        lb.setToolTip(TTips["Z"])
+        vb.addWidget(lb, 1)
         self.bxZPP = QtWidgets.QSpinBox()
-        self.bxZPP.setRange(0, 200); self.bxZPP.setValue(8)
+        self.bxZPP.setRange(0, 200)
+        self.bxZPP.setValue(8)
         self.bxZPP.valueChanged.connect(self.updateParams)
-        self.bxZPP.setToolTip(TTips['Z'])
+        self.bxZPP.setToolTip(TTips["Z"])
         self.bxZPP.setKeyboardTracking(False)
         vb.addWidget(self.bxZPP, 2)
 
         # Charge multipole
-        lb = QtWidgets.QLabel("Multipole"); lb.setToolTip(TTips['Multipole']); vb.addWidget(lb, 2)
+        lb = QtWidgets.QLabel("Multipole")
+        lb.setToolTip(TTips["Multipole"])
+        vb.addWidget(lb, 2)
         self.slMultipole = QtWidgets.QComboBox()
         self.slMultipole.addItems([m.name for m in Multipoles])
         self.slMultipole.setCurrentIndex(self.slMultipole.findText(Multipoles.dz2.name))
         self.slMultipole.currentIndexChanged.connect(self.updateParams)
-        self.slMultipole.setToolTip(TTips['Multipole'])
+        self.slMultipole.setToolTip(TTips["Multipole"])
         vb.addWidget(self.slMultipole, 2)
 
         # Charge magnitude and sigma
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("Q [e]"); lb.setToolTip(TTips['Q']); vb.addWidget(lb, 1)
-        self.bxQ = _spin_box((-2.0, 2.0), -0.1, 0.05, self.updateParams, TTips['Q'], vb, 2)
-        lb = QtWidgets.QLabel("Sigma [Å]"); lb.setToolTip(TTips['Sigma']); vb.addWidget(lb, 2)
-        self.bxS = _spin_box((0.0, 2.0), 0.71, 0.05, self.updateParams, TTips['Sigma'], vb, 2)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("Q [e]")
+        lb.setToolTip(TTips["Q"])
+        vb.addWidget(lb, 1)
+        self.bxQ = _spin_box(
+            (-2.0, 2.0), -0.1, 0.05, self.updateParams, TTips["Q"], vb, 2
+        )
+        lb = QtWidgets.QLabel("Sigma [Å]")
+        lb.setToolTip(TTips["Sigma"])
+        vb.addWidget(lb, 2)
+        self.bxS = _spin_box(
+            (0.0, 2.0), 0.71, 0.05, self.updateParams, TTips["Sigma"], vb, 2
+        )
 
         # Point charge toggle
-        lb = QtWidgets.QLabel("Point Charges"); lb.setToolTip(TTips['point_charge']); vb.addWidget(lb)
+        lb = QtWidgets.QLabel("Point Charges")
+        lb.setToolTip(TTips["point_charge"])
+        vb.addWidget(lb)
         self.bxPC = QtWidgets.QCheckBox()
         self.bxPC.setChecked(True)
         self.bxPC.toggled.connect(self.updateParams)
-        self.bxPC.setToolTip(TTips['point_charge'])
+        self.bxPC.setToolTip(TTips["point_charge"])
         vb.addWidget(self.bxPC)
 
         # Left-right divide for labels and input boxes
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        bxl = QtWidgets.QVBoxLayout(); vb.addLayout(bxl, 1)
-        bxr = QtWidgets.QVBoxLayout(); vb.addLayout(bxr, 3)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        bxl = QtWidgets.QVBoxLayout()
+        vb.addLayout(bxl, 1)
+        bxr = QtWidgets.QVBoxLayout()
+        vb.addLayout(bxr, 3)
 
         # Spring constants
-        lb = QtWidgets.QLabel("K (x,y,R) [N/m]"); lb.setToolTip(TTips['K']); bxl.addWidget(lb)
-        vb = QtWidgets.QHBoxLayout(); bxr.addLayout(vb)
-        self.bxKx = _spin_box((0.0,   2.0),  0.25, 0.05, self.updateParams, TTips['K'], vb)
-        self.bxKy = _spin_box((0.0,   2.0),  0.25, 0.05, self.updateParams, TTips['K'], vb)
-        self.bxKr = _spin_box((0.0, 100.0), 30.00, 5.00, self.updateParams, TTips['K'], vb)
+        lb = QtWidgets.QLabel("K (x,y,R) [N/m]")
+        lb.setToolTip(TTips["K"])
+        bxl.addWidget(lb)
+        vb = QtWidgets.QHBoxLayout()
+        bxr.addLayout(vb)
+        self.bxKx = _spin_box((0.0, 2.0), 0.25, 0.05, self.updateParams, TTips["K"], vb)
+        self.bxKy = _spin_box((0.0, 2.0), 0.25, 0.05, self.updateParams, TTips["K"], vb)
+        self.bxKr = _spin_box(
+            (0.0, 100.0), 30.00, 5.00, self.updateParams, TTips["K"], vb
+        )
 
         # Probe equilibrium position
-        lb = QtWidgets.QLabel("Eq. pos (x,y,R) [Å]"); lb.setToolTip(TTips['EqPos']); bxl.addWidget(lb)
-        vb = QtWidgets.QHBoxLayout(); bxr.addLayout(vb)
-        self.bxP0x = _spin_box((-2.0,  2.0), 0.0, 0.1, self.updateParams, TTips['EqPos'], vb)
-        self.bxP0y = _spin_box((-2.0,  2.0), 0.0, 0.1, self.updateParams, TTips['EqPos'], vb)
-        self.bxP0r = _spin_box(( 0.0, 10.0), 3.0, 0.1, self.updateParams, TTips['EqPos'], vb)
+        lb = QtWidgets.QLabel("Eq. pos (x,y,R) [Å]")
+        lb.setToolTip(TTips["EqPos"])
+        bxl.addWidget(lb)
+        vb = QtWidgets.QHBoxLayout()
+        bxr.addLayout(vb)
+        self.bxP0x = _spin_box(
+            (-2.0, 2.0), 0.0, 0.1, self.updateParams, TTips["EqPos"], vb
+        )
+        self.bxP0y = _spin_box(
+            (-2.0, 2.0), 0.0, 0.1, self.updateParams, TTips["EqPos"], vb
+        )
+        self.bxP0r = _spin_box(
+            (0.0, 10.0), 3.0, 0.1, self.updateParams, TTips["EqPos"], vb
+        )
 
         # FDBM settings
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("FDBM settings:"); vb.addWidget(lb)
-        l = QtWidgets.QHBoxLayout(); vb.addLayout(l)
-        lb = QtWidgets.QLabel("V0"); lb.setToolTip(TTips['fdbm_V0']); l.addWidget(lb)
-        self.bxV0 = _spin_box((0.1, 999), 18.0, 1.0, self.updateParams, TTips['fdbm_V0'], l)
-        lb = QtWidgets.QLabel("alpha"); lb.setToolTip(TTips['fdbm_alpha']); l.addWidget(lb)
-        self.bxAlpha = _spin_box((0.1, 9.9), 1.0, 0.02, self.updateParams, TTips['fdbm_alpha'], l)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("FDBM settings:")
+        vb.addWidget(lb)
+        l = QtWidgets.QHBoxLayout()
+        vb.addLayout(l)
+        lb = QtWidgets.QLabel("V0")
+        lb.setToolTip(TTips["fdbm_V0"])
+        l.addWidget(lb)
+        self.bxV0 = _spin_box(
+            (0.1, 999), 18.0, 1.0, self.updateParams, TTips["fdbm_V0"], l
+        )
+        lb = QtWidgets.QLabel("alpha")
+        lb.setToolTip(TTips["fdbm_alpha"])
+        l.addWidget(lb)
+        self.bxAlpha = _spin_box(
+            (0.1, 9.9), 1.0, 0.02, self.updateParams, TTips["fdbm_alpha"], l
+        )
 
     def _create_scan_settings_ui(self):
-
         # Title
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("Scan settings"); lb.setAlignment(QtCore.Qt.AlignCenter)
-        font = lb.font(); font.setPointSize(12); lb.setFont(font); lb.setMaximumHeight(50)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("Scan settings")
+        lb.setAlignment(QtCore.Qt.AlignCenter)
+        font = lb.font()
+        font.setPointSize(12)
+        lb.setFont(font)
+        lb.setMaximumHeight(50)
         vb.addWidget(lb)
 
         # Left-right divide for labels and input boxes
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        bxl = QtWidgets.QVBoxLayout(); vb.addLayout(bxl, 1)
-        bxr = QtWidgets.QVBoxLayout(); vb.addLayout(bxr, 3)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        bxl = QtWidgets.QVBoxLayout()
+        vb.addLayout(bxl, 1)
+        bxr = QtWidgets.QVBoxLayout()
+        vb.addLayout(bxr, 3)
 
         # Scan step
-        lb = QtWidgets.QLabel("Scan step (x,y,z)[Å]"); lb.setToolTip(TTips['ScanStep']); bxl.addWidget(lb)
-        vb = QtWidgets.QHBoxLayout(); bxr.addLayout(vb)
-        self.bxStepX = _spin_box((0.02, 0.5), 0.1, 0.02, self.updateScanWindow, TTips['ScanStep'], vb)
-        self.bxStepY = _spin_box((0.02, 0.5), 0.1, 0.02, self.updateScanWindow, TTips['ScanStep'], vb)
-        self.bxStepZ = _spin_box((0.02, 0.5), 0.1, 0.02, self.updateScanWindow, TTips['ScanStep'], vb)
+        lb = QtWidgets.QLabel("Scan step (x,y,z)[Å]")
+        lb.setToolTip(TTips["ScanStep"])
+        bxl.addWidget(lb)
+        vb = QtWidgets.QHBoxLayout()
+        bxr.addLayout(vb)
+        self.bxStepX = _spin_box(
+            (0.02, 0.5), 0.1, 0.02, self.updateScanWindow, TTips["ScanStep"], vb
+        )
+        self.bxStepY = _spin_box(
+            (0.02, 0.5), 0.1, 0.02, self.updateScanWindow, TTips["ScanStep"], vb
+        )
+        self.bxStepZ = _spin_box(
+            (0.02, 0.5), 0.1, 0.02, self.updateScanWindow, TTips["ScanStep"], vb
+        )
 
         # Scan size
-        lb = QtWidgets.QLabel("Scan size (x,y)[Å]"); lb.setToolTip(TTips['ScanSize']); bxl.addWidget(lb)
-        vb = QtWidgets.QHBoxLayout(); bxr.addLayout(vb)
-        self.bxSSx = _spin_box((1, 100), 16, 0.1, self.updateScanWindow, TTips['ScanSize'], vb)
-        self.bxSSy = _spin_box((1, 100), 16, 0.1, self.updateScanWindow, TTips['ScanSize'], vb)
+        lb = QtWidgets.QLabel("Scan size (x,y)[Å]")
+        lb.setToolTip(TTips["ScanSize"])
+        bxl.addWidget(lb)
+        vb = QtWidgets.QHBoxLayout()
+        bxr.addLayout(vb)
+        self.bxSSx = _spin_box(
+            (1, 100), 16, 0.1, self.updateScanWindow, TTips["ScanSize"], vb
+        )
+        self.bxSSy = _spin_box(
+            (1, 100), 16, 0.1, self.updateScanWindow, TTips["ScanSize"], vb
+        )
 
         # Scan start
-        lb = QtWidgets.QLabel("Scan start (x,y)[Å]"); lb.setToolTip(TTips['ScanStart']); bxl.addWidget(lb)
-        vb = QtWidgets.QHBoxLayout(); bxr.addLayout(vb)
-        self.bxSCx = _spin_box((-100, 100), 0, 0.1, self.updateScanWindow, TTips['ScanStart'], vb)
-        self.bxSCy = _spin_box((-100, 100), 0, 0.1, self.updateScanWindow, TTips['ScanStart'], vb)
+        lb = QtWidgets.QLabel("Scan start (x,y)[Å]")
+        lb.setToolTip(TTips["ScanStart"])
+        bxl.addWidget(lb)
+        vb = QtWidgets.QHBoxLayout()
+        bxr.addLayout(vb)
+        self.bxSCx = _spin_box(
+            (-100, 100), 0, 0.1, self.updateScanWindow, TTips["ScanStart"], vb
+        )
+        self.bxSCy = _spin_box(
+            (-100, 100), 0, 0.1, self.updateScanWindow, TTips["ScanStart"], vb
+        )
 
         # Distance, amplitude, rotation
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("Distance [Å]"); lb.setToolTip(TTips['Distance']); vb.addWidget(lb)
-        self.bxD = _spin_box((-1000, 1000), 6.5, 0.1, self.updateScanWindow, TTips['Distance'], vb)
-        lb = QtWidgets.QLabel("Amplitude [Å]"); lb.setToolTip(TTips['Amplitude']); vb.addWidget(lb)
-        self.bxA = _spin_box((0.0, 100), 1.0, 0.1, self.updateScanWindow, TTips['Amplitude'], vb)
-        lb = QtWidgets.QLabel("Rotation"); lb.setToolTip(TTips['Rotation']); vb.addWidget(lb)
-        self.bxRot = _spin_box((-360.0, 360.0), 0.0, 5.0, self.updateRotation, TTips['Rotation'], vb)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("Distance [Å]")
+        lb.setToolTip(TTips["Distance"])
+        vb.addWidget(lb)
+        self.bxD = _spin_box(
+            (-1000, 1000), 6.5, 0.1, self.updateScanWindow, TTips["Distance"], vb
+        )
+        lb = QtWidgets.QLabel("Amplitude [Å]")
+        lb.setToolTip(TTips["Amplitude"])
+        vb.addWidget(lb)
+        self.bxA = _spin_box(
+            (0.0, 100), 1.0, 0.1, self.updateScanWindow, TTips["Amplitude"], vb
+        )
+        lb = QtWidgets.QLabel("Rotation")
+        lb.setToolTip(TTips["Rotation"])
+        vb.addWidget(lb)
+        self.bxRot = _spin_box(
+            (-360.0, 360.0), 0.0, 5.0, self.updateRotation, TTips["Rotation"], vb
+        )
 
     def _create_pbc_settings_ui(self):
-
         # Title
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("Periodic Boundaries"); lb.setAlignment(QtCore.Qt.AlignCenter)
-        font = lb.font(); font.setPointSize(12); lb.setFont(font); lb.setMaximumHeight(50)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("Periodic Boundaries")
+        lb.setAlignment(QtCore.Qt.AlignCenter)
+        font = lb.font()
+        font.setPointSize(12)
+        lb.setFont(font)
+        lb.setMaximumHeight(50)
         vb.addWidget(lb)
 
         # Toggle PBC
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("Use periodic boundary conditions"); lb.setToolTip(TTips['PBC']); vb.addWidget(lb)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("Use periodic boundary conditions")
+        lb.setToolTip(TTips["PBC"])
+        vb.addWidget(lb)
         self.bxPBC = QtWidgets.QCheckBox()
         self.bxPBC.setChecked(True)
         self.bxPBC.toggled.connect(self.updatePBC)
         vb.addWidget(self.bxPBC)
 
         # Toggle z PBC
-        lb = QtWidgets.QLabel("z periodicity"); lb.setToolTip(TTips['PBCz']); vb.addWidget(lb)
+        lb = QtWidgets.QLabel("z periodicity")
+        lb.setToolTip(TTips["PBCz"])
+        vb.addWidget(lb)
         self.bxPBCz = QtWidgets.QCheckBox()
         self.bxPBCz.setChecked(False)
         self.bxPBCz.toggled.connect(self.updatePBC)
-        self.bxPBCz.setToolTip(TTips['PBCz'])
+        self.bxPBCz.setToolTip(TTips["PBCz"])
         vb.addWidget(self.bxPBCz)
 
         # Left-right divide for labels and input boxes
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        bxl = QtWidgets.QVBoxLayout(); vb.addLayout(bxl, 1)
-        bxr = QtWidgets.QVBoxLayout(); vb.addLayout(bxr, 3)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        bxl = QtWidgets.QVBoxLayout()
+        vb.addLayout(bxl, 1)
+        bxr = QtWidgets.QVBoxLayout()
+        vb.addLayout(bxr, 3)
 
         # Lattice vector A
-        lb = QtWidgets.QLabel("A (x, y, z) [Å]"); lb.setToolTip(TTips['PBC']); bxl.addWidget(lb)
-        vb = QtWidgets.QHBoxLayout(); bxr.addLayout(vb)
-        self.bxPBCAx = _spin_box((-1000, 1000), 50, 0.1, self.updatePBC, TTips['PBC'], vb)
-        self.bxPBCAy = _spin_box((-1000, 1000),  0, 0.1, self.updatePBC, TTips['PBC'], vb)
-        self.bxPBCAz = _spin_box((-1000, 1000),  0, 0.1, self.updatePBC, TTips['PBC'], vb)
+        lb = QtWidgets.QLabel("A (x, y, z) [Å]")
+        lb.setToolTip(TTips["PBC"])
+        bxl.addWidget(lb)
+        vb = QtWidgets.QHBoxLayout()
+        bxr.addLayout(vb)
+        self.bxPBCAx = _spin_box(
+            (-1000, 1000), 50, 0.1, self.updatePBC, TTips["PBC"], vb
+        )
+        self.bxPBCAy = _spin_box(
+            (-1000, 1000), 0, 0.1, self.updatePBC, TTips["PBC"], vb
+        )
+        self.bxPBCAz = _spin_box(
+            (-1000, 1000), 0, 0.1, self.updatePBC, TTips["PBC"], vb
+        )
 
         # Lattice vector B
-        lb = QtWidgets.QLabel("B (x, y, z) [Å]"); lb.setToolTip(TTips['PBC']); bxl.addWidget(lb)
-        vb = QtWidgets.QHBoxLayout(); bxr.addLayout(vb)
-        self.bxPBCBx = _spin_box((-1000, 1000),  0, 0.1, self.updatePBC, TTips['PBC'], vb)
-        self.bxPBCBy = _spin_box((-1000, 1000), 50, 0.1, self.updatePBC, TTips['PBC'], vb)
-        self.bxPBCBz = _spin_box((-1000, 1000),  0, 0.1, self.updatePBC, TTips['PBC'], vb)
+        lb = QtWidgets.QLabel("B (x, y, z) [Å]")
+        lb.setToolTip(TTips["PBC"])
+        bxl.addWidget(lb)
+        vb = QtWidgets.QHBoxLayout()
+        bxr.addLayout(vb)
+        self.bxPBCBx = _spin_box(
+            (-1000, 1000), 0, 0.1, self.updatePBC, TTips["PBC"], vb
+        )
+        self.bxPBCBy = _spin_box(
+            (-1000, 1000), 50, 0.1, self.updatePBC, TTips["PBC"], vb
+        )
+        self.bxPBCBz = _spin_box(
+            (-1000, 1000), 0, 0.1, self.updatePBC, TTips["PBC"], vb
+        )
 
         # Lattice vector C
-        lb = QtWidgets.QLabel("C (x, y, z) [Å]"); lb.setToolTip(TTips['PBC']); bxl.addWidget(lb)
-        vb = QtWidgets.QHBoxLayout(); bxr.addLayout(vb)
-        self.bxPBCCx = _spin_box((-1000, 1000),  0, 0.1, self.updatePBC, TTips['PBC'], vb)
-        self.bxPBCCy = _spin_box((-1000, 1000),  0, 0.1, self.updatePBC, TTips['PBC'], vb)
-        self.bxPBCCz = _spin_box((-1000, 1000), 50, 0.1, self.updatePBC, TTips['PBC'], vb)
+        lb = QtWidgets.QLabel("C (x, y, z) [Å]")
+        lb.setToolTip(TTips["PBC"])
+        bxl.addWidget(lb)
+        vb = QtWidgets.QHBoxLayout()
+        bxr.addLayout(vb)
+        self.bxPBCCx = _spin_box(
+            (-1000, 1000), 0, 0.1, self.updatePBC, TTips["PBC"], vb
+        )
+        self.bxPBCCy = _spin_box(
+            (-1000, 1000), 0, 0.1, self.updatePBC, TTips["PBC"], vb
+        )
+        self.bxPBCCz = _spin_box(
+            (-1000, 1000), 50, 0.1, self.updatePBC, TTips["PBC"], vb
+        )
 
     def _create_df_settings_ui(self):
-
         # Title
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("df settings"); lb.setAlignment(QtCore.Qt.AlignCenter)
-        font = lb.font(); font.setPointSize(12); lb.setFont(font); lb.setMaximumHeight(50)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("df settings")
+        lb.setAlignment(QtCore.Qt.AlignCenter)
+        font = lb.font()
+        font.setPointSize(12)
+        lb.setFont(font)
+        lb.setMaximumHeight(50)
         vb.addWidget(lb)
 
         # Cantilevel settings
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
-        lb = QtWidgets.QLabel("k [kN/m]"); lb.setToolTip(TTips['k']); vb.addWidget(lb)
-        self.bxCant_K = _spin_box((0, 1000), 1.8, 0.1, self.updateScanWindow, TTips['k'], vb)
-        lb = QtWidgets.QLabel("f0 [kHz]"); lb.setToolTip(TTips['f0']); vb.addWidget(lb)
-        self.bxCant_f0 = _spin_box((0, 1000), 30.3, 1.0, self.updateScanWindow, TTips['k'], vb)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
+        lb = QtWidgets.QLabel("k [kN/m]")
+        lb.setToolTip(TTips["k"])
+        vb.addWidget(lb)
+        self.bxCant_K = _spin_box(
+            (0, 1000), 1.8, 0.1, self.updateScanWindow, TTips["k"], vb
+        )
+        lb = QtWidgets.QLabel("f0 [kHz]")
+        lb.setToolTip(TTips["f0"])
+        vb.addWidget(lb)
+        self.bxCant_f0 = _spin_box(
+            (0, 1000), 30.3, 1.0, self.updateScanWindow, TTips["k"], vb
+        )
 
         # Number of z-steps in df curve
-        lb = QtWidgets.QLabel("z steps"); lb.setToolTip(TTips['z_steps']); vb.addWidget(lb, 1)
+        lb = QtWidgets.QLabel("z steps")
+        lb.setToolTip(TTips["z_steps"])
+        vb.addWidget(lb, 1)
         self.bxdfst = QtWidgets.QSpinBox()
-        self.bxdfst.setRange(1, 100); self.bxdfst.setValue(10)
+        self.bxdfst.setRange(1, 100)
+        self.bxdfst.setValue(10)
         self.bxdfst.valueChanged.connect(self.updateScanWindow)
-        self.bxdfst.setToolTip(TTips['z_steps'])
+        self.bxdfst.setToolTip(TTips["z_steps"])
         self.bxdfst.setKeyboardTracking(False)
         vb.addWidget(self.bxdfst, 2)
 
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
 
         # Colorbar toggle
-        lb = QtWidgets.QLabel("Colorbar"); lb.setToolTip(TTips['df_colorbar']); vb.addWidget(lb)
+        lb = QtWidgets.QLabel("Colorbar")
+        lb.setToolTip(TTips["df_colorbar"])
+        vb.addWidget(lb)
         self.bxDfCbar = QtWidgets.QCheckBox()
         self.bxDfCbar.setChecked(False)
         self.bxDfCbar.toggled.connect(self.updateDfColorbar)
-        self.bxDfCbar.setToolTip(TTips['df_colorbar'])
+        self.bxDfCbar.setToolTip(TTips["df_colorbar"])
         vb.addWidget(self.bxDfCbar)
 
         # Colorbar range
-        lb = QtWidgets.QLabel("df range"); lb.setToolTip(TTips['df_range']); vb.addWidget(lb)
-        self.bxDfMin = _spin_box((-1000, 1000), -1.0, 0.1, self.updateDfRange, TTips['df_range'], vb)
-        self.bxDfMax = _spin_box((-1000, 1000),  1.0, 0.1, self.updateDfRange, TTips['df_range'], vb)
+        lb = QtWidgets.QLabel("df range")
+        lb.setToolTip(TTips["df_range"])
+        vb.addWidget(lb)
+        self.bxDfMin = _spin_box(
+            (-1000, 1000), -1.0, 0.1, self.updateDfRange, TTips["df_range"], vb
+        )
+        self.bxDfMax = _spin_box(
+            (-1000, 1000), 1.0, 0.1, self.updateDfRange, TTips["df_range"], vb
+        )
         self.bxDfMin.setDisabled(True)
         self.bxDfMax.setDisabled(True)
 
         # Colorbar range reset button
-        self.btDfReset = QtWidgets.QPushButton('Reset', self)
-        self.btDfReset.setToolTip(TTips['df_reset'])
+        self.btDfReset = QtWidgets.QPushButton("Reset", self)
+        self.btDfReset.setToolTip(TTips["df_reset"])
         self.btDfReset.clicked.connect(self.resetDfRange)
         self.btDfReset.setDisabled(True)
         vb.addWidget(self.btDfReset)
 
     def _create_buttons_ui(self):
-
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
 
         # Geometry viewer
-        bt = QtWidgets.QPushButton('View Geometry', self)
-        bt.setToolTip(TTips['view_geom'])
+        bt = QtWidgets.QPushButton("View Geometry", self)
+        bt.setToolTip(TTips["view_geom"])
         bt.clicked.connect(self.showGeometry)
-        self.btViewGeom = bt; vb.addWidget(bt)
+        self.btViewGeom = bt
+        vb.addWidget(bt)
 
         # Geometry editor
         self.geomEditor = None
-        bt = QtWidgets.QPushButton('Edit Geometry', self)
-        bt.setToolTip(TTips['edit_geom'])
+        bt = QtWidgets.QPushButton("Edit Geometry", self)
+        bt.setToolTip(TTips["edit_geom"])
         bt.clicked.connect(self.showGeomEditor)
-        self.btEditAtoms = bt; vb.addWidget(bt)
+        self.btEditAtoms = bt
+        vb.addWidget(bt)
 
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
 
         # Forcefield viewer
         self.FFViewer = guiw.FFViewer(self, verbose=self.verbose)
-        bt = QtWidgets.QPushButton('View Forcefield', self)
-        bt.setToolTip(TTips['view_ff'])
+        bt = QtWidgets.QPushButton("View Forcefield", self)
+        bt.setToolTip(TTips["view_ff"])
         bt.clicked.connect(self.showFFViewer)
-        self.btViewFF = bt; vb.addWidget(bt)
+        self.btViewFF = bt
+        vb.addWidget(bt)
 
         # Forcefield parameter editor
         self.FFEditor = guiw.LJParamEditor(self.afmulator.typeParams, self)
-        bt = QtWidgets.QPushButton('Edit Forcefield', self)
-        bt.setToolTip(TTips['edit_ff'])
+        bt = QtWidgets.QPushButton("Edit Forcefield", self)
+        bt.setToolTip(TTips["edit_ff"])
         bt.clicked.connect(self.FFEditor.show)
-        self.btEditFF = bt; vb.addWidget(bt)
+        self.btEditFF = bt
+        vb.addWidget(bt)
 
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
 
         # Buttons for saving/loading parameters
-        self.btSaveParams = QtWidgets.QPushButton('Save parameters...', self)
-        self.btSaveParams.setToolTip('Save all current parameters into a params.ini file.')
+        self.btSaveParams = QtWidgets.QPushButton("Save parameters...", self)
+        self.btSaveParams.setToolTip(
+            "Save all current parameters into a params.ini file."
+        )
         self.btSaveParams.clicked.connect(self.saveParams)
-        vb.addWidget( self.btSaveParams )
-        self.btLoadParams = QtWidgets.QPushButton('Load parameters...', self)
-        self.btLoadParams.setToolTip('Load parameters from a params.ini file.')
+        vb.addWidget(self.btSaveParams)
+        self.btLoadParams = QtWidgets.QPushButton("Load parameters...", self)
+        self.btLoadParams.setToolTip("Load parameters from a params.ini file.")
         self.btLoadParams.clicked.connect(self.loadParams)
-        vb.addWidget( self.btLoadParams )
+        vb.addWidget(self.btLoadParams)
 
-        vb = QtWidgets.QHBoxLayout(); self.l0.addLayout(vb)
+        vb = QtWidgets.QHBoxLayout()
+        self.l0.addLayout(vb)
 
         # --- btLoad
         self.openFileDialog = guiw.FileOpen(self)
-        self.btLoad = QtWidgets.QPushButton('Open File...', self)
-        self.btLoad.setToolTip('Open new file.')
+        self.btLoad = QtWidgets.QPushButton("Open File...", self)
+        self.btLoad.setToolTip("Open new file.")
         self.btLoad.clicked.connect(self.openFile)
-        vb.addWidget( self.btLoad )
+        vb.addWidget(self.btLoad)
 
         # --- btSave
-        self.btSave = QtWidgets.QPushButton('Save Image...', self)
-        self.btSave.setToolTip('Save current image.')
+        self.btSave = QtWidgets.QPushButton("Save Image...", self)
+        self.btSave.setToolTip("Save current image.")
         self.btSave.clicked.connect(self.saveFig)
-        vb.addWidget( self.btSave )
+        vb.addWidget(self.btSave)
 
         # --- btSaveW (W- wsxm)
-        self.btSaveW = QtWidgets.QPushButton('Save df...', self)
-        self.btSaveW.setToolTip('Save current frequency shift data.')
+        self.btSaveW = QtWidgets.QPushButton("Save df...", self)
+        self.btSaveW.setToolTip("Save current frequency shift data.")
         self.btSaveW.clicked.connect(self.saveDataW)
-        vb.addWidget( self.btSaveW )
+        vb.addWidget(self.btSaveW)
+
 
 def _separator_line(parent):
     ln = QtWidgets.QFrame()
@@ -1139,6 +1486,7 @@ def _separator_line(parent):
     ln.setFrameShadow(QtWidgets.QFrame.Sunken)
     parent.addWidget(ln)
     return ln
+
 
 def _spin_box(value_range, value, step, connect_func, tool_tip, parent, stretch=2):
     bx = QtWidgets.QDoubleSpinBox()
@@ -1151,11 +1499,12 @@ def _spin_box(value_range, value, step, connect_func, tool_tip, parent, stretch=
     parent.addWidget(bx, stretch)
     return bx
 
+
 def main():
     qApp = QtWidgets.QApplication(sys.argv)
     args = parse_args()
     if args.list_devices:
-        print('\nAvailable OpenCL platforms:')
+        print("\nAvailable OpenCL platforms:")
         oclu.print_platforms()
         sys.exit(0)
     try:
@@ -1166,7 +1515,10 @@ def main():
         pass
     except:
         traceback.print_exc()
-        guiw.show_warning(None, f'Ran into an error!\n\n{traceback.format_exc()}', 'Error!')
+        guiw.show_warning(
+            None, f"Ran into an error!\n\n{traceback.format_exc()}", "Error!"
+        )
+
 
 if __name__ == "__main__":
     main()

--- a/ppafm/cli/plot_results.py
+++ b/ppafm/cli/plot_results.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -13,232 +14,458 @@ import ppafm.HighLevel as PPH
 import ppafm.PPPlot as PPPlot
 from ppafm import elements, io
 
-import matplotlib as mpl;  mpl.use('Agg'); print("plot WITHOUT Xserver"); # this makes it run without Xserver (e.g. on supercomputer) # see http://stackoverflow.com/questions/4931376/generating-matplotlib-graphs-without-a-running-x-server
+mpl.use("Agg")
+print("plot WITHOUT Xserver")
+# this makes it run without Xserver (e.g. on supercomputer) # see http://stackoverflow.com/questions/4931376/generating-matplotlib-graphs-without-a-running-x-server
 
 
 def main():
-
     parser = PPU.CLIParser(
-        description='Plot results for a scan with a specified charge, amplitude, and spring constant. '
-            'Images are saved in folder Q{charge}K{klat}/Amp{Amplitude}.'
+        description="Plot results for a scan with a specified charge, amplitude, and spring constant. "
+        "Images are saved in folder Q{charge}K{klat}/Amp{Amplitude}."
     )
-    parser.add_arguments(['output_format', 'Amplitude', 'arange', 'klat', 'krange', 'charge', 'qrange', 'Vbias', 'Vrange', 'noPBC'])
-    parser.add_argument( "--iets", action="store", type=float, help="Mass [a.u.]; Bias offset [eV]; Peak width [eV] ", nargs=3 )
-    parser.add_argument( "--LCPD_maps", action="store_true", help="Print LCPD maps")
-    parser.add_argument("--z0", action="store", type=float, default=0.0, help="Height of the topmost layer of metallic substrate for E to V conversion (Ang)")
-    parser.add_argument("--V0", action="store", type=float, default=0.0, help="Empirical LCPD maxima shift due to mesoscopic workfunction diference")
+    parser.add_arguments(
+        [
+            "output_format",
+            "Amplitude",
+            "arange",
+            "klat",
+            "krange",
+            "charge",
+            "qrange",
+            "Vbias",
+            "Vrange",
+            "noPBC",
+        ]
+    )
+    parser.add_argument(
+        "--iets",
+        action="store",
+        type=float,
+        help="Mass [a.u.]; Bias offset [eV]; Peak width [eV] ",
+        nargs=3,
+    )
+    parser.add_argument("--LCPD_maps", action="store_true", help="Print LCPD maps")
+    parser.add_argument(
+        "--z0",
+        action="store",
+        type=float,
+        default=0.0,
+        help="Height of the topmost layer of metallic substrate for E to V conversion (Ang)",
+    )
+    parser.add_argument(
+        "--V0",
+        action="store",
+        type=float,
+        default=0.0,
+        help="Empirical LCPD maxima shift due to mesoscopic workfunction diference",
+    )
 
-    parser.add_argument( "--df",       action="store_true", help="Plot images for dfz " )
-    parser.add_argument( "--save_df" , action="store_true", help="Save frequency shift as df.xsf " )
-    parser.add_argument( "--Laplace",  action="store_true", help="Plot Laplace-filtered images and save them " )
-    parser.add_argument( "--pos",      action="store_true", help="Save probe particle positions" )
-    parser.add_argument( "--atoms",    action="store_true", help="Plot atoms to images" )
-    parser.add_argument( "--bonds",    action="store_true", help="Plot bonds to images" )
-    parser.add_argument( "--cbar",     action="store_true", help="Plot colorbars to images" )
-    parser.add_argument( "--WSxM",     action="store_true", help="Save frequency shift into WsXM *.dat files" )
-    parser.add_argument( "--bI",       action="store_true", help="Plot images for Boltzmann current" )
+    parser.add_argument("--df", action="store_true", help="Plot images for dfz ")
+    parser.add_argument(
+        "--save_df", action="store_true", help="Save frequency shift as df.xsf "
+    )
+    parser.add_argument(
+        "--Laplace",
+        action="store_true",
+        help="Plot Laplace-filtered images and save them ",
+    )
+    parser.add_argument(
+        "--pos", action="store_true", help="Save probe particle positions"
+    )
+    parser.add_argument("--atoms", action="store_true", help="Plot atoms to images")
+    parser.add_argument("--bonds", action="store_true", help="Plot bonds to images")
+    parser.add_argument("--cbar", action="store_true", help="Plot colorbars to images")
+    parser.add_argument(
+        "--WSxM", action="store_true", help="Save frequency shift into WsXM *.dat files"
+    )
+    parser.add_argument(
+        "--bI", action="store_true", help="Plot images for Boltzmann current"
+    )
 
     args = parser.parse_args()
     opt_dict = vars(args)
 
-    PPU.loadParams( 'params.ini' )
+    PPU.loadParams("params.ini")
     PPU.apply_options(opt_dict)
 
-    if opt_dict['Laplace']:
+    if opt_dict["Laplace"]:
         from scipy.ndimage import laplace
 
     print(" >> OVEWRITING SETTINGS by command line arguments  ")
     # Ks
-    if opt_dict['krange'] is not None:
-        Ks = np.linspace( opt_dict['krange'][0], opt_dict['krange'][1], int(opt_dict['krange'][2]) )
-    elif opt_dict['klat'] is not None:
-        Ks = [ opt_dict['klat'] ]
-    elif PPU.params['stiffness'][0] > 0.0:
-        Ks = [PPU.params['stiffness'][0]]
+    if opt_dict["krange"] is not None:
+        Ks = np.linspace(
+            opt_dict["krange"][0], opt_dict["krange"][1], int(opt_dict["krange"][2])
+        )
+    elif opt_dict["klat"] is not None:
+        Ks = [opt_dict["klat"]]
+    elif PPU.params["stiffness"][0] > 0.0:
+        Ks = [PPU.params["stiffness"][0]]
     else:
-        Ks = [ PPU.params['klat']]
+        Ks = [PPU.params["klat"]]
     # Qs
-    if opt_dict['qrange'] is not None:
-        Qs = np.linspace( opt_dict['qrange'][0], opt_dict['qrange'][1], int(opt_dict['qrange'][2]) )
-    elif opt_dict['charge'] is not None:
-        Qs = [ opt_dict['charge'] ]
+    if opt_dict["qrange"] is not None:
+        Qs = np.linspace(
+            opt_dict["qrange"][0], opt_dict["qrange"][1], int(opt_dict["qrange"][2])
+        )
+    elif opt_dict["charge"] is not None:
+        Qs = [opt_dict["charge"]]
     else:
-        Qs = [ PPU.params['charge'] ]
+        Qs = [PPU.params["charge"]]
     # Amps
-    if opt_dict['arange'] is not None:
-        Amps = np.linspace( opt_dict['arange'][0], opt_dict['arange'][1], int(opt_dict['arange'][2]) )
-    elif opt_dict['Amplitude'] is not None:
-        Amps = [ opt_dict['Amplitude'] ]
+    if opt_dict["arange"] is not None:
+        Amps = np.linspace(
+            opt_dict["arange"][0], opt_dict["arange"][1], int(opt_dict["arange"][2])
+        )
+    elif opt_dict["Amplitude"] is not None:
+        Amps = [opt_dict["Amplitude"]]
     else:
-        Amps = [ PPU.params['Amplitude'] ]
+        Amps = [PPU.params["Amplitude"]]
     # Applied biases
     applied_bias = False
-    if opt_dict['Vrange'] is not None:
-        Vs = np.linspace( opt_dict['Vrange'][0], opt_dict['Vrange'][1], int(opt_dict['Vrange'][2]) )
-    elif opt_dict['Vbias'] is not None:
-        Vs = [ opt_dict['Vbias'] ]
+    if opt_dict["Vrange"] is not None:
+        Vs = np.linspace(
+            opt_dict["Vrange"][0], opt_dict["Vrange"][1], int(opt_dict["Vrange"][2])
+        )
+    elif opt_dict["Vbias"] is not None:
+        Vs = [opt_dict["Vbias"]]
     else:
         Vs = [0.0]
-    for iV,Vx in enumerate(Vs):
-        if ( abs(Vx) > 1e-7):
-            applied_bias=True
+    for iV, Vx in enumerate(Vs):
+        if abs(Vx) > 1e-7:
+            applied_bias = True
 
-    if (applied_bias == True):
+    if applied_bias == True:
         print("Vs   =", Vs)
     print("Ks   =", Ks)
     print("Qs   =", Qs)
     print("Amps =", Amps)
     print(" ============= RUN  ")
 
-    dz  = PPU.params['scanStep'][2]
-    xTips,yTips,zTips,lvecScan = PPU.prepareScanGrids( )
-    extent = ( xTips[0], xTips[-1], yTips[0], yTips[-1] )
+    dz = PPU.params["scanStep"][2]
+    xTips, yTips, zTips, lvecScan = PPU.prepareScanGrids()
+    extent = (xTips[0], xTips[-1], yTips[0], yTips[-1])
 
-    atoms_str=""
+    atoms_str = ""
     atoms = None
     bonds = None
     FFparams = None
-    if opt_dict['atoms'] or opt_dict['bonds']:
-        speciesFile=None
-        if os.path.isfile( 'atomtypes.ini' ):
-            speciesFile='atomtypes.ini'
-        FFparams=PPU.loadSpecies( speciesFile )
-        atoms_str="_atoms"
-        xyzs, Zs, qs, _ = io.loadXYZ('input_plot.xyz')
-        atoms = [list(Zs), list(xyzs[:, 0]), list(xyzs[:, 1]), list(xyzs[:, 2]), list(qs)]
-        FFparams            = PPU.loadSpecies( )
-        elem_dict           = PPU.getFFdict(FFparams)
-        iZs,Rs,Qs_tmp=PPU.parseAtoms(atoms, elem_dict, autogeom = False, PBC = PPU.params['PBC'] )
-        atom_colors = au.getAtomColors(iZs,FFparams=FFparams)
-        Rs=Rs.transpose().copy()
-        atoms= [iZs,Rs[0],Rs[1],Rs[2],atom_colors]
-    if opt_dict['bonds']:
-        bonds = au.findBonds(atoms,iZs,1.0,FFparams=FFparams)
+    if opt_dict["atoms"] or opt_dict["bonds"]:
+        speciesFile = None
+        if os.path.isfile("atomtypes.ini"):
+            speciesFile = "atomtypes.ini"
+        FFparams = PPU.loadSpecies(speciesFile)
+        atoms_str = "_atoms"
+        xyzs, Zs, qs, _ = io.loadXYZ("input_plot.xyz")
+        atoms = [
+            list(Zs),
+            list(xyzs[:, 0]),
+            list(xyzs[:, 1]),
+            list(xyzs[:, 2]),
+            list(qs),
+        ]
+        FFparams = PPU.loadSpecies()
+        elem_dict = PPU.getFFdict(FFparams)
+        iZs, Rs, Qs_tmp = PPU.parseAtoms(
+            atoms, elem_dict, autogeom=False, PBC=PPU.params["PBC"]
+        )
+        atom_colors = au.getAtomColors(iZs, FFparams=FFparams)
+        Rs = Rs.transpose().copy()
+        atoms = [iZs, Rs[0], Rs[1], Rs[2], atom_colors]
+    if opt_dict["bonds"]:
+        bonds = au.findBonds(atoms, iZs, 1.0, FFparams=FFparams)
     atomSize = 0.15
 
-    cbar_str =""
-    if opt_dict['cbar']:
-        cbar_str="_cbar"
+    cbar_str = ""
+    if opt_dict["cbar"]:
+        cbar_str = "_cbar"
 
-    for iq,Q in enumerate( Qs ):
-        for ik,K in enumerate( Ks ):
-            dirname = "Q%1.2fK%1.2f" %(Q,K)
-            for iv,Vx in enumerate( Vs ):
+    for iq, Q in enumerate(Qs):
+        for ik, K in enumerate(Ks):
+            dirname = f"Q{Q:1.2f}K{K:1.2f}"
+            for iv, Vx in enumerate(Vs):
                 if applied_bias:
-                    dirname = "Q%1.2fK%1.2fV%1.2f" %(Q,K,Vx)
-                if opt_dict['pos']:
+                    dirname = f"Q{Q:1.2f}K{K:1.2f}V{Vx:1.2f}"
+                if opt_dict["pos"]:
                     try:
-                        PPpos, lvec, nDim , atomic_info_or_head = io.load_vec_field(dirname+'/PPpos' ,data_format=args.output_format)
+                        PPpos, lvec, nDim, atomic_info_or_head = io.load_vec_field(
+                            dirname + "/PPpos", data_format=args.output_format
+                        )
                         print(" plotting PPpos : ")
                         PPPlot.plotDistortions(
-                            dirname+"/xy"+atoms_str+cbar_str, PPpos[:,:,:,0], PPpos[:,:,:,1], slices = list(range( 0, len(PPpos))), BG=PPpos[:,:,:,2],
-                            extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, markersize=2.0, cbar=opt_dict['cbar']
+                            dirname + "/xy" + atoms_str + cbar_str,
+                            PPpos[:, :, :, 0],
+                            PPpos[:, :, :, 1],
+                            slices=list(range(0, len(PPpos))),
+                            BG=PPpos[:, :, :, 2],
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            markersize=2.0,
+                            cbar=opt_dict["cbar"],
                         )
                         del PPpos
                     except:
                         print("error: ", sys.exc_info())
-                        print("cannot load : " + ( dirname+'/PPpos_?.' + args.output_format ))
-                if opt_dict['iets'] is not None:
-                    try :
-                        eigvalK, lvec, nDim = io.load_vec_field( dirname+'/eigvalKs' ,data_format=args.output_format)
-                        M  = opt_dict['iets'][0]
-                        E0 = opt_dict['iets'][1]
-                        w  = opt_dict['iets'][2]
-                        print(" plotting IETS M=%f V=%f w=%f " %(M,E0,w))
-                        hbar       = 6.58211951440e-16 # [eV.s]
-                        aumass     = 1.66053904020e-27 # [kg]
-                        eVA2_to_Nm = 16.0217662        # [eV/A^2] / [N/m]
-                        Evib = hbar * np.sqrt( ( eVA2_to_Nm * eigvalK )/( M * aumass ) )
-                        IETS = PPH.symGauss(Evib[:,:,:,0], E0, w) + PPH.symGauss(Evib[:,:,:,1], E0, w) + PPH.symGauss(Evib[:,:,:,2], E0, w)
-                        PPPlot.plotImages( dirname+"/IETS"+atoms_str+cbar_str, IETS, slices = list(range(0,len(IETS))), zs=zTips, extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'] )
-                        PPPlot.plotImages( dirname+"/Evib"+atoms_str+cbar_str, Evib[:,:,:,0], slices = list(range(0,len(IETS))), zs=zTips, extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'] )
-                        PPPlot.plotImages( dirname+"/Kvib"+atoms_str+cbar_str, 16.0217662 * eigvalK[:,:,:,0], slices = list(range(0,len(IETS))), zs=zTips, extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'] )
-                        del eigvalK; del Evib; del IETS
+                        print(
+                            "cannot load : "
+                            + (dirname + "/PPpos_?." + args.output_format)
+                        )
+                if opt_dict["iets"] is not None:
+                    try:
+                        eigvalK, lvec, nDim = io.load_vec_field(
+                            dirname + "/eigvalKs", data_format=args.output_format
+                        )
+                        M = opt_dict["iets"][0]
+                        E0 = opt_dict["iets"][1]
+                        w = opt_dict["iets"][2]
+                        print(f" plotting IETS M={M:f} V={E0:f} w={w:f} ")
+                        hbar = 6.58211951440e-16  # [eV.s]
+                        aumass = 1.66053904020e-27  # [kg]
+                        eVA2_to_Nm = 16.0217662  # [eV/A^2] / [N/m]
+                        Evib = hbar * np.sqrt((eVA2_to_Nm * eigvalK) / (M * aumass))
+                        IETS = (
+                            PPH.symGauss(Evib[:, :, :, 0], E0, w)
+                            + PPH.symGauss(Evib[:, :, :, 1], E0, w)
+                            + PPH.symGauss(Evib[:, :, :, 2], E0, w)
+                        )
+                        PPPlot.plotImages(
+                            dirname + "/IETS" + atoms_str + cbar_str,
+                            IETS,
+                            slices=list(range(0, len(IETS))),
+                            zs=zTips,
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            cbar=opt_dict["cbar"],
+                        )
+                        PPPlot.plotImages(
+                            dirname + "/Evib" + atoms_str + cbar_str,
+                            Evib[:, :, :, 0],
+                            slices=list(range(0, len(IETS))),
+                            zs=zTips,
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            cbar=opt_dict["cbar"],
+                        )
+                        PPPlot.plotImages(
+                            dirname + "/Kvib" + atoms_str + cbar_str,
+                            16.0217662 * eigvalK[:, :, :, 0],
+                            slices=list(range(0, len(IETS))),
+                            zs=zTips,
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            cbar=opt_dict["cbar"],
+                        )
+                        del eigvalK
+                        del Evib
+                        del IETS
                     except:
                         print("error: ", sys.exc_info())
-                        print("cannot load : ", dirname+'/PPpos_?.' + args.output_format)
-                if (  opt_dict['df'] or opt_dict['save_df'] or opt_dict['WSxM']  ):
-                    try :
-                        for iA,Amp in enumerate( Amps ):
-                            PPU.params['Amplitude'] = Amp
-                            AmpStr = "/Amp%2.2f" %Amp
-                            print("Amp= ",AmpStr)
-                            dirNameAmp = dirname+AmpStr
-                            if not os.path.exists( dirNameAmp ):
-                                os.makedirs( dirNameAmp )
-                            if PPU.params['tiltedScan']:
-                                Fout, lvec, nDim , atomic_info_or_head = io.load_vec_field(dirname+'/OutF' , data_format=args.output_format)
-                                dfs = PPU.Fz2df_tilt( Fout, PPU.params['scanTilt'], k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], n=int(Amp/dz) )
+                        print(
+                            "cannot load : ", dirname + "/PPpos_?." + args.output_format
+                        )
+                if opt_dict["df"] or opt_dict["save_df"] or opt_dict["WSxM"]:
+                    try:
+                        for iA, Amp in enumerate(Amps):
+                            PPU.params["Amplitude"] = Amp
+                            AmpStr = "/Amp%2.2f" % Amp
+                            print("Amp= ", AmpStr)
+                            dirNameAmp = dirname + AmpStr
+                            if not os.path.exists(dirNameAmp):
+                                os.makedirs(dirNameAmp)
+                            if PPU.params["tiltedScan"]:
+                                (
+                                    Fout,
+                                    lvec,
+                                    nDim,
+                                    atomic_info_or_head,
+                                ) = io.load_vec_field(
+                                    dirname + "/OutF", data_format=args.output_format
+                                )
+                                dfs = PPU.Fz2df_tilt(
+                                    Fout,
+                                    PPU.params["scanTilt"],
+                                    k0=PPU.params["kCantilever"],
+                                    f0=PPU.params["f0Cantilever"],
+                                    n=int(Amp / dz),
+                                )
                             else:
-                                fzs, lvec, nDim , atomic_info_or_head = io.load_scal_field(dirname+'/OutFz' , data_format=args.output_format)
-                                if (applied_bias):
-                                    Rtip = PPU.params['Rtip']
-                                    for iz,z in enumerate( zTips ):
-                                        fzs[iz,:,:] = fzs[iz,:,:] - np.pi*PPU.params['permit']*((Rtip*Rtip)/((z-args.z0)*(z+Rtip)))*(Vx-args.V0)*(Vx-args.V0)
-                                dfs = PPU.Fz2df( fzs, dz = dz, k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], n=int(Amp/dz) )
-                            if opt_dict['save_df']:
-                                io.save_scal_field(dirNameAmp+'/df', dfs, lvec,data_format=args.output_format , head = atomic_info_or_head , atomic_info = atomic_info_or_head)
-                            if opt_dict['df']:
+                                (
+                                    fzs,
+                                    lvec,
+                                    nDim,
+                                    atomic_info_or_head,
+                                ) = io.load_scal_field(
+                                    dirname + "/OutFz", data_format=args.output_format
+                                )
+                                if applied_bias:
+                                    Rtip = PPU.params["Rtip"]
+                                    for iz, z in enumerate(zTips):
+                                        fzs[iz, :, :] = fzs[
+                                            iz, :, :
+                                        ] - np.pi * PPU.params["permit"] * (
+                                            (Rtip * Rtip) / ((z - args.z0) * (z + Rtip))
+                                        ) * (
+                                            Vx - args.V0
+                                        ) * (
+                                            Vx - args.V0
+                                        )
+                                dfs = PPU.Fz2df(
+                                    fzs,
+                                    dz=dz,
+                                    k0=PPU.params["kCantilever"],
+                                    f0=PPU.params["f0Cantilever"],
+                                    n=int(Amp / dz),
+                                )
+                            if opt_dict["save_df"]:
+                                io.save_scal_field(
+                                    dirNameAmp + "/df",
+                                    dfs,
+                                    lvec,
+                                    data_format=args.output_format,
+                                    head=atomic_info_or_head,
+                                    atomic_info=atomic_info_or_head,
+                                )
+                            if opt_dict["df"]:
                                 print(" plotting df : ")
                                 PPPlot.plotImages(
-                                    dirNameAmp+"/df"+atoms_str+cbar_str, dfs,  slices = list(range( 0, len(dfs))), zs=zTips+PPU.params['Amplitude']/2.0,
-                                    extent=extent,cmap=PPU.params['colorscale'], atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar']
+                                    dirNameAmp + "/df" + atoms_str + cbar_str,
+                                    dfs,
+                                    slices=list(range(0, len(dfs))),
+                                    zs=zTips + PPU.params["Amplitude"] / 2.0,
+                                    extent=extent,
+                                    cmap=PPU.params["colorscale"],
+                                    atoms=atoms,
+                                    bonds=bonds,
+                                    atomSize=atomSize,
+                                    cbar=opt_dict["cbar"],
                                 )
-                            if opt_dict['Laplace']:
+                            if opt_dict["Laplace"]:
                                 print("plotting Laplace-filtered df : ")
                                 df_LaplaceFiltered = dfs.copy()
-                                laplace( dfs, output = df_LaplaceFiltered )
-                                io.save_scal_field(dirNameAmp+'/df_laplace', df_LaplaceFiltered, lvec,data_format=args.output_format , head = atomic_info_or_head , atomic_info = atomic_info_or_head)
-                                PPPlot.plotImages(
-                                    dirNameAmp+"/df_laplace"+atoms_str+cbar_str, df_LaplaceFiltered, slices = list(range( 0, len(dfs))), zs=zTips+PPU.params['Amplitude']/2.0,
-                                    extent=extent,cmap=PPU.params['colorscale'], atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar']
+                                laplace(dfs, output=df_LaplaceFiltered)
+                                io.save_scal_field(
+                                    dirNameAmp + "/df_laplace",
+                                    df_LaplaceFiltered,
+                                    lvec,
+                                    data_format=args.output_format,
+                                    head=atomic_info_or_head,
+                                    atomic_info=atomic_info_or_head,
                                 )
-                            if opt_dict['WSxM']:
+                                PPPlot.plotImages(
+                                    dirNameAmp + "/df_laplace" + atoms_str + cbar_str,
+                                    df_LaplaceFiltered,
+                                    slices=list(range(0, len(dfs))),
+                                    zs=zTips + PPU.params["Amplitude"] / 2.0,
+                                    extent=extent,
+                                    cmap=PPU.params["colorscale"],
+                                    atoms=atoms,
+                                    bonds=bonds,
+                                    atomSize=atomSize,
+                                    cbar=opt_dict["cbar"],
+                                )
+                            if opt_dict["WSxM"]:
                                 print(" printing df into WSxM files :")
-                                io.saveWSxM_3D( dirNameAmp+"/df" , dfs , extent , slices=None)
-                            if  opt_dict['LCPD_maps']:
-                                if (iv == 0):
-                                    LCPD_b = - dfs
-                                if (iv == (Vs.shape[0]-1)):
-                                    LCPD_b = (LCPD_b + dfs)/(2*Vx)
+                                io.saveWSxM_3D(
+                                    dirNameAmp + "/df", dfs, extent, slices=None
+                                )
+                            if opt_dict["LCPD_maps"]:
+                                if iv == 0:
+                                    LCPD_b = -dfs
+                                if iv == (Vs.shape[0] - 1):
+                                    LCPD_b = (LCPD_b + dfs) / (2 * Vx)
 
-                                if (iv == 0):
+                                if iv == 0:
                                     LCPD_a = dfs
-                                if (Vx == 0.0):
-                                    LCPD_a = LCPD_a - 2*dfs
-                                if (iv == (Vs.shape[0]-1)):
-                                    LCPD_a = (LCPD_a + dfs)/(2*Vx**2)
+                                if Vx == 0.0:
+                                    LCPD_a = LCPD_a - 2 * dfs
+                                if iv == (Vs.shape[0] - 1):
+                                    LCPD_a = (LCPD_a + dfs) / (2 * Vx**2)
                             del dfs
-                        del fzs
+                        if PPU.params["tiltedScan"]:
+                            del Fout
+                        else:
+                            del fzs
                     except:
                         print("error: ", sys.exc_info())
-                        print("cannot load : ",dirname+'/OutFz.'+args.output_format)
-                if opt_dict['bI']:
+                        print(
+                            "cannot load : ", dirname + "/OutFz." + args.output_format
+                        )
+                if opt_dict["bI"]:
                     try:
-                        I, lvec, nDim , atomic_info_or_head = io.load_scal_field(dirname+'/OutI_boltzmann', data_format=args.output_format )
+                        I, lvec, nDim, atomic_info_or_head = io.load_scal_field(
+                            dirname + "/OutI_boltzmann", data_format=args.output_format
+                        )
                         print(" plotting Boltzmann current: ")
-                        PPPlot.plotImages( dirname+"/OutI"+atoms_str+cbar_str, I,  slices = list(range( 0,len(I))), zs=zTips, extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'] )
+                        PPPlot.plotImages(
+                            dirname + "/OutI" + atoms_str + cbar_str,
+                            I,
+                            slices=list(range(0, len(I))),
+                            zs=zTips,
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            cbar=opt_dict["cbar"],
+                        )
                         del I
                     except:
                         print("error: ", sys.exc_info())
-                        print("cannot load : " + (dirname+'/OutI_boltzmann.'+args.output_format ))
-            if  opt_dict['LCPD_maps']:
-                LCPD = -LCPD_b/(2*LCPD_a)
+                        print(
+                            "cannot load : "
+                            + (dirname + "/OutI_boltzmann." + args.output_format)
+                        )
+            if opt_dict["LCPD_maps"]:
+                LCPD = -LCPD_b / (2 * LCPD_a)
                 PPPlot.plotImages(
-                    "./LCPD"+atoms_str+cbar_str, LCPD,  slices = list(range( 0, len(LCPD))), zs=zTips+PPU.params['Amplitude']/2.0,
-                    extent=extent,cmap=PPU.params['colorscale_kpfm'], atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'], symetric_map=True ,V0=args.V0
+                    "./LCPD" + atoms_str + cbar_str,
+                    LCPD,
+                    slices=list(range(0, len(LCPD))),
+                    zs=zTips + PPU.params["Amplitude"] / 2.0,
+                    extent=extent,
+                    cmap=PPU.params["colorscale_kpfm"],
+                    atoms=atoms,
+                    bonds=bonds,
+                    atomSize=atomSize,
+                    cbar=opt_dict["cbar"],
+                    symetric_map=True,
+                    V0=args.V0,
                 )
                 PPPlot.plotImages(
-                    "./_Asym-LCPD"+atoms_str+cbar_str, LCPD,  slices = list(range( 0, len(LCPD))), zs=zTips+PPU.params['Amplitude']/2.0,
-                    extent=extent,cmap=PPU.params['colorscale_kpfm'], atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'], symetric_map=False
+                    "./_Asym-LCPD" + atoms_str + cbar_str,
+                    LCPD,
+                    slices=list(range(0, len(LCPD))),
+                    zs=zTips + PPU.params["Amplitude"] / 2.0,
+                    extent=extent,
+                    cmap=PPU.params["colorscale_kpfm"],
+                    atoms=atoms,
+                    bonds=bonds,
+                    atomSize=atomSize,
+                    cbar=opt_dict["cbar"],
+                    symetric_map=False,
                 )
-                io.save_scal_field('./LCDP_HzperV', LCPD, lvec,data_format=args.output_format , head = atomic_info_or_head , atomic_info = atomic_info_or_head)
-                if opt_dict['WSxM']:
+                io.save_scal_field(
+                    "./LCDP_HzperV",
+                    LCPD,
+                    lvec,
+                    data_format=args.output_format,
+                    head=atomic_info_or_head,
+                    atomic_info=atomic_info_or_head,
+                )
+                if opt_dict["WSxM"]:
                     print(" printing LCPD_b into WSxM files :")
-                    io.saveWSxM_3D( "./LCPD"+atoms_str , LCPD , extent , slices=None)
-
+                    io.saveWSxM_3D("./LCPD" + atoms_str, LCPD, extent, slices=None)
 
     print(" ***** ALL DONE ***** ")
+
 
 if __name__ == "__main__":
     main()

--- a/ppafm/common.py
+++ b/ppafm/common.py
@@ -11,316 +11,355 @@ verbose = 0
 
 # ====================== constants
 
-eVA_Nm               =  16.0217657
-CoulombConst         = -14.3996448915;
+eVA_Nm = 16.0217657
+CoulombConst = -14.3996448915
 
 # default parameters of simulation
-params={
-    'PBC': True,
-    'nPBC' :       np.array( [      1,        1,        1 ] ),
-    'gridN':       np.array( [ -1,     -1,   -1   ] ).astype(int),
-    'gridA':       np.array( [ 12.798,  -7.3889,  0.00000 ] ),
-    'gridB':       np.array( [ 12.798,   7.3889,  0.00000 ] ),
-    'gridC':       np.array( [      0,        0,      5.0 ] ),
-    'FFgrid0':     np.array( [ -1.0, -1.0, -1.0 ] ),
-    'FFgridA':     np.array( [ -1.0, -1.0, -1.0 ] ),
-    'FFgridB':     np.array( [ -1.0, -1.0, -1.0 ] ),
-    'FFgridC':     np.array( [ -1.0, -1.0, -1.0 ] ),
-    'moleculeShift':  np.array( [  0.0,      0.0,    0.0 ] ),
-    'probeType':   'O',
-    'charge':      0.00,
-    'Apauli':    18.0,
-    'Bpauli':     1.0,
-    'ffModel':     'LJ',
-    'Rcore':    0.7,
-    'r0Probe'  :  np.array( [ 0.00, 0.00, 4.00] ),
-    'stiffness':  np.array( [ -1.0, -1.0, -1.0] ),
-    'klat': 0.5,
-    'krad': 20.00,
-    'tip':  's',
-    'sigma': 0.7,
-    'scanStep': np.array( [ 0.10, 0.10, 0.10 ] ),
-    'scanMin': np.array( [   0.0,     0.0,    5.0 ] ),
-    'scanMax': np.array( [  20.0,    20.0,    8.0 ] ),
-    'scanTilt': np.array( [  0.0,    0.0,   -0.1 ] ),
-    'tiltedScan': False,
-    'kCantilever'  :  1800.0,
-    'f0Cantilever' :  30300.0,
-    'Amplitude'    :  1.0,
-    'plotSliceFrom':  16,
-    'plotSliceTo'  :  22,
-    'plotSliceBy'  :  1,
-    'imageInterpolation': 'bicubic',
-    'colorscale'   : 'gray',
-    'colorscale_kpfm'   : 'seismic',
-    'ddisp'        :  0.05,
-    'aMorse'       :  -1.6,
-    'tip_base':  np.array( ['None', 0.00 ]),
-    'Rtip'         :  30.0,
-    'permit'       :  0.00552634959,
-    'vdWDampKind' : 2,
-    '#' : None
+params = {
+    "PBC": True,
+    "nPBC": np.array([1, 1, 1]),
+    "gridN": np.array([-1, -1, -1]).astype(int),
+    "gridA": np.array([0.0, 0.0, 0.0]),
+    "gridB": np.array([0.0, 0.0, 0.0]),
+    "gridC": np.array([0.0, 0.0, 0.0]),
+    "FFgrid0": np.array([-1.0, -1.0, -1.0]),
+    "FFgridA": np.array([-1.0, -1.0, -1.0]),
+    "FFgridB": np.array([-1.0, -1.0, -1.0]),
+    "FFgridC": np.array([-1.0, -1.0, -1.0]),
+    "moleculeShift": np.array([0.0, 0.0, 0.0]),
+    "probeType": "O",
+    "charge": 0.00,
+    "Apauli": 18.0,
+    "Bpauli": 1.0,
+    "ffModel": "LJ",
+    "Rcore": 0.7,
+    "r0Probe": np.array([0.00, 0.00, 4.00]),
+    "stiffness": np.array([-1.0, -1.0, -1.0]),
+    "klat": 0.5,
+    "krad": 20.00,
+    "tip": "s",
+    "sigma": 0.7,
+    "scanStep": np.array([0.10, 0.10, 0.10]),
+    "scanMin": np.array([0.0, 0.0, 5.0]),
+    "scanMax": np.array([20.0, 20.0, 8.0]),
+    "scanTilt": np.array([0.0, 0.0, -0.1]),
+    "tiltedScan": False,
+    "kCantilever": 1800.0,
+    "f0Cantilever": 30300.0,
+    "Amplitude": 1.0,
+    "plotSliceFrom": 16,
+    "plotSliceTo": 22,
+    "plotSliceBy": 1,
+    "imageInterpolation": "bicubic",
+    "colorscale": "gray",
+    "colorscale_kpfm": "seismic",
+    "ddisp": 0.05,
+    "aMorse": -1.6,
+    "tip_base": np.array(["None", 0.00]),
+    "Rtip": 30.0,
+    "permit": 0.00552634959,
+    "vdWDampKind": 2,
+    "#": None,
 }
 
+
 class CLIParser(ArgumentParser):
-    '''
+    """
     Subclass from the built-in ArgumentParser with functionality to easily add arguments commonly used in ppafm scripts.
-    '''
+    """
 
     _cli_args = None
     _params_args = {
-        'Amplitude': {
-            'short_name': '-a',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Oscillation amplitude [Å]'
+        "Amplitude": {
+            "short_name": "-a",
+            "action": "store",
+            "type": float,
+            "help": "Oscillation amplitude [Å]",
         },
-        'klat': {
-            'short_name': '-k',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Lateral tip stiffness [N/m]'
+        "klat": {
+            "short_name": "-k",
+            "action": "store",
+            "type": float,
+            "help": "Lateral tip stiffness [N/m]",
         },
-        'charge': {
-            'short_name': '-q',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Probe particle charge [e]'
+        "charge": {
+            "short_name": "-q",
+            "action": "store",
+            "type": float,
+            "help": "Probe particle charge [e]",
         },
-        'tip': {
-            'short_name': '-t',
-            'action'    : 'store',
-            'type'      : str,
-            'default'   : 's',
-            'help'      : 'Tip model (multipole) {s,pz,dz2,..}'
+        "tip": {
+            "short_name": "-t",
+            "action": "store",
+            "type": str,
+            "default": "s",
+            "help": "Tip model (multipole) {s,pz,dz2,..}",
         },
-        'Rcore': {
-            'action'    : 'store',
-            'type'      : float,
-            'default'   : params['Rcore'],
-            'help'      : 'Width of nuclear charge density blob to achieve charge neutrality [Å]'
+        "Rcore": {
+            "action": "store",
+            "type": float,
+            "default": params["Rcore"],
+            "help": "Width of nuclear charge density blob to achieve charge neutrality [Å]",
         },
-        'sigma': {
-            'short_name': '-w',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Gaussian width for convolution in Electrostatics [Å]'
+        "sigma": {
+            "short_name": "-w",
+            "action": "store",
+            "type": float,
+            "help": "Gaussian width for convolution in Electrostatics [Å]",
         },
-        'Apauli': {
-            'short_name': '-A',
-            'action'    : 'store',
-            'type'      : float,
-            'default'   : 1.0,
-            'help'      : 'Prefactor A in the density overlap integral.'
+        "Apauli": {
+            "short_name": "-A",
+            "action": "store",
+            "type": float,
+            "default": 1.0,
+            "help": "Prefactor A in the density overlap integral.",
         },
-        'Bpauli': {
-            'short_name': '-B',
-            'action'    : 'store',
-            'type'      : float,
-            'default'   : -1.0,
-            'help'      : 'Exponent B in the density overlap integral. Negative value is equivalent to B=1.'
+        "Bpauli": {
+            "short_name": "-B",
+            "action": "store",
+            "type": float,
+            "default": -1.0,
+            "help": "Exponent B in the density overlap integral. Negative value is equivalent to B=1.",
         },
-        'ffModel': {
-            'action'    : 'store',
-            'default'   : 'LJ',
-            'help'      : "Force field model ('LJ','Morse','vdW')"
+        "ffModel": {
+            "action": "store",
+            "default": "LJ",
+            "help": "Force field model ('LJ','Morse','vdW')",
         },
     }
     _extra_args = {
-        'input': {
-            'short_name': '-i',
-            'action'    : 'store',
-            'required'  : True,
-            'help'      : 'Input file path. Mandatory. Supported formats are: .xyz, .cube, .xsf.'
+        "input": {
+            "short_name": "-i",
+            "action": "store",
+            "required": True,
+            "help": "Input file path. Mandatory. Supported formats are: .xyz, .cube, .xsf.",
         },
-        'input_format' : {
-            'short_name': '-F',
-            'action'    : 'store',
-            'default'   : None,
-            'help'      : 'Specify the input file format. By default the format is inferred from the file extension.'
+        "input_format": {
+            "short_name": "-F",
+            "action": "store",
+            "default": None,
+            "help": "Specify the input file format. By default the format is inferred from the file extension.",
         },
-        'output_format' : {
-            'short_name': '-f',
-            'action'    : 'store',
-            'default'   : 'xsf',
-            'help'      : 'Specify the output format. Supported formats are: xsf, npy'
+        "output_format": {
+            "short_name": "-f",
+            "action": "store",
+            "default": "xsf",
+            "help": "Specify the output format. Supported formats are: xsf, npy",
         },
-        'noPBC': {
-            'action'    : 'store_false',
-            'dest'      : 'PBC',
-            'default'   : None,
-            'help'      : 'Disable periodic boundary conditions.'
+        "noPBC": {
+            "action": "store_false",
+            "dest": "PBC",
+            "default": None,
+            "help": "Disable periodic boundary conditions.",
         },
-        'energy': {
-            'short_name': '-E',
-            'action'    : 'store_true',
-            'default'   : False,
-            'help'      : 'Compute the potential energy in addition to the force.'
+        "energy": {
+            "short_name": "-E",
+            "action": "store_true",
+            "default": False,
+            "help": "Compute the potential energy in addition to the force.",
         },
-        'krange': {
-            'action'    : 'store',
-            'type'      : float,
-            'nargs'     : 3,
-            'metavar'   : ('k_min', 'k_max', 'n_k'),
-            'help'      : 'Do scan for a range of tip stiffnesses. Overrides --klat.'
+        "krange": {
+            "action": "store",
+            "type": float,
+            "nargs": 3,
+            "metavar": ("k_min", "k_max", "n_k"),
+            "help": "Do scan for a range of tip stiffnesses. Overrides --klat.",
         },
-        'qrange': {
-            'action'    : 'store',
-            'type'      : float,
-            'nargs'     : 3,
-            'metavar'   : ('q_min', 'q_max', 'n_q'),
-            'help'      : 'Do scan for a range of tip charges. Overrides --charge.'
+        "qrange": {
+            "action": "store",
+            "type": float,
+            "nargs": 3,
+            "metavar": ("q_min", "q_max", "n_q"),
+            "help": "Do scan for a range of tip charges. Overrides --charge.",
         },
-        'arange': {
-            'action'    : 'store',
-            'type'      : float,
-            'nargs'     : 3,
-            'metavar'   : ('A_min', 'A_max', 'n_A'),
-            'help'      : 'Do scan for a range of amplitudes. Overrides --Amplitude.'
+        "arange": {
+            "action": "store",
+            "type": float,
+            "nargs": 3,
+            "metavar": ("A_min", "A_max", "n_A"),
+            "help": "Do scan for a range of amplitudes. Overrides --Amplitude.",
         },
-        'Vbias': {
-            'short_name': '-V',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Applied bias voltage [V].'
+        "Vbias": {
+            "short_name": "-V",
+            "action": "store",
+            "type": float,
+            "help": "Applied bias voltage [V].",
         },
-        'Vrange': {
-            'action'    : 'store',
-            'type'      : float,
-            'nargs'     : 3,
-            'metavar'   : ('V_min', 'V_max', 'n_V'),
-            'help'      : 'Do scan for a range of voltages. Overrides --Vbias.'
+        "Vrange": {
+            "action": "store",
+            "type": float,
+            "nargs": 3,
+            "metavar": ("V_min", "V_max", "n_V"),
+            "help": "Do scan for a range of voltages. Overrides --Vbias.",
         },
     }
 
     def _check_params_args(self):
         for arg in self._params_args:
             if arg not in params:
-                raise ValueError(f'Argument name `{arg}` does not match with any parameter in global parameters dictionary.')
+                raise ValueError(
+                    f"Argument name `{arg}` does not match with any parameter in global parameters dictionary."
+                )
 
     @property
     def cli_args(self):
-        '''Dictionary of arguments.'''
+        """Dictionary of arguments."""
         if self._cli_args is None:
             self._check_params_args()
             self._cli_args = {**self._params_args, **self._extra_args}
         return self._cli_args
 
     def add_arguments(self, arg_names):
-        '''
+        """
         Add CLI arguments from predefined dictionary :data:`cli_params`.
 
         Arguments:
             arg_names: list of str. Names of arguments to add.
-        '''
+        """
         for name in arg_names:
             if name not in self.cli_args:
-                raise ValueError(f'Invalid argument name `{name}`')
+                raise ValueError(f"Invalid argument name `{name}`")
             arg_dict = self.cli_args[name]
-            if 'help' not in arg_dict:
-                raise ValueError(f'No help message defined for `{name}`')
-            if 'short_name' in arg_dict:
-                arg_names = [arg_dict['short_name'], f'--{name}']
-                del arg_dict['short_name']
+            if "help" not in arg_dict:
+                raise ValueError(f"No help message defined for `{name}`")
+            if "short_name" in arg_dict:
+                arg_names = [arg_dict["short_name"], f"--{name}"]
+                del arg_dict["short_name"]
             else:
-                arg_names = [f'--{name}']
+                arg_names = [f"--{name}"]
             self.add_argument(*arg_names, **arg_dict)
+
 
 # ==============================
 # ============================== Pure python functions
 # ==============================
 
-def getDfWeight( n, dz=0.1 ):
-    '''
-    conversion of vertical force Fz to frequency shift
-    according to:
-    Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
-    oscialltion amplitude of cantilever is A = n * dz
-    '''
-    x  = np.linspace(-1,1,n+1)
-    y  = np.sqrt(1-x*x)
-    dy =  ( y[1:] - y[:-1] )/(dz*n)
-    fpi    = (n-2)**2
-    prefactor = -1 * ( 1 + fpi*(2/np.pi) ) / (fpi+1) # correction for small n
-    return dy*prefactor, (x[1:]+x[:-1])*0.5
 
-def Fz2df( F, dz=0.1, k0 = params['kCantilever'], f0=params['f0Cantilever'], n=4, units=16.0217656 ):
-    '''
+def getDfWeight(n, dz=0.1):
+    """
     conversion of vertical force Fz to frequency shift
     according to:
     Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
     oscialltion amplitude of cantilever is A = n * dz
-    '''
-    W,xs = getDfWeight( n, dz=dz )
-    dFconv = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F )
-    return dFconv*units*f0/k0
+    """
+    x = np.linspace(-1, 1, n + 1)
+    y = np.sqrt(1 - x * x)
+    dy = (y[1:] - y[:-1]) / (dz * n)
+    fpi = (n - 2) ** 2
+    prefactor = -1 * (1 + fpi * (2 / np.pi)) / (fpi + 1)  # correction for small n
+    return dy * prefactor, (x[1:] + x[:-1]) * 0.5
 
-def Fz2df_tilt( F,  d=params['scanTilt'], k0 = params['kCantilever'], f0=params['f0Cantilever'], n=4, units=16.0217656 ):
-    '''
+
+def Fz2df(
+    F,
+    dz=0.1,
+    k0=params["kCantilever"],
+    f0=params["f0Cantilever"],
+    n=4,
+    units=16.0217656,
+):
+    """
     conversion of vertical force Fz to frequency shift
     according to:
     Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
     oscialltion amplitude of cantilever is A = n * dz
-    '''
-    dr = np.sqrt( d[0]**2 + d[1]**2 + d[2]**2 )
-    W,xs = getDfWeight( n, dz=dr )
-    dFconv_x = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F[:,:,:,0] )
-    dFconv_y = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F[:,:,:,1] )
-    dFconv_z = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F[:,:,:,2] )
-    return (dFconv_x*d[0] + dFconv_y*d[1] + dFconv_z*d[2] )*units*f0/k0
+    """
+    W, xs = getDfWeight(n, dz=dz)
+    dFconv = np.apply_along_axis(
+        lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F
+    )
+    return dFconv * units * f0 / k0
+
+
+def Fz2df_tilt(
+    F,
+    d=params["scanTilt"],
+    k0=params["kCantilever"],
+    f0=params["f0Cantilever"],
+    n=4,
+    units=16.0217656,
+):
+    """
+    conversion of vertical force Fz to frequency shift
+    according to:
+    Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
+    oscialltion amplitude of cantilever is A = n * dz
+    """
+    dr = np.sqrt(d[0] ** 2 + d[1] ** 2 + d[2] ** 2)
+    W, xs = getDfWeight(n, dz=dr)
+    dFconv_x = np.apply_along_axis(
+        lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F[:, :, :, 0]
+    )
+    dFconv_y = np.apply_along_axis(
+        lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F[:, :, :, 1]
+    )
+    dFconv_z = np.apply_along_axis(
+        lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F[:, :, :, 2]
+    )
+    return (dFconv_x * d[0] + dFconv_y * d[1] + dFconv_z * d[2]) * units * f0 / k0
+
 
 def rotation_matrix(axis, theta):
     """
     Return the rotation matrix associated with counterclockwise rotation about
     the given axis by theta radians.
     """
-    axis    =  np.asarray(axis)
-    axis    =  axis/np.sqrt(np.dot(axis, axis))
-    a       =  np.cos(theta/2.0)
-    b, c, d = -axis*np.sin(theta/2.0)
-    aa, bb, cc, dd = a*a, b*b, c*c, d*d
-    bc, ad, ac, ab, bd, cd = b*c, a*d, a*c, a*b, b*d, c*d
-    return np.array([[aa+bb-cc-dd, 2*(bc+ad), 2*(bd-ac)],
-                     [2*(bc-ad), aa+cc-bb-dd, 2*(cd+ab)],
-                     [2*(bd+ac), 2*(cd-ab), aa+dd-bb-cc]])
+    axis = np.asarray(axis)
+    axis = axis / np.sqrt(np.dot(axis, axis))
+    a = np.cos(theta / 2.0)
+    b, c, d = -axis * np.sin(theta / 2.0)
+    aa, bb, cc, dd = a * a, b * b, c * c, d * d
+    bc, ad, ac, ab, bd, cd = b * c, a * d, a * c, a * b, b * d, c * d
+    return np.array(
+        [
+            [aa + bb - cc - dd, 2 * (bc + ad), 2 * (bd - ac)],
+            [2 * (bc - ad), aa + cc - bb - dd, 2 * (cd + ab)],
+            [2 * (bd + ac), 2 * (cd - ab), aa + dd - bb - cc],
+        ]
+    )
 
-def makeRotJitter( n=10, maxAngle=0.3 ):
+
+def makeRotJitter(n=10, maxAngle=0.3):
     rotJitter = []
     nrn = 50
-    rnjit = (np.random.rand(nrn,4) - 0.5) * 2
+    rnjit = (np.random.rand(nrn, 4) - 0.5) * 2
     for i in range(nrn):
-        axis = rnjit[i,:3] /np.sqrt( np.dot(rnjit[i,:3],rnjit[i,:3]) )
-        rotJitter.append( rotation_matrix(axis, rnjit[i,3]*maxAngle  ) )
+        axis = rnjit[i, :3] / np.sqrt(np.dot(rnjit[i, :3], rnjit[i, :3]))
+        rotJitter.append(rotation_matrix(axis, rnjit[i, 3] * maxAngle))
     return rotJitter
 
-def genRotations( axis, thetas ):
-    return np.array( [ rotation_matrix(axis, theta) for theta in thetas ] )
+
+def genRotations(axis, thetas):
+    return np.array([rotation_matrix(axis, theta) for theta in thetas])
+
 
 def sphereTangentSpace(n=100):
-    golden_angle = np.pi * ( 3.0 - np.sqrt(5.0) )
-    theta  = golden_angle * np.arange(n)
-    z      = np.linspace(1.0 - 1.0/n, 1.0/n - 1.0, n)
-    radius = np.sqrt( 1.0 - z*z )
-    cas  = np.cos(theta)
-    sas  = np.sin(theta)
-    rots = np.zeros( (n,3,3) )
-    rots[:,2,0] = radius * cas
-    rots[:,2,1] = radius * sas
-    rots[:,2,2] = z
-    rots[:,0,0] = -sas
-    rots[:,0,1] =  cas
-    rots[:,1,:] =  np.cross( rots[:,2,:], rots[:,0,:] )
+    golden_angle = np.pi * (3.0 - np.sqrt(5.0))
+    theta = golden_angle * np.arange(n)
+    z = np.linspace(1.0 - 1.0 / n, 1.0 / n - 1.0, n)
+    radius = np.sqrt(1.0 - z * z)
+    cas = np.cos(theta)
+    sas = np.sin(theta)
+    rots = np.zeros((n, 3, 3))
+    rots[:, 2, 0] = radius * cas
+    rots[:, 2, 1] = radius * sas
+    rots[:, 2, 2] = z
+    rots[:, 0, 0] = -sas
+    rots[:, 0, 1] = cas
+    rots[:, 1, :] = np.cross(rots[:, 2, :], rots[:, 0, :])
     return rots
 
+
 def maxAlongDir(atoms, hdir):
-    xdir = np.dot( atoms[:,:3], hdir[:,None] )
+    xdir = np.dot(atoms[:, :3], hdir[:, None])
     imin = np.argmax(xdir)
     return imin, xdir[imin][0]
 
-def maxAlongDirEntropy(atoms, hdir, beta=1.0 ):
-    xdir = np.dot( atoms[:,:3], hdir[:,None] )
+
+def maxAlongDirEntropy(atoms, hdir, beta=1.0):
+    xdir = np.dot(atoms[:, :3], hdir[:, None])
     imin = np.argmax(xdir)
-    entropy = np.sum( np.exp( beta*(xdir - xdir[imin]) ) )
+    entropy = np.sum(np.exp(beta * (xdir - xdir[imin])))
     return imin, xdir[imin][0], entropy
 
 
@@ -328,311 +367,411 @@ def maxAlongDirEntropy(atoms, hdir, beta=1.0 ):
 # ==============================  server interface file I/O
 # ==============================
 
+
 def autoGridN():
-    params["gridN"][0]=round(np.linalg.norm(params["gridA"])*10)
-    params["gridN"][1]=round(np.linalg.norm(params["gridB"])*10)
-    params["gridN"][2]=round(np.linalg.norm(params["gridC"])*10)
+    params["gridN"][0] = round(np.linalg.norm(params["gridA"]) * 10)
+    params["gridN"][1] = round(np.linalg.norm(params["gridB"]) * 10)
+    params["gridN"][2] = round(np.linalg.norm(params["gridC"]) * 10)
     return params["gridN"]
 
 
 # overide default parameters by parameters read from a file
-def loadParams( fname ):
-    if(verbose>0): print(" >> OVERWRITING SETTINGS by "+fname)
+def loadParams(fname):
+    if verbose > 0:
+        print(" >> OVERWRITING SETTINGS by " + fname)
     fin = open(fname)
     for line in fin:
-        words=line.split()
-        if len(words)>=2:
+        words = line.split()
+        if len(words) >= 2:
             key = words[0]
             if key in params:
                 val = params[key]
-                if key[0][0] == '#' : continue
-                if(verbose>0): print(key,' is class ', val.__class__)
-                if   isinstance( val, bool ):
-                    word=words[1].strip()
-                    if (word[0]=="T") or (word[0]=="t"):
+                if key[0][0] == "#":
+                    continue
+                if verbose > 0:
+                    print(key, " is class ", val.__class__)
+                if isinstance(val, bool):
+                    word = words[1].strip()
+                    if (word[0] == "T") or (word[0] == "t"):
                         params[key] = True
                     else:
                         params[key] = False
-                    if(verbose>0): print(key, params[key], ">>",word,"<<")
-                elif isinstance( val, float ):
-                    params[key] = float( words[1] )
-                    if(verbose>0): print(key, params[key], words[1])
-                elif   isinstance( val, int ):
-                    params[key] = int( words[1] )
-                    if(verbose>0): print(key, params[key], words[1])
-                elif isinstance( val, str ):
+                    if verbose > 0:
+                        print(key, params[key], ">>", word, "<<")
+                elif isinstance(val, float):
+                    params[key] = float(words[1])
+                    if verbose > 0:
+                        print(key, params[key], words[1])
+                elif isinstance(val, int):
+                    params[key] = int(words[1])
+                    if verbose > 0:
+                        print(key, params[key], words[1])
+                elif isinstance(val, str):
                     params[key] = words[1]
-                    if(verbose>0): print(key, params[key], words[1])
-                elif isinstance(val, np.ndarray ):
+                    if verbose > 0:
+                        print(key, params[key], words[1])
+                elif isinstance(val, np.ndarray):
                     if val.dtype == float:
-                        params[key] = np.array([ float(words[1]), float(words[2]), float(words[3]) ])
-                        if(verbose>0): print(key, params[key], words[1], words[2], words[3])
+                        params[key] = np.array(
+                            [float(words[1]), float(words[2]), float(words[3])]
+                        )
+                        if verbose > 0:
+                            print(key, params[key], words[1], words[2], words[3])
                     elif val.dtype == int:
-                        if(verbose>0): print(key)
-                        params[key] = np.array([ int(words[1]), int(words[2]), int(words[3]) ])
-                        if(verbose>0): print(key, params[key], words[1], words[2], words[3])
+                        if verbose > 0:
+                            print(key)
+                        params[key] = np.array(
+                            [int(words[1]), int(words[2]), int(words[3])]
+                        )
+                        if verbose > 0:
+                            print(key, params[key], words[1], words[2], words[3])
                     else:
-                        params[key] = np.array([ str(words[1]), float(words[2]) ])
-                        if(verbose>0): print(key, params[key], words[1], words[2])
-            else :
+                        params[key] = np.array([str(words[1]), float(words[2])])
+                        if verbose > 0:
+                            print(key, params[key], words[1], words[2])
+            else:
                 raise ValueError(f"Parameter {key} is not known")
     fin.close()
-    if (params["gridN"][0]<=0):
-        autoGridN()
 
-    params["tip"] = params["tip"].replace('"', ''); params["tip"] = params["tip"].replace("'", ''); ### necessary for working even with quotemarks in params.ini
-    params["tip_base"][0] = params["tip_base"][0].replace('"', ''); params["tip_base"][0] = params["tip_base"][0].replace("'", ''); ### necessary for working even with quotemarks in params.ini
+    params["tip"] = params["tip"].replace('"', "")
+    params["tip"] = params["tip"].replace("'", "")
+    ### necessary for working even with quotemarks in params.ini
+    params["tip_base"][0] = params["tip_base"][0].replace('"', "")
+    params["tip_base"][0] = params["tip_base"][0].replace("'", "")
+    ### necessary for working even with quotemarks in params.ini
+
 
 def apply_options(opt):
-    if(verbose>0): print("!!!! OVERRIDE params !!!! in Apply options:")
-    if(verbose>0): print(opt)
+    if verbose > 0:
+        print("!!!! OVERRIDE params !!!! in Apply options:")
+    if verbose > 0:
+        print(opt)
     for key, value in opt.items():
         if value is None:
             continue
         if key in params:
             params[key] = value
-            if key == 'klat' and params['stiffness'][0] > 0.0:
-                print('Overriding stiffness parameter with klat')
-                params['stiffness'] = np.array( [ -1.0, -1.0, -1.0] ) # klat overrides stiffness
-            if(verbose>0): print(f'Applied: {key} = {value}')
+            if key == "klat" and params["stiffness"][0] > 0.0:
+                print("Overriding stiffness parameter with klat")
+                params["stiffness"] = np.array(
+                    [-1.0, -1.0, -1.0]
+                )  # klat overrides stiffness
+            if verbose > 0:
+                print(f"Applied: {key} = {value}")
 
-# load atoms species parameters form a file ( currently used to load Lenard-Jones parameters )
-def loadSpecies( fname=None ):
+
+# load atoms species parameters form a file ( currently used to load Lennard-Jones parameters )
+def loadSpecies(fname=None):
     if fname is None or not os.path.exists(fname):
-        if(verbose>0): print("WARRNING: loadSpecies(None) => load default atomtypes.ini")
-        fname = cpp_utils.PACKAGE_PATH / 'defaults' / 'atomtypes.ini'
-    if(verbose>0): print(" loadSpecies from ", fname)
-    #FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('atom',int),('symbol', '|S10')],usecols=[0,1,2,3])
-    FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('alpha',np.float64),('atom',int),('symbol', '|S10')],usecols=(0,1,2,3,4))
+        if verbose > 0:
+            print("WARRNING: loadSpecies(None) => load default atomtypes.ini")
+        fname = cpp_utils.PACKAGE_PATH / "defaults" / "atomtypes.ini"
+    if verbose > 0:
+        print(" loadSpecies from ", fname)
+    # FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('atom',int),('symbol', '|S10')],usecols=[0,1,2,3])
+    FFparams = np.genfromtxt(
+        fname,
+        dtype=[
+            ("rmin", np.float64),
+            ("epsilon", np.float64),
+            ("alpha", np.float64),
+            ("atom", int),
+            ("symbol", "|S10"),
+        ],
+        usecols=(0, 1, 2, 3, 4),
+    )
     return FFparams
 
-# load atoms species parameters form a file ( currently used to load Lenard-Jones parameters )
-def loadSpeciesLines( lines ):
+
+# load atoms species parameters form a file ( currently used to load Lennard-Jones parameters )
+def loadSpeciesLines(lines):
     params = []
     for l in lines:
         l = l.split()
         if len(l) >= 5:
             # print l
-            params.append( ( float(l[0]), float(l[1]), float(l[2]), int(l[3]), l[4] ) )
-    return np.array( params, dtype=[('rmin',np.float64),('epsilon',np.float64),('alpha',np.float64),('atom',int),('symbol', '|S10')])
+            params.append((float(l[0]), float(l[1]), float(l[2]), int(l[3]), l[4]))
+    return np.array(
+        params,
+        dtype=[
+            ("rmin", np.float64),
+            ("epsilon", np.float64),
+            ("alpha", np.float64),
+            ("atom", int),
+            ("symbol", "|S10"),
+        ],
+    )
 
-def autoGeom( Rs, shiftXY=False, fitCell=False, border=3.0 ):
-    '''
+
+def autoGeom(Rs, shiftXY=False, fitCell=False, border=3.0):
+    """
     set Force-Filed and Scanning supercell to fit optimally given geometry
     then shifts the geometry in the center of the supercell
-    '''
-    zmax=max(Rs[2]); 	Rs[2] -= zmax
-    if(verbose>0): print(" autoGeom subtracted zmax = ",zmax)
-    xmin=min(Rs[0]); xmax=max(Rs[0])
-    ymin=min(Rs[1]); ymax=max(Rs[1])
+    """
+    zmax = max(Rs[2])
+    Rs[2] -= zmax
+    if verbose > 0:
+        print(" autoGeom subtracted zmax = ", zmax)
+    xmin = min(Rs[0])
+    xmax = max(Rs[0])
+    ymin = min(Rs[1])
+    ymax = max(Rs[1])
     if fitCell:
-        params[ 'gridA'   ][0] = (xmax-xmin) + 2*border
-        params[ 'gridA'   ][1] = 0
-        params[ 'gridB'   ][0] = 0
-        params[ 'gridB'   ][1] = (ymax-ymin) + 2*border
-        params[ 'scanMin' ][0] = 0
-        params[ 'scanMin' ][1] = 0
-        params[ 'scanMax' ][0] = params[ 'gridA' ][0]
-        params[ 'scanMax' ][1] = params[ 'gridB' ][1]
-        if(verbose>0): print(" autoGeom changed cell to = ", params[ 'scanMax' ])
+        params["gridA"][0] = (xmax - xmin) + 2 * border
+        params["gridA"][1] = 0
+        params["gridB"][0] = 0
+        params["gridB"][1] = (ymax - ymin) + 2 * border
+        params["scanMin"][0] = 0
+        params["scanMin"][1] = 0
+        params["scanMax"][0] = params["gridA"][0]
+        params["scanMax"][1] = params["gridB"][1]
+        if verbose > 0:
+            print(" autoGeom changed cell to = ", params["scanMax"])
     if shiftXY:
-        dx = -0.5*(xmin+xmax) + 0.5*( params[ 'gridA' ][0] + params[ 'gridB' ][0] ); Rs[0] += dx
-        dy = -0.5*(ymin+ymax) + 0.5*( params[ 'gridA' ][1] + params[ 'gridB' ][1] ); Rs[1] += dy;
-        if(verbose>0): print(" autoGeom moved geometry by ",dx,dy)
+        dx = -0.5 * (xmin + xmax) + 0.5 * (params["gridA"][0] + params["gridB"][0])
+        Rs[0] += dx
+        dy = -0.5 * (ymin + ymax) + 0.5 * (params["gridA"][1] + params["gridB"][1])
+        Rs[1] += dy
+        if verbose > 0:
+            print(" autoGeom moved geometry by ", dx, dy)
 
-def wrapAtomsCell( Rs, da, db, avec, bvec ):
-    M    = np.array( (avec[:2],bvec[:2]) )
+
+def wrapAtomsCell(Rs, da, db, avec, bvec):
+    M = np.array((avec[:2], bvec[:2]))
     invM = np.linalg.inv(M)
-    if(verbose>0): print(M)
-    if(verbose>0): print(invM)
-    ABs = np.dot( Rs[:,:2], invM )
-    if(verbose>0): print("ABs.shape", ABs.shape)
-    ABs[:,0] = (ABs[:,0] +10+da)%1.0
-    ABs[:,1] = (ABs[:,1] +10+db)%1.0
-    Rs[:,:2] = np.dot( ABs, M )
+    if verbose > 0:
+        print(M)
+    if verbose > 0:
+        print(invM)
+    ABs = np.dot(Rs[:, :2], invM)
+    if verbose > 0:
+        print("ABs.shape", ABs.shape)
+    ABs[:, 0] = (ABs[:, 0] + 10 + da) % 1.0
+    ABs[:, 1] = (ABs[:, 1] + 10 + db) % 1.0
+    Rs[:, :2] = np.dot(ABs, M)
 
-def PBCAtoms( Zs, Rs, Qs, avec, bvec, na=None, nb=None ):
-    '''
+
+def PBCAtoms(Zs, Rs, Qs, avec, bvec, na=None, nb=None):
+    """
     multiply atoms of sample along supercell vectors
     the multiplied sample geometry is used for evaluation of forcefield in Periodic-boundary-Conditions ( PBC )
-    '''
+    """
     Zs_ = []
     Rs_ = []
     Qs_ = []
-    if na is None: na=params['nPBC'][0]
-    if nb is None: nb=params['nPBC'][1]
-    for i in range(-na,na+1):
-        for j in range(-nb,nb+1):
+    if na is None:
+        na = params["nPBC"][0]
+    if nb is None:
+        nb = params["nPBC"][1]
+    for i in range(-na, na + 1):
+        for j in range(-nb, nb + 1):
             for iatom in range(len(Zs)):
-                x = Rs[iatom][0] + i*avec[0] + j*bvec[0]
-                y = Rs[iatom][1] + i*avec[1] + j*bvec[1]
-                Zs_.append( Zs[iatom]          )
-                Rs_.append( (x,y,Rs[iatom][2]) )
-                Qs_.append( Qs[iatom]          )
+                x = Rs[iatom][0] + i * avec[0] + j * bvec[0]
+                y = Rs[iatom][1] + i * avec[1] + j * bvec[1]
+                Zs_.append(Zs[iatom])
+                Rs_.append((x, y, Rs[iatom][2]))
+                Qs_.append(Qs[iatom])
     return np.array(Zs_).copy(), np.array(Rs_).copy(), np.array(Qs_).copy()
 
-def PBCAtoms3D( Zs, Rs, Qs, cLJs, lvec, npbc=[1,1,1] ):
-    '''
+
+def PBCAtoms3D(Zs, Rs, Qs, cLJs, lvec, npbc=[1, 1, 1]):
+    """
     multiply atoms of sample along supercell vectors
     the multiplied sample geometry is used for evaluation of forcefield in Periodic-boundary-Conditions ( PBC )
-    '''
-    Zs_   = []
-    Rs_   = []
-    Qs_   = []
+    """
+    Zs_ = []
+    Rs_ = []
+    Qs_ = []
     cLJs_ = []
     for iatom in range(len(Zs)):
-        Zs_.append( Zs[iatom] )
-        Rs_.append( Rs[iatom] )
-        Qs_.append( Qs[iatom] )
-    for ia in range(-npbc[0],npbc[0]+1):
-        for ib in range(-npbc[1],npbc[1]+1):
-            for ic in range(-npbc[2],npbc[2]+1):
-                if (ia==0) and (ib==0) and (ic==0) :
+        Zs_.append(Zs[iatom])
+        Rs_.append(Rs[iatom])
+        Qs_.append(Qs[iatom])
+    for ia in range(-npbc[0], npbc[0] + 1):
+        for ib in range(-npbc[1], npbc[1] + 1):
+            for ic in range(-npbc[2], npbc[2] + 1):
+                if (ia == 0) and (ib == 0) and (ic == 0):
                     continue
                 for iatom in range(len(Zs)):
-                    x = Rs[iatom][0] + ia*lvec[0][0] + ib*lvec[1][0] + ic*lvec[2][0]
-                    y = Rs[iatom][1] + ia*lvec[0][1] + ib*lvec[1][1] + ic*lvec[2][1]
-                    z = Rs[iatom][2] + ia*lvec[0][2] + ib*lvec[1][2] + ic*lvec[2][2]
-                    Zs_.append( Zs[iatom] )
-                    Rs_.append( (x,y,z)   )
-                    Qs_.append( Qs[iatom] )
-                    cLJs_.append( cLJs[iatom,:] )
-    return np.array(Zs_).copy(), np.array(Rs_).copy(), np.array(Qs_).copy(), np.array(cLJs_).copy()
+                    x = (
+                        Rs[iatom][0]
+                        + ia * lvec[0][0]
+                        + ib * lvec[1][0]
+                        + ic * lvec[2][0]
+                    )
+                    y = (
+                        Rs[iatom][1]
+                        + ia * lvec[0][1]
+                        + ib * lvec[1][1]
+                        + ic * lvec[2][1]
+                    )
+                    z = (
+                        Rs[iatom][2]
+                        + ia * lvec[0][2]
+                        + ib * lvec[1][2]
+                        + ic * lvec[2][2]
+                    )
+                    Zs_.append(Zs[iatom])
+                    Rs_.append((x, y, z))
+                    Qs_.append(Qs[iatom])
+                    cLJs_.append(cLJs[iatom, :])
+    return (
+        np.array(Zs_).copy(),
+        np.array(Rs_).copy(),
+        np.array(Qs_).copy(),
+        np.array(cLJs_).copy(),
+    )
 
-def findPBCAtoms3D_cutoff( Rs, lvec, Rcut=1.0, corners=None ):
-    '''
+
+def findPBCAtoms3D_cutoff(Rs, lvec, Rcut=1.0, corners=None):
+    """
     find which atoms with positions 'Rs' and radius 'Rcut' thouch rhombic cell defined by 3x3 matrix 'lvec';
        or more precisely which points 'Rs' belong to a rhombic cell enlarged by margin Rcut on each side
     all assuming that 'Rcut' is smaller than the rhombic cell (in all directions)
-    '''
+    """
     invLvec = np.linalg.inv(lvec)
-    abc = np.dot( invLvec, Rs )  # atoms in grid coordinates
+    abc = np.dot(invLvec, Rs)  # atoms in grid coordinates
     # calculate margin on each side in grid coordinates
-    ra  = np.sqrt(np.dot(invLvec[0],invLvec[0]));   mA = ra*Rcut
-    rb  = np.sqrt(np.dot(invLvec[1],invLvec[1]));   mB = rb*Rcut
-    rc  = np.sqrt(np.dot(invLvec[2],invLvec[2]));   mC = rc*Rcut
-    cells = [-1,0,1]
-    inds  = []
-    Rs_   = []
-    a = abc[0];
-    b = abc[1];
-    c = abc[2];
+    ra = np.sqrt(np.dot(invLvec[0], invLvec[0]))
+    mA = ra * Rcut
+    rb = np.sqrt(np.dot(invLvec[1], invLvec[1]))
+    mB = rb * Rcut
+    rc = np.sqrt(np.dot(invLvec[2], invLvec[2]))
+    mC = rc * Rcut
+    cells = [-1, 0, 1]
+    inds = []
+    Rs_ = []
+    a = abc[0]
+    b = abc[1]
+    c = abc[2]
     i = 0
     for ia in cells:
-        mask_a  = (a>(-mA-ia)) & (a<(mA+1-ia))
-        shift_a = ia*lvec[0,:]
+        mask_a = (a > (-mA - ia)) & (a < (mA + 1 - ia))
+        shift_a = ia * lvec[0, :]
         for ib in cells:
-            mask_ab  = (b>(-mB-ib)) & (b<(mB+1-ib)) & mask_a
-            shift_ab = ib*lvec[1,:] + shift_a
+            mask_ab = (b > (-mB - ib)) & (b < (mB + 1 - ib)) & mask_a
+            shift_ab = ib * lvec[1, :] + shift_a
             for ic in cells:
-                v_shift  = ic*lvec[2,:] + shift_ab
-                mask = mask_ab & (c>(-mC-ic)) & (c<(mC+1-ic))
-                inds_abc = np.nonzero( mask )[0]
-                if len(inds_abc)==0: continue
-                Rs_abc   = Rs[:,inds_abc]
-                Rs_abc  += v_shift[:,None]
-                inds.append( inds_abc )
-                Rs_ .append( Rs_abc   )
-                i+=1
-    inds = np.concatenate( inds )
-    Rs_  = np.hstack( Rs_  )
+                v_shift = ic * lvec[2, :] + shift_ab
+                mask = mask_ab & (c > (-mC - ic)) & (c < (mC + 1 - ic))
+                inds_abc = np.nonzero(mask)[0]
+                if len(inds_abc) == 0:
+                    continue
+                Rs_abc = Rs[:, inds_abc]
+                Rs_abc += v_shift[:, None]
+                inds.append(inds_abc)
+                Rs_.append(Rs_abc)
+                i += 1
+    inds = np.concatenate(inds)
+    Rs_ = np.hstack(Rs_)
 
     if corners is not None:
-        corns = np.array([
-            [ -mA, -mB, -mC],
-            [ -mA, -mB,1+mC],
-            [ -mA,1+mB, -mC],
-            [ -mA,1+mB,1+mC],
-            [1+mA, -mB, -mC],
-            [1+mA, -mB,1+mC],
-            [1+mA,1+mB, -mC],
-            [1+mA,1+mB,1+mC],
-        ]).transpose()
-        corners.append( np.dot(lvec,corns) )
+        corns = np.array(
+            [
+                [-mA, -mB, -mC],
+                [-mA, -mB, 1 + mC],
+                [-mA, 1 + mB, -mC],
+                [-mA, 1 + mB, 1 + mC],
+                [1 + mA, -mB, -mC],
+                [1 + mA, -mB, 1 + mC],
+                [1 + mA, 1 + mB, -mC],
+                [1 + mA, 1 + mB, 1 + mC],
+            ]
+        ).transpose()
+        corners.append(np.dot(lvec, corns))
 
     return inds, Rs_
 
 
-def PBCAtoms3D_np( Zs, Rs, Qs, cLJs, REAs, lvec, npbc=[1,1,1] ):
-    '''
+def PBCAtoms3D_np(Zs, Rs, Qs, cLJs, REAs, lvec, npbc=[1, 1, 1]):
+    """
     multiply atoms of sample along supercell vectors
     the multiplied sample geometry is used for evaluation of forcefield in Periodic-boundary-Conditions ( PBC )
-    '''
-    #print( "PBCAtoms3D_np lvec", lvec )
-    mx = npbc[0]*2 + 1
-    my = npbc[1]*2 + 1
-    mz = npbc[2]*2 + 1
-    mtot = mx*my*mz
+    """
+    # print( "PBCAtoms3D_np lvec", lvec )
+    mx = npbc[0] * 2 + 1
+    my = npbc[1] * 2 + 1
+    mz = npbc[2] * 2 + 1
+    mtot = mx * my * mz
     natom = len(Zs)
     matom = mtot * natom
-    Zs_    = np.empty(  matom   , np.int32  )
-    xyzs_ = np.empty( (matom,3), np.float32)
-    qs_ = np.empty( (matom,), np.float32)
+    Zs_ = np.empty(matom, np.int32)
+    xyzs_ = np.empty((matom, 3), np.float32)
+    qs_ = np.empty((matom,), np.float32)
     if cLJs is not None:
-        cLJs_  = np.empty( (matom,2), np.float32)
+        cLJs_ = np.empty((matom, 2), np.float32)
     else:
-        cLJs_=None
+        cLJs_ = None
     if REAs is not None:
-        REAs_ = np.empty( (matom,4), np.float32)
+        REAs_ = np.empty((matom, 4), np.float32)
     else:
         REAs_ = None
     i0 = 0
     i1 = i0 + natom
     # we want to have cell=(0,0,0) first
-    Zs_   [i0:i1] = Zs[:  ]
-    xyzs_ [i0:i1] = Rs[:,:]
-    qs_   [i0:i1] = Qs[:  ]
+    Zs_[i0:i1] = Zs[:]
+    xyzs_[i0:i1] = Rs[:, :]
+    qs_[i0:i1] = Qs[:]
     if cLJs is not None:
-        cLJs_ [i0:i1,: ] = cLJs[:,:]
+        cLJs_[i0:i1, :] = cLJs[:, :]
     if REAs is not None:
-        REAs_ [i0:i1,: ] = REAs[:,:]
+        REAs_[i0:i1, :] = REAs[:, :]
     i0 += natom
-    for ia in range(-npbc[0],npbc[0]+1):
-        for ib in range(-npbc[1],npbc[1]+1):
-            for ic in range(-npbc[2],npbc[2]+1):
-                if (ia==0) and (ib==0) and (ic==0) : continue
-                v_shift = ia*lvec[0,:] + ib*lvec[1,:] + ic*lvec[2,:]
+    for ia in range(-npbc[0], npbc[0] + 1):
+        for ib in range(-npbc[1], npbc[1] + 1):
+            for ic in range(-npbc[2], npbc[2] + 1):
+                if (ia == 0) and (ib == 0) and (ic == 0):
+                    continue
+                v_shift = ia * lvec[0, :] + ib * lvec[1, :] + ic * lvec[2, :]
                 i1 = i0 + natom
-                Zs_  [i0:i1] = Zs[:  ]
-                xyzs_[i0:i1] = Rs[:,:] + v_shift[None,:]
-                qs_  [i0:i1] = Qs[:  ]
+                Zs_[i0:i1] = Zs[:]
+                xyzs_[i0:i1] = Rs[:, :] + v_shift[None, :]
+                qs_[i0:i1] = Qs[:]
                 if cLJs is not None:
-                    cLJs_ [i0:i1,: ] = cLJs[:,:]
+                    cLJs_[i0:i1, :] = cLJs[:, :]
                 if REAs is not None:
-                    REAs_ [i0:i1,: ] = REAs[:,:]
+                    REAs_[i0:i1, :] = REAs[:, :]
                 i0 += natom
     return Zs_, xyzs_, qs_, cLJs_, REAs_
 
-def multRot( Zs, Rs, Qs, cLJs, rots, cog = (0,0,0) ):
-    '''
+
+def multRot(Zs, Rs, Qs, cLJs, rots, cog=(0, 0, 0)):
+    """
     multiply atoms of sample along supercell vectors
     the multiplied sample geometry is used for evaluation of forcefield in Periodic-boundary-Conditions ( PBC )
-    '''
-    Zs_   = []
-    Rs_   = []
-    Qs_   = []
+    """
+    Zs_ = []
+    Rs_ = []
+    Qs_ = []
     cLJs_ = []
     for rot in rots:
         for iatom in range(len(Zs)):
-            xyz = ( Rs[iatom][0] -cog[0],  Rs[iatom][1] -cog[1], Rs[iatom][2] -cog[2] )
-            x = xyz[0]*rot[0][0] + xyz[1]*rot[0][1] + xyz[2]*rot[0][2]    + cog[0]
-            y = xyz[0]*rot[1][0] + xyz[1]*rot[1][1] + xyz[2]*rot[1][2]    + cog[1]
-            z = xyz[0]*rot[2][0] + xyz[1]*rot[2][1] + xyz[2]*rot[2][2]    + cog[2]
-            Zs_.append( Zs[iatom] )
-            Rs_.append( (x,y,z)   )
-            Qs_.append( Qs[iatom] )
-            cLJs_.append( cLJs[iatom,:] )
-    return np.array(Zs_).copy(), np.array(Rs_).copy(), np.array(Qs_).copy(), np.array(cLJs_).copy()
+            xyz = (Rs[iatom][0] - cog[0], Rs[iatom][1] - cog[1], Rs[iatom][2] - cog[2])
+            x = xyz[0] * rot[0][0] + xyz[1] * rot[0][1] + xyz[2] * rot[0][2] + cog[0]
+            y = xyz[0] * rot[1][0] + xyz[1] * rot[1][1] + xyz[2] * rot[1][2] + cog[1]
+            z = xyz[0] * rot[2][0] + xyz[1] * rot[2][1] + xyz[2] * rot[2][2] + cog[2]
+            Zs_.append(Zs[iatom])
+            Rs_.append((x, y, z))
+            Qs_.append(Qs[iatom])
+            cLJs_.append(cLJs[iatom, :])
+    return (
+        np.array(Zs_).copy(),
+        np.array(Rs_).copy(),
+        np.array(Qs_).copy(),
+        np.array(cLJs_).copy(),
+    )
 
 
-def getFFdict( FFparams ):
-    elem_dict={}
-    for i,ff in enumerate(FFparams):
-        if(verbose>0): print(i,ff)
-        elem_dict[ff[4]] = i+1
+def getFFdict(FFparams):
+    elem_dict = {}
+    for i, ff in enumerate(FFparams):
+        if verbose > 0:
+            print(i, ff)
+        elem_dict[ff[4]] = i + 1
     return elem_dict
 
-def atom2iZ( atm, elem_dict ):
+
+def atom2iZ(atm, elem_dict):
     try:
         return int(atm)
     except:
@@ -641,149 +780,192 @@ def atom2iZ( atm, elem_dict ):
         except:
             raise ValueError(f"Did not find atomkind: {atm}")
 
-def atoms2iZs( names, elem_dict ):
-    return np.array( [atom2iZ(name,elem_dict) for name in names], dtype=np.int32 )
 
-def parseAtoms( atoms, elem_dict, PBC=True, autogeom=False, lvec=None ):
-    Rs = np.array([atoms[1],atoms[2],atoms[3]]);
+def atoms2iZs(names, elem_dict):
+    return np.array([atom2iZ(name, elem_dict) for name in names], dtype=np.int32)
+
+
+def parseAtoms(atoms, elem_dict, PBC=True, autogeom=False, lvec=None):
+    Rs = np.array([atoms[1], atoms[2], atoms[3]])
     if elem_dict is None:
-        if(verbose>0): print("WARRNING: elem_dict is None => iZs are zero")
-        iZs=np.zeros( len(atoms[0]) )
+        if verbose > 0:
+            print("WARRNING: elem_dict is None => iZs are zero")
+        iZs = np.zeros(len(atoms[0]))
     else:
-        iZs = atoms2iZs( atoms[0], elem_dict )
+        iZs = atoms2iZs(atoms[0], elem_dict)
     if autogeom:
-        if(verbose>0): print("WARRNING: autoGeom shifts atoms")
-        autoGeom( Rs, shiftXY=True,  fitCell=True,  border=3.0 )
-    Rs = np.transpose( Rs, (1,0) ).copy()
-    Qs = np.array( atoms[4] )
+        if verbose > 0:
+            print("WARRNING: autoGeom shifts atoms")
+        autoGeom(Rs, shiftXY=True, fitCell=True, border=3.0)
+    Rs = np.transpose(Rs, (1, 0)).copy()
+    Qs = np.array(atoms[4])
     if PBC:
-        if lvec is not None: avec=lvec[1];         bvec=lvec[2]
-        else:                avec=params['gridA']; bvec=params['gridB']
-        iZs,Rs,Qs = PBCAtoms( iZs, Rs, Qs, avec=avec, bvec=bvec )
-    return iZs,Rs,Qs
+        if lvec is not None:
+            avec = lvec[1]
+            bvec = lvec[2]
+        else:
+            avec = params["gridA"]
+            bvec = params["gridB"]
+        iZs, Rs, Qs = PBCAtoms(iZs, Rs, Qs, avec=avec, bvec=bvec)
+    return iZs, Rs, Qs
 
-def get_C612( i, j, FFparams ):
-    '''
-    compute Lenard-Jones coefitioens C6 and C12 pair of atoms i,j
-    '''
+
+def get_C612(i, j, FFparams):
+    """
+    compute Lennard-Jones coefitioens C6 and C12 pair of atoms i,j
+    """
     Rij = FFparams[i][0] + FFparams[j][0]
-    Eij = np.sqrt( FFparams[i][1] * FFparams[j][1] )
-    return 2*Eij*(Rij**6), Eij*(Rij**12)
+    Eij = np.sqrt(FFparams[i][1] * FFparams[j][1])
+    return 2 * Eij * (Rij**6), Eij * (Rij**12)
 
-def getAtomsLJ( iZprobe, iZs,  FFparams ):
-    '''
-    compute Lenard-Jones coefitioens C6 and C12 for interaction between atoms in list "iZs" and probe-particle "iZprobe"
-    '''
-    n   = len(iZs)
-    cLJs  = np.zeros((n,2))
+
+def getAtomsLJ(iZprobe, iZs, FFparams):
+    """
+    compute Lennard-Jones coefitioens C6 and C12 for interaction between atoms in list "iZs" and probe-particle "iZprobe"
+    """
+    n = len(iZs)
+    cLJs = np.zeros((n, 2))
     for i in range(n):
-        cLJs[i,0],cLJs[i,1] = get_C612( iZprobe-1, iZs[i]-1, FFparams )
+        cLJs[i, 0], cLJs[i, 1] = get_C612(iZprobe - 1, iZs[i] - 1, FFparams)
     return cLJs
 
-def REA2LJ( cREAs, cLJs=None ):
+
+def REA2LJ(cREAs, cLJs=None):
     if cLJs is None:
-        cLJs = np.zeros((len(cREAs),2))
-    R6   = cREAs[:,0]**6
-    cLJs[:,0] = 2*cREAs[:,1] *  R6
-    cLJs[:,1] =   cREAs[:,1] * (R6**2)
+        cLJs = np.zeros((len(cREAs), 2))
+    R6 = cREAs[:, 0] ** 6
+    cLJs[:, 0] = 2 * cREAs[:, 1] * R6
+    cLJs[:, 1] = cREAs[:, 1] * (R6**2)
     return cLJs
 
-def getAtomsREA(  iZprobe, iZs,  FFparams, alphaFac=-1.0 ):
-    '''
-    compute Lenard-Jones coefitioens C6 and C12 for interaction between atoms in list "iZs" and probe-particle "iZprobe"
-    '''
-    n   = len(iZs)
-    REAs  = np.zeros( (n,4) )
-    i = iZprobe-1
+
+def getAtomsREA(iZprobe, iZs, FFparams, alphaFac=-1.0):
+    """
+    compute Lennard-Jones coefitioens C6 and C12 for interaction between atoms in list "iZs" and probe-particle "iZprobe"
+    """
+    n = len(iZs)
+    REAs = np.zeros((n, 4))
+    i = iZprobe - 1
     for ii in range(n):
-        j = iZs[ii]-1
-        REAs[ii,0] = FFparams[i][0] + FFparams[j][0]
-        REAs[ii,1] = np.sqrt( FFparams[i][1] * FFparams[j][1] )
-        REAs[ii,2] = FFparams[j][2] * alphaFac
+        j = iZs[ii] - 1
+        REAs[ii, 0] = FFparams[i][0] + FFparams[j][0]
+        REAs[ii, 1] = np.sqrt(FFparams[i][1] * FFparams[j][1])
+        REAs[ii, 2] = FFparams[j][2] * alphaFac
     return REAs
 
-def getSampleAtomsREA( iZs, FFparams ):
-    return np.array( [ ( FFparams[i-1][0],FFparams[i-1][1],FFparams[i-1][2] ) for i in iZs ] )
 
-def getAtomsRE(  iZprobe, iZs,  FFparams ):
-    n   = len(iZs)
-    Rpp = FFparams[iZprobe-1][0]
-    Epp = FFparams[iZprobe-1][1]
-    REs = np.array( [ ( Rpp+ FFparams[iZs[i]-1][0],  Epp * FFparams[iZs[i]-1][1] )  for i in range(n) ] )
-    REs[:,1] = np.sqrt(REs[:,1])
+def getSampleAtomsREA(iZs, FFparams):
+    return np.array(
+        [(FFparams[i - 1][0], FFparams[i - 1][1], FFparams[i - 1][2]) for i in iZs]
+    )
+
+
+def getAtomsRE(iZprobe, iZs, FFparams):
+    n = len(iZs)
+    Rpp = FFparams[iZprobe - 1][0]
+    Epp = FFparams[iZprobe - 1][1]
+    REs = np.array(
+        [
+            (Rpp + FFparams[iZs[i] - 1][0], Epp * FFparams[iZs[i] - 1][1])
+            for i in range(n)
+        ]
+    )
+    REs[:, 1] = np.sqrt(REs[:, 1])
     return REs
 
-def getAtomsLJ_fast( iZprobe, iZs,  FFparams ):
-    R = np.array( [ FFparams[i-1][0] for i in iZs ] )
-    E = np.array( [ FFparams[i-1][1] for i in iZs ] )
-    R+=FFparams[iZprobe-1][0]
-    E=np.sqrt(E*FFparams[iZprobe-1][1]);
-    cLJs = np.zeros((len(E),2))
-    cLJs[:,0] = E         * 2  *R6    # C6  = 2*Eij*(Rij**6 )
-    cLJs[:,1] = cLJs[:,0] * 0.5*R6    # C12 =   Eij*(Rij**12)
+
+def getAtomsLJ_fast(iZprobe, iZs, FFparams):
+    R = np.array([FFparams[i - 1][0] for i in iZs])
+    E = np.array([FFparams[i - 1][1] for i in iZs])
+    R += FFparams[iZprobe - 1][0]
+    E = np.sqrt(E * FFparams[iZprobe - 1][1])
+    cLJs = np.zeros((len(E), 2))
+    cLJs[:, 0] = E * 2 * R6  # C6  = 2*Eij*(Rij**6 )
+    cLJs[:, 1] = cLJs[:, 0] * 0.5 * R6  # C12 =   Eij*(Rij**12)
     return cLJs
+
 
 # ============= Hi-Level Macros
 
-def prepareScanGrids( ):
-    '''
+
+def prepareScanGrids():
+    """
     Defines the grid over which the tip will scan, according to scanMin, scanMax, and scanStep.
     The origin of the grid is going to be shifted (from scanMin) by the bond length between the "Probe Particle"
     and the "Apex", so that while the point of reference on the tip used to interpret scanMin  was the Apex,
     the new point of reference used in the XSF output will be the Probe Particle.
-    '''
-    zTips  = np.arange( params['scanMin'][2], params['scanMax'][2]+0.00001, params['scanStep'][2] )
-    xTips  = np.arange( params['scanMin'][0], params['scanMax'][0]+0.00001, params['scanStep'][0] )
-    yTips  = np.arange( params['scanMin'][1], params['scanMax'][1]+0.00001, params['scanStep'][1] )
-    ( xTips[0], xTips[-1], yTips[0], yTips[-1] )
-    lvecScan =np.array([
-        [(params['scanMin'] + params['r0Probe'])[0],
-         (params['scanMin'] + params['r0Probe'])[1],
-         (params['scanMin'] - params['r0Probe'])[2] ] ,
-        [        (params['scanMax']-params['scanMin'])[0],0.0,0.0],
-        [0.0,    (params['scanMax']-params['scanMin'])[1],0.0    ],
-        [0.0,0.0,(params['scanMax']-params['scanMin'])[2]        ]
-    ]).copy()
-    return xTips,yTips,zTips,lvecScan
+    """
+    zTips = np.arange(
+        params["scanMin"][2], params["scanMax"][2] + 0.00001, params["scanStep"][2]
+    )
+    xTips = np.arange(
+        params["scanMin"][0], params["scanMax"][0] + 0.00001, params["scanStep"][0]
+    )
+    yTips = np.arange(
+        params["scanMin"][1], params["scanMax"][1] + 0.00001, params["scanStep"][1]
+    )
+    (xTips[0], xTips[-1], yTips[0], yTips[-1])
+    lvecScan = np.array(
+        [
+            [
+                (params["scanMin"] + params["r0Probe"])[0],
+                (params["scanMin"] + params["r0Probe"])[1],
+                (params["scanMin"] - params["r0Probe"])[2],
+            ],
+            [(params["scanMax"] - params["scanMin"])[0], 0.0, 0.0],
+            [0.0, (params["scanMax"] - params["scanMin"])[1], 0.0],
+            [0.0, 0.0, (params["scanMax"] - params["scanMin"])[2]],
+        ]
+    ).copy()
+    return xTips, yTips, zTips, lvecScan
 
-def lvec2params( lvec ):
-    params['gridA'] = lvec[ 1,: ].copy()
-    params['gridB'] = lvec[ 2,: ].copy()
-    params['gridC'] = lvec[ 3,: ].copy()
 
-def params2lvec( ):
-    lvec = np.array([
-        [ 0.0, 0.0, 0.0 ],
-        params['gridA'],
-        params['gridB'],
-        params['gridC'],
-    ]).copy
+def lvec2params(lvec):
+    params["gridA"] = lvec[1, :].copy()
+    params["gridB"] = lvec[2, :].copy()
+    params["gridC"] = lvec[3, :].copy()
+
+
+def params2lvec():
+    lvec = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            params["gridA"],
+            params["gridB"],
+            params["gridC"],
+        ]
+    ).copy
     return lvec
 
 
-def genFFSampling( lvec, pixPerAngstrome=10 ):
-    nDim = np.array([
-        int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[1],lvec[1])) )),
-        int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[2],lvec[2])) )),
-        int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[3],lvec[3])) )),
-        4,
-    ], np.int32 )
+def genFFSampling(lvec, pixPerAngstrome=10):
+    nDim = np.array(
+        [
+            int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[1], lvec[1])))),
+            int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[2], lvec[2])))),
+            int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[3], lvec[3])))),
+            4,
+        ],
+        np.int32,
+    )
     return nDim
 
-def getPos( lvec, nDim=None, pixPerAngstrome=10 ):
+
+def getPos(lvec, nDim=None, pixPerAngstrome=10):
     if nDim is None:
-        nDim =  genFFSampling( lvec, pixPerAngstrome=pixPerAngstrome )
-    dCell = np.array( ( lvec[1,:]/nDim[2], lvec[2,:]/nDim[1], lvec[3,:]/nDim[0] ) )
-    ABC   = np.mgrid[0:nDim[0],0:nDim[1],0:nDim[2]]
-    X = lvec[0,0] + ABC[2]*dCell[0,0] + ABC[1]*dCell[1,0] + ABC[0]*dCell[2,0]
-    Y = lvec[0,1] + ABC[2]*dCell[0,1] + ABC[1]*dCell[1,1] + ABC[0]*dCell[2,1]
-    Z = lvec[0,2] + ABC[2]*dCell[0,2] + ABC[1]*dCell[1,2] + ABC[0]*dCell[2,2]
+        nDim = genFFSampling(lvec, pixPerAngstrome=pixPerAngstrome)
+    dCell = np.array((lvec[1, :] / nDim[2], lvec[2, :] / nDim[1], lvec[3, :] / nDim[0]))
+    ABC = np.mgrid[0 : nDim[0], 0 : nDim[1], 0 : nDim[2]]
+    X = lvec[0, 0] + ABC[2] * dCell[0, 0] + ABC[1] * dCell[1, 0] + ABC[0] * dCell[2, 0]
+    Y = lvec[0, 1] + ABC[2] * dCell[0, 1] + ABC[1] * dCell[1, 1] + ABC[0] * dCell[2, 1]
+    Z = lvec[0, 2] + ABC[2] * dCell[0, 2] + ABC[1] * dCell[1, 2] + ABC[0] * dCell[2, 2]
     return X, Y, Z
 
-def getPos_Vec3d( lvec, nDim=None, pixPerAngstrome=10 ):
-    X,Y,Z = getPos( lvec, nDim=nDim, pixPerAngstrome=pixPerAngstrome )
-    XYZ = np.empty( X.shape + (3,) )
-    XYZ[:,:,:,0] = X
-    XYZ[:,:,:,1] = Y
-    XYZ[:,:,:,2] = Z
+
+def getPos_Vec3d(lvec, nDim=None, pixPerAngstrome=10):
+    X, Y, Z = getPos(lvec, nDim=nDim, pixPerAngstrome=pixPerAngstrome)
+    XYZ = np.empty(X.shape + (3,))
+    XYZ[:, :, :, 0] = X
+    XYZ[:, :, :, 1] = Y
+    XYZ[:, :, :, 2] = Z
     return XYZ

--- a/ppafm/core.py
+++ b/ppafm/core.py
@@ -13,174 +13,244 @@ from .io import bohrRadius2angstroem
 # ============================== interface to C++ core
 # ==============================
 
-lib = cpp_utils.get_cdll('PP')
+lib = cpp_utils.get_cdll("PP")
 
 # define used numpy array types for interfacing with C++
-array1i = np.ctypeslib.ndpointer(dtype=np.int32,  ndim=1, flags='CONTIGUOUS')
-array1d = np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags='CONTIGUOUS')
-array2d = np.ctypeslib.ndpointer(dtype=np.double, ndim=2, flags='CONTIGUOUS')
-array3d = np.ctypeslib.ndpointer(dtype=np.double, ndim=3, flags='CONTIGUOUS')
-array4d = np.ctypeslib.ndpointer(dtype=np.double, ndim=4, flags='CONTIGUOUS')
+array1i = np.ctypeslib.ndpointer(dtype=np.int32, ndim=1, flags="CONTIGUOUS")
+array1d = np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags="CONTIGUOUS")
+array2d = np.ctypeslib.ndpointer(dtype=np.double, ndim=2, flags="CONTIGUOUS")
+array3d = np.ctypeslib.ndpointer(dtype=np.double, ndim=3, flags="CONTIGUOUS")
+array4d = np.ctypeslib.ndpointer(dtype=np.double, ndim=4, flags="CONTIGUOUS")
 
 # ========
 # ======== Python warper function for C++ functions
 # ========
 
-#void setGridN( int * n ){
+# void setGridN( int * n ){
 lib.setGridN.argtypes = [array1i]
-lib.setGridN.restype  = None
+lib.setGridN.restype = None
+
+
 def setGridN(n):
-    n=np.array(n, dtype=np.int32).copy()
+    n = np.array(n, dtype=np.int32).copy()
     lib.setGridN(n)
 
-#void setGridCell( double * cell ){
-lib.setGridCell.argtypes = [array2d]
-lib.setGridCell.restype  = None
-def setGridCell( cell=None):
-    if( cell is None ):
-        cell = np.array([
-            PPU.params['gridA'],
-            PPU.params['gridB'],
-            PPU.params['gridC'],
-        ], dtype=np.float64 ).copy()
-    cell = np.array( cell, dtype=np.float64 )
-    if   cell.shape == (3,3): cell = cell.copy()
-    elif cell.shape == (4,3): cell = cell[1:,:].copy()
-    else: raise ValueError("cell has wrong format"); exit()
-    print("cell", cell)
-    lib.setGridCell( cell )
 
-def setFF_shape( n_, cell ):
+# void setGridCell( double * cell ){
+lib.setGridCell.argtypes = [array2d]
+lib.setGridCell.restype = None
+
+
+def setGridCell(cell=None):
+    if cell is None:
+        cell = np.array(
+            [
+                PPU.params["gridA"],
+                PPU.params["gridB"],
+                PPU.params["gridC"],
+            ],
+            dtype=np.float64,
+        ).copy()
+    cell = np.array(cell, dtype=np.float64)
+    if cell.shape == (3, 3):
+        cell = cell.copy()
+    elif cell.shape == (4, 3):
+        cell = cell[1:, :].copy()
+    else:
+        raise ValueError("cell has wrong format")
+        exit()
+    print("cell", cell)
+    lib.setGridCell(cell)
+
+
+def setFF_shape(n_, cell):
     n = np.array(n_).astype(np.int32)
-    lib.setGridN    ( n    )
-    setGridCell( cell )
+    lib.setGridN(n)
+    setGridCell(cell)
+
 
 # void setFF_pointer( double * gridF, double * gridE  )
 lib.setFF_Fpointer.argtypes = [array4d]
-lib.setFF_Fpointer.restype  = None
-def setFF_Fpointer( gridF ):
-    lib.setFF_Fpointer( gridF )
+lib.setFF_Fpointer.restype = None
+
+
+def setFF_Fpointer(gridF):
+    lib.setFF_Fpointer(gridF)
+
 
 # void setFF_pointer( double * gridF, double * gridE  )
 lib.setFF_Epointer.argtypes = [array3d]
-lib.setFF_Epointer.restype  = None
-def setFF_Epointer( gridE ):
-    lib.setFF_Epointer( gridE )
+lib.setFF_Epointer.restype = None
 
-def setFF( cell=None, gridF=None, gridE=None ):
+
+def setFF_Epointer(gridE):
+    lib.setFF_Epointer(gridE)
+
+
+def setFF(cell=None, gridF=None, gridE=None):
     n_ = None
     if gridF is not None:
-        setFF_Fpointer( gridF )
-        n_    = np.shape(gridF)
+        setFF_Fpointer(gridF)
+        n_ = np.shape(gridF)
     if gridE is not None:
-        setFF_Epointer( gridE )
-        n_    = np.shape(gridF)
+        setFF_Epointer(gridE)
+        n_ = np.shape(gridF)
     if cell is None:
-        cell = np.array([
-            PPU.params['gridA'],
-            PPU.params['gridB'],
-            PPU.params['gridC'],
-        ]).copy()
+        cell = np.array(
+            [
+                PPU.params["gridA"],
+                PPU.params["gridB"],
+                PPU.params["gridC"],
+            ]
+        ).copy()
     if n_ is not None:
         print("setFF() n_ : ", n_)
-        setFF_shape( n_, cell )
+        setFF_shape(n_, cell)
     else:
-        "Warrning : setFF shape not set !!! "
+        "Warrning : setFF shape not set !!!"
 
 
-#void setRelax( int maxIters, double convF2, double dt, double damping )
-lib.setRelax.argtypes = [ c_int, c_double, c_double, c_double ]
-lib.setRelax.restype  = None
-def setRelax( maxIters  = 1000, convF2 = 1.0e-4, dt = 0.1, damping = 0.1 ):
-    lib.setRelax( maxIters, convF*convF, dt, damping )
-
-#void setFIRE( double finc, double fdec, double falpha )
-lib.setFIRE.argtypes = [ c_double, c_double, c_double ]
-lib.setFIRE.restype  = None
-def setFIRE( finc = 1.1, fdec = 0.5, falpha  = 0.99 ):
-    lib.setFIRE( finc, fdec, falpha )
+# void setRelax( int maxIters, double convF2, double dt, double damping )
+lib.setRelax.argtypes = [c_int, c_double, c_double, c_double]
+lib.setRelax.restype = None
 
 
-#void setTip( double lRad, double kRad, double * rPP0, double * kSpring )
-lib.setTip.argtypes = [ c_double, c_double, array1d, array1d ]
-lib.setTip.restype  = None
-def setTip( lRadial=None, kRadial=None, rPP0=None, kSpring=None	):
+def setRelax(maxIters=1000, convF2=1.0e-4, dt=0.1, damping=0.1):
+    lib.setRelax(maxIters, convF * convF, dt, damping)
+
+
+# void setFIRE( double finc, double fdec, double falpha )
+lib.setFIRE.argtypes = [c_double, c_double, c_double]
+lib.setFIRE.restype = None
+
+
+def setFIRE(finc=1.1, fdec=0.5, falpha=0.99):
+    lib.setFIRE(finc, fdec, falpha)
+
+
+# void setTip( double lRad, double kRad, double * rPP0, double * kSpring )
+lib.setTip.argtypes = [c_double, c_double, array1d, array1d]
+lib.setTip.restype = None
+
+
+def setTip(lRadial=None, kRadial=None, rPP0=None, kSpring=None):
     if lRadial is None:
-        lRadial=PPU.params['r0Probe'][2]
-    if kRadial is  None:
-        kRadial=PPU.params['krad']/-PPU.eVA_Nm
-    if rPP0 is  None:
-        rPP0=np.array((PPU.params['r0Probe'][0],PPU.params['r0Probe'][1],0.0))
-    if kSpring is  None:
-        kSpring=np.array((PPU.params['klat'],PPU.params['klat'],0.0))/-PPU.eVA_Nm
+        lRadial = PPU.params["r0Probe"][2]
+    if kRadial is None:
+        kRadial = PPU.params["krad"] / -PPU.eVA_Nm
+    if rPP0 is None:
+        rPP0 = np.array((PPU.params["r0Probe"][0], PPU.params["r0Probe"][1], 0.0))
+    if kSpring is None:
+        kSpring = np.array((PPU.params["klat"], PPU.params["klat"], 0.0)) / -PPU.eVA_Nm
     print(" IN setTip !!!!!!!!!!!!!! ")
     print(" lRadial ", lRadial)
     print(" kRadial ", kRadial)
     print(" rPP0 ", rPP0)
     print(" kSpring ", kSpring)
-    lib.setTip( lRadial, kRadial, rPP0, kSpring )
+    lib.setTip(lRadial, kRadial, rPP0, kSpring)
 
-#void setTipSpline( int n, double * xs, double * ydys ){
-lib.setTipSpline.argtypes = [ c_int, array1d, array2d ]
-lib.setTipSpline.restype  = None
-def setTipSpline( xs, ydys	):
+
+# void setTipSpline( int n, double * xs, double * ydys ){
+lib.setTipSpline.argtypes = [c_int, array1d, array2d]
+lib.setTipSpline.restype = None
+
+
+def setTipSpline(xs, ydys):
     n = len(xs)
-    lib.setTipSpline( n, xs, ydys )
+    lib.setTipSpline(n, xs, ydys)
 
-#void getInPoints_LJ( int npoints, double * points, double * FEs, int natoms_, double * Ratoms_, double * cLJs ){
-lib.getInPoints_LJ.argtypes = [ c_int, array2d, array2d, c_int, array2d, array2d ]
-lib.getInPoints_LJ.restype  = None
-def getInPoints_LJ( ps, Rs, cLJs, FEs=None ):
-    nats = len(Rs); npts = len(ps)
-    if FEs is None: FEs=np.zeros((npts,4));
-    lib.getInPoints_LJ( npts, ps, FEs, nats, Rs, cLJs)
+
+# void getInPoints_LJ( int npoints, double * points, double * FEs, int natoms_, double * Ratoms_, double * cLJs ){
+lib.getInPoints_LJ.argtypes = [c_int, array2d, array2d, c_int, array2d, array2d]
+lib.getInPoints_LJ.restype = None
+
+
+def getInPoints_LJ(ps, Rs, cLJs, FEs=None):
+    nats = len(Rs)
+    npts = len(ps)
+    if FEs is None:
+        FEs = np.zeros((npts, 4))
+    lib.getInPoints_LJ(npts, ps, FEs, nats, Rs, cLJs)
     return FEs
 
-#void evalRadialFF( int n, double* rs, double* coefs, double* Es, double* Fs, int kind ){
-lib.evalRadialFF.argtypes  = [ c_int,  array1d,  array1d,  array1d, array1d, c_int, c_double ]
-lib.evalRadialFF.restype   = None
-def evalRadialFF( rs, coefs, Es=None, Fs=None, kind=1, ADamp=-1 ):
+
+# void evalRadialFF( int n, double* rs, double* coefs, double* Es, double* Fs, int kind ){
+lib.evalRadialFF.argtypes = [c_int, array1d, array1d, array1d, array1d, c_int, c_double]
+lib.evalRadialFF.restype = None
+
+
+def evalRadialFF(rs, coefs, Es=None, Fs=None, kind=1, ADamp=-1):
     n = len(rs)
-    if(Es is None): Es = np.zeros(n)
-    if(Fs is None): Fs = np.zeros(n)
+    if Es is None:
+        Es = np.zeros(n)
+    if Fs is None:
+        Fs = np.zeros(n)
     coefs = np.array(coefs, dtype=np.float64)
-    lib.evalRadialFF( n, rs, coefs, Es, Fs, kind, ADamp )
-    return Es,Fs
+    lib.evalRadialFF(n, rs, coefs, Es, Fs, kind, ADamp)
+    return Es, Fs
+
 
 # void getClassicalFF       (    int natom,   double * Rs_, double * cLJs )
-lib.getLenardJonesFF.argtypes  = [ c_int,       array2d,      array2d     ]
-lib.getLenardJonesFF.restype   = None
-def getLenardJonesFF( Rs, cLJs ):
+lib.getLennardJonesFF.argtypes = [c_int, array2d, array2d]
+lib.getLennardJonesFF.restype = None
+
+
+def getLennardJonesFF(Rs, cLJs):
     natom = len(Rs)
-    lib.getLenardJonesFF( natom, Rs, cLJs )
+    lib.getLennardJonesFF(natom, Rs, cLJs)
+
 
 # void getClassicalFF       (    int natom,   double * Rs_, double * cLJs )
-lib.getVdWFF.argtypes  = [ c_int,       array2d,      array2d     ]
-lib.getVdWFF.restype   = None
-def getVdWFF( Rs, cLJs ):
+lib.getVdWFF.argtypes = [c_int, array2d, array2d]
+lib.getVdWFF.restype = None
+
+
+def getVdWFF(Rs, cLJs):
     natom = len(Rs)
-    lib.getVdWFF( natom, Rs, cLJs )
+    lib.getVdWFF(natom, Rs, cLJs)
+
 
 # void getVdWFF_RE( int natoms_, double * Ratoms_, double * REs, int kind, double ADamp_=-1.0 ){
-lib.getVdWFF_RE.argtypes  = [ c_int,       array2d,      array2d, c_int, c_double   ]
-lib.getVdWFF_RE.restype   = None
-def getVdWFF_RE( Rs, REs, kind=0, ADamp=-1. ):
+lib.getVdWFF_RE.argtypes = [c_int, array2d, array2d, c_int, c_double]
+lib.getVdWFF_RE.restype = None
+
+
+def getVdWFF_RE(Rs, REs, kind=0, ADamp=-1.0):
     natom = len(Rs)
-    lib.getVdWFF_RE( natom, Rs, REs, kind, ADamp )
+    lib.getVdWFF_RE(natom, Rs, REs, kind, ADamp)
+
 
 # void getDFTD3FF(int natoms_, double * Ratoms_, double *d3_coeffs)
-lib.getDFTD3FF.argtypes  = [c_int, array2d, array2d]
-lib.getDFTD3FF.restype   = None
+lib.getDFTD3FF.argtypes = [c_int, array2d, array2d]
+lib.getDFTD3FF.restype = None
+
+
 def getDFTD3FF(Rs, d3_coeffs):
     natom = len(Rs)
     lib.getDFTD3FF(natom, Rs, d3_coeffs)
 
+
 # void computeD3Coeffs(
 #    const int natoms_, const double *rs, const double *elems, const double *r_cov, const double *r_cut, const double *ref_cn,
 #    const double *ref_c6, const double *r4r2, const double *k, const double *params, const int elem_pp, double *coeffs
-#)
-lib.computeD3Coeffs.argtypes = [c_int, array2d, array1i, array1d, array1d, array1d, array1d, array1d, array1d, array1d, c_int, array1d]
-lib.computeD3Coeffs.restype  = None
+# )
+lib.computeD3Coeffs.argtypes = [
+    c_int,
+    array2d,
+    array1i,
+    array1d,
+    array1d,
+    array1d,
+    array1d,
+    array1d,
+    array1d,
+    array1d,
+    c_int,
+    array1d,
+]
+lib.computeD3Coeffs.restype = None
+
+
 def computeD3Coeffs(Rs, iZs, iZPP, df_params):
     natom = len(Rs)
     Rs = np.array(Rs, dtype=np.float64)
@@ -191,105 +261,179 @@ def computeD3Coeffs(Rs, iZs, iZPP, df_params):
     r4r2 = d3.R4R2.astype(np.float64)
     ref_c6 = d3.load_ref_c6().astype(np.float64).flatten()
     k = np.array([d3.K1, d3.K2, d3.K3], dtype=np.float64)
-    df_params = np.array([df_params['s6'], df_params['s8'], df_params['a1'], df_params['a2'] * bohrRadius2angstroem], dtype=np.float64)
+    df_params = np.array(
+        [
+            df_params["s6"],
+            df_params["s8"],
+            df_params["a1"],
+            df_params["a2"] * bohrRadius2angstroem,
+        ],
+        dtype=np.float64,
+    )
     coeffs = np.empty(4 * natom, dtype=np.float64)
-    lib.computeD3Coeffs(natom, Rs, iZs, r_cov, r_cut, ref_cn, ref_c6, r4r2, k, df_params, iZPP, coeffs)
+    lib.computeD3Coeffs(
+        natom, Rs, iZs, r_cov, r_cut, ref_cn, ref_c6, r4r2, k, df_params, iZPP, coeffs
+    )
     return coeffs.reshape((natom, 4))
 
+
 # void getClassicalFF       (    int natom,   double * Rs_, double * cLJs )
-lib.getMorseFF.argtypes  = [ c_int,       array2d,      array2d, c_double ]
-lib.getMorseFF.restype   = None
-def getMorseFF( Rs, REs, alpha=None ):
-    if alpha is None: alpha = PPU.params['aMorse']
+lib.getMorseFF.argtypes = [c_int, array2d, array2d, c_double]
+lib.getMorseFF.restype = None
+
+
+def getMorseFF(Rs, REs, alpha=None):
+    if alpha is None:
+        alpha = PPU.params["aMorse"]
     print("getMorseFF: alpha: %g [1/A] ", alpha)
     natom = len(Rs)
-    lib.getMorseFF( natom, Rs, REs, alpha )
+    lib.getMorseFF(natom, Rs, REs, alpha)
+
 
 # void getCoulombFF       (    int natom,   double * Rs_, double * C6, double * C12 )
-lib.getCoulombFF.argtypes  = [ c_int,       array2d,      array1d, c_int   ]
-lib.getCoulombFF.restype   = None
-def getCoulombFF( Rs, kQQs, kind=0 ):
+lib.getCoulombFF.argtypes = [c_int, array2d, array1d, c_int]
+lib.getCoulombFF.restype = None
+
+
+def getCoulombFF(Rs, kQQs, kind=0):
     natom = len(Rs)
-    lib.getCoulombFF( natom, Rs, kQQs, kind )
+    lib.getCoulombFF(natom, Rs, kQQs, kind)
+
 
 # void getGaussDensity( int natoms_, double * Ratoms_, double * cRAs ){
-lib.getGaussDensity.argtypes  = [ c_int,       array2d,      array2d  ]
-lib.getGaussDensity.restype   = None
-def getGaussDensity( Rs, cRAs ):
+lib.getGaussDensity.argtypes = [c_int, array2d, array2d]
+lib.getGaussDensity.restype = None
+
+
+def getGaussDensity(Rs, cRAs):
     natom = len(Rs)
-    lib.getGaussDensity( natom, Rs, cRAs )
+    lib.getGaussDensity(natom, Rs, cRAs)
+
 
 # void getSlaterDensity( int natoms_, double * Ratoms_, double * cRAs ){
-lib.getSlaterDensity.argtypes  = [ c_int,       array2d,      array2d  ]
-lib.getSlaterDensity.restype   = None
-def getSlaterDensity( Rs, cRAs ):
+lib.getSlaterDensity.argtypes = [c_int, array2d, array2d]
+lib.getSlaterDensity.restype = None
+
+
+def getSlaterDensity(Rs, cRAs):
     natom = len(Rs)
-    lib.getSlaterDensity( natom, Rs, cRAs )
+    lib.getSlaterDensity(natom, Rs, cRAs)
+
 
 # void getDensityR4spline( int natoms_, double * Ratoms_, double * cRAs ){
-lib.getDensityR4spline.argtypes  = [ c_int,       array2d,      array2d  ]
-lib.getDensityR4spline.restype   = None
-def getDensityR4spline( Rs, cRAs, bNormalize=True ):
+lib.getDensityR4spline.argtypes = [c_int, array2d, array2d]
+lib.getDensityR4spline.restype = None
+
+
+def getDensityR4spline(Rs, cRAs, bNormalize=True):
     if bNormalize:
-        cRAs[:,0] /= ((np.pi*32)/105)*cRAs[:,1]**3     # see https://www.wolframalpha.com/input/?i=4*pi*x%5E2*%281-x%5E2%29%5E2+integrate+from+0+to+1
+        cRAs[:, 0] /= ((np.pi * 32) / 105) * cRAs[
+            :, 1
+        ] ** 3  # see https://www.wolframalpha.com/input/?i=4*pi*x%5E2*%281-x%5E2%29%5E2+integrate+from+0+to+1
     natom = len(Rs)
-    lib.getDensityR4spline( natom, Rs, cRAs )
+    lib.getDensityR4spline(natom, Rs, cRAs)
+
 
 # int relaxTipStroke ( int probeStart, int nstep, double * rTips_, double * rs_, double * fs_ )
-lib.relaxTipStroke.argtypes  = [ c_int, c_int, c_int,  array2d, array2d, array2d ]
-lib.relaxTipStroke.restype   = c_int
-def relaxTipStroke( rTips, rs, fs, probeStart=1, relaxAlg=1 ):
+lib.relaxTipStroke.argtypes = [c_int, c_int, c_int, array2d, array2d, array2d]
+lib.relaxTipStroke.restype = c_int
+
+
+def relaxTipStroke(rTips, rs, fs, probeStart=1, relaxAlg=1):
     n = len(rTips)
-    return lib.relaxTipStroke( probeStart, relaxAlg, n, rTips, rs, fs )
+    return lib.relaxTipStroke(probeStart, relaxAlg, n, rTips, rs, fs)
+
 
 # void stiffnessMatrix( double ddisp, int which, int n,  double * rTips_, double * rs_,    double * eigenvals_, double * evec1_, double * evec2_, double * evec3_ ){
-lib.stiffnessMatrix.argtypes  = [ c_double, c_int, c_int, array2d, array2d,    array2d, array2d, array2d, array2d  ]
-lib.stiffnessMatrix.restype   = None
-def stiffnessMatrix( rTips, rPPs, which=0, ddisp=0.05 ):
+lib.stiffnessMatrix.argtypes = [
+    c_double,
+    c_int,
+    c_int,
+    array2d,
+    array2d,
+    array2d,
+    array2d,
+    array2d,
+    array2d,
+]
+lib.stiffnessMatrix.restype = None
+
+
+def stiffnessMatrix(rTips, rPPs, which=0, ddisp=0.05):
     n = len(rTips)
-    eigenvals = np.zeros( (n,3) )
+    eigenvals = np.zeros((n, 3))
     # this is really stupid solution because we cannot simply pass null pointer by ctypes; see :
     # https://github.com/numpy/numpy/issues/6239
     # http://stackoverflow.com/questions/32120178/how-can-i-pass-null-to-an-external-library-using-ctypes-with-an-argument-decla
-    evecs = [eigenvals,eigenvals,eigenvals]
-    for i in range(which): evecs[i] = np.zeros( (n,3) )
-    lib.stiffnessMatrix( ddisp, which, n, rTips, rPPs, eigenvals, evecs[0], evecs[1], evecs[2] )
+    evecs = [eigenvals, eigenvals, eigenvals]
+    for i in range(which):
+        evecs[i] = np.zeros((n, 3))
+    lib.stiffnessMatrix(
+        ddisp, which, n, rTips, rPPs, eigenvals, evecs[0], evecs[1], evecs[2]
+    )
     return eigenvals, evecs
 
+
 # void subsample_uniform_spline( double x0, double dx, int n, double * ydys, int m, double * xs_, double * ys_ )
-lib.subsample_uniform_spline.argtypes  = [ c_double, c_double, c_int, array2d, c_int, array1d, array1d ]
-lib.subsample_uniform_spline.restype   = None
-def subsample_uniform_spline( x0, dx, ydys, xs_, ys_=None ):
+lib.subsample_uniform_spline.argtypes = [
+    c_double,
+    c_double,
+    c_int,
+    array2d,
+    c_int,
+    array1d,
+    array1d,
+]
+lib.subsample_uniform_spline.restype = None
+
+
+def subsample_uniform_spline(x0, dx, ydys, xs_, ys_=None):
     n = len(ydys)
     m = len(xs_)
-    if ys_ is None :
+    if ys_ is None:
         ys_ = np.zeros(m)
-    lib.subsample_uniform_spline( x0, dx, n, ydys, m, xs_, ys_ );
-    return ys_;
+    lib.subsample_uniform_spline(x0, dx, n, ydys, m, xs_, ys_)
+    return ys_
+
 
 # void subsample_nonuniform_spline( int n, double * xs, double * ydys, int m, double * xs_, double * ys_ )
-lib.subsample_nonuniform_spline.argtypes  = [ c_int, array1d, array2d, c_int, array1d, array1d ]
-lib.subsample_nonuniform_spline.restype   = None
-def subsample_nonuniform_spline( xs, ydys, xs_, ys_=None ):
-    n = len(xs )
+lib.subsample_nonuniform_spline.argtypes = [
+    c_int,
+    array1d,
+    array2d,
+    c_int,
+    array1d,
+    array1d,
+]
+lib.subsample_nonuniform_spline.restype = None
+
+
+def subsample_nonuniform_spline(xs, ydys, xs_, ys_=None):
+    n = len(xs)
     m = len(xs_)
-    if ys_ is None :
+    if ys_ is None:
         ys_ = np.zeros(m)
-    lib.subsample_nonuniform_spline( n, xs, ydys, m, xs_, ys_ );
-    return ys_;
+    lib.subsample_nonuniform_spline(n, xs, ydys, m, xs_, ys_)
+    return ys_
+
 
 # void test_force( int type, int n, double * r0_, double * dr_, double * R_, double * fs_ ){
-lib.test_force.argtypes  = [ c_int, c_int, array1d, array1d, array1d, array2d ]
-lib.test_force.restype   = None
-def test_force( typ, r0, dr, R, fs ):
-    n = len( fs )
-    lib.test_force( typ, n, r0, dr, R, fs );
-    return fs;
+lib.test_force.argtypes = [c_int, c_int, array1d, array1d, array1d, array2d]
+lib.test_force.restype = None
+
+
+def test_force(typ, r0, dr, R, fs):
+    n = len(fs)
+    lib.test_force(typ, n, r0, dr, R, fs)
+    return fs
+
 
 # void test_eigen3x3( double * mat, double * evs ){
-lib.test_eigen3x3.argtypes  = [ array2d, array2d ]
-lib.test_eigen3x3.restype   = None
-def  test_eigen3x3( mat ):
-    evs = np.zeros((4,3))
-    lib.test_eigen3x3( mat, evs );
-    return evs;
+lib.test_eigen3x3.argtypes = [array2d, array2d]
+lib.test_eigen3x3.restype = None
+
+
+def test_eigen3x3(mat):
+    evs = np.zeros((4, 3))
+    lib.test_eigen3x3(mat, evs)
+    return evs

--- a/ppafm/cpp/ProbeParticle.cpp
+++ b/ppafm/cpp/ProbeParticle.cpp
@@ -457,7 +457,7 @@ DLLEXPORT void computeD3Coeffs(
 
 }
 
-DLLEXPORT void getLenardJonesFF( int natoms_, double * Ratoms_, double * cLJs ){
+DLLEXPORT void getLennardJonesFF( int natoms_, double * Ratoms_, double * cLJs ){
     natoms=natoms_; Ratoms=(Vec3d*)Ratoms_; nCoefPerAtom = 2;
     Vec3d r0; r0.set(0.0,0.0,0.0);
     interateGrid3D < evalCell < addAtom_LJ  > >( r0, gridShape.n, gridShape.dCell, cLJs );

--- a/ppafm/io.py
+++ b/ppafm/io.py
@@ -475,9 +475,24 @@ def loadGeometry(fname=None, format=None, params=None):
     elif format == "npy":
         atoms, nDim, lvec = loadNPYGeom(fname)  # under development
     elif format == "poscar":
-        atoms, nDim, lvec = loadPOSCAR(fname)
+        xyzs, Zs, lvec = loadPOSCAR(fname)
+        atoms = [
+            list(Zs),
+            list(xyzs[:, 0]),
+            list(xyzs[:, 1]),
+            list(xyzs[:, 2]),
+            [0.0 for q in Zs],
+        ]
     elif format == "in":
-        atoms, nDim, lvec = loadGeometryIN(fname)
+        xyzs, Zs, lvec = loadGeometryIN(fname)
+        nDim = params["gridN"].copy()
+        atoms = [
+            list(Zs),
+            list(xyzs[:, 0]),
+            list(xyzs[:, 1]),
+            list(xyzs[:, 2]),
+            [0.0 for q in Zs],
+        ]
     # TODO: introduce a function which reads the geometry from the .npy file
     else:
         if format is None:

--- a/ppafm/io.py
+++ b/ppafm/io.py
@@ -652,9 +652,8 @@ def saveXSF(fname, data, lvec=None, dd=None, head=XSF_HEAD_DEFAULT, verbose=1):
     _writeArr(fileout, (nDim[2] + 1, nDim[1] + 1, nDim[0] + 1))
     _writeArr2D(fileout, lvec)
     data2 = np.zeros(np.array(nDim) + 1)
-    # These crazy 3 lines are here since the first and the last cube
+    # These crazy 3 lines are here since the first and the last cube in XSF in every direction is the same
     data2[:-1, :-1, :-1] = data
-    # in XSF in every direction is the same
     data2[-1, :, :] = data2[0, :, :]
     data2[:, -1, :] = data2[:, 0, :]
     data2[:, :, -1] = data2[:, :, 0]

--- a/ppafm/io.py
+++ b/ppafm/io.py
@@ -9,12 +9,13 @@ from . import elements
 from .GridUtils import readNumsUpTo
 
 bohrRadius2angstroem = 0.5291772109217
-Hartree2eV           = 27.211396132
+Hartree2eV = 27.211396132
 
 verbose = 0
 
+
 def loadXYZ(fname):
-    '''
+    """
     Read the contents of an xyz file.
 
     The standard xyz file format only has per-atom elements and xyz positions. In Probe-Particle
@@ -30,24 +31,26 @@ def loadXYZ(fname):
         Zs: np.ndarray of shape (N_atoms,). Atomic numbers.
         qs: np.ndarray of shape (N_atoms). Per-atom charges. All zeros if no charges are present in the file.
         comment: str. The contents of the second line of the xyz file.
-    '''
+    """
 
     xyzs = []
     Zs = []
     extra_cols = []
 
     with open(fname) as f:
-
         line = f.readline().strip()
         try:
             N = int(line)
         except ValueError:
-            raise ValueError(f'The first line of an xyz file should have the number of atoms, but got `{line}`')
+            raise ValueError(
+                f"The first line of an xyz file should have the number of atoms, but got `{line}`"
+            )
 
         comment = f.readline().strip()
 
         for i, line in enumerate(f):
-            if i >= N: break
+            if i >= N:
+                break
             wds = line.split()
             try:
                 Z = wds[0]
@@ -55,11 +58,11 @@ def loadXYZ(fname):
                     Z = elements.ELEMENT_DICT[Z][0]
                 else:
                     Z = int(Z)
-                xyzs.append( ( float(wds[1]), float(wds[2]), float(wds[3]) ) )
+                xyzs.append((float(wds[1]), float(wds[2]), float(wds[3])))
                 Zs.append(Z)
                 extra_cols.append(wds[4:])
             except (ValueError, IndexError):
-                raise ValueError(f'Could not interpret line in xyz file: `{line}`')
+                raise ValueError(f"Could not interpret line in xyz file: `{line}`")
 
     xyzs = np.array(xyzs, dtype=np.float64)
     Zs = np.array(Zs, dtype=np.int32)
@@ -71,14 +74,17 @@ def loadXYZ(fname):
 
     return xyzs, Zs, qs, comment
 
+
 def _getCharges(comment, extra_cols):
-    match = re.match(r'.*Properties=(\S*) ', comment)
+    match = re.match(r".*Properties=(\S*) ", comment)
     if match:
         # ASE format, check if one of the columns has charges
-        props = match.group(1).split(':')[6:] # [6:] is for skipping over elements and positions
+        props = match.group(1).split(":")[
+            6:
+        ]  # [6:] is for skipping over elements and positions
         col = 0
         for name, size in zip(props[::3], props[2::3]):
-            if name in ['charge', 'initial_charges']:
+            if name in ["charge", "initial_charges"]:
                 qs = np.array([float(ex[col]) for ex in extra_cols], dtype=np.float64)
                 break
             col += int(size)
@@ -89,8 +95,9 @@ def _getCharges(comment, extra_cols):
         qs = np.array([float(ex[0]) for ex in extra_cols], dtype=np.float64)
     return qs
 
-def saveXYZ(fname, xyzs, Zs, qs=None, comment='', append=False):
-    '''
+
+def saveXYZ(fname, xyzs, Zs, qs=None, comment="", append=False):
+    """
     Save atom types, positions, and, (optionally) charges to an xyz file.
 
     Arguments:
@@ -102,52 +109,62 @@ def saveXYZ(fname, xyzs, Zs, qs=None, comment='', append=False):
         comment: str. Comment string written to the second line of the xyz file.
         append: bool. Append to file instead of overwriting if it already exists. Useful for creating
             movies of changing structures.
-    '''
+    """
     N = len(xyzs)
-    mode = 'a' if append else 'w'
+    mode = "a" if append else "w"
     file_exists = os.path.exists(fname)
     with open(fname, mode) as f:
-        if append and file_exists: f.write('\n')
-        f.write(f'{N}\n{comment}\n')
+        if append and file_exists:
+            f.write("\n")
+        f.write(f"{N}\n{comment}\n")
         for i in range(N):
-            f.write(f'{Zs[i]} {xyzs[i, 0]} {xyzs[i, 1]} {xyzs[i, 2]}')
-            if qs is not None: f.write(f' {qs[i]}')
-            if i < (N-1): f.write('\n')
+            f.write(f"{Zs[i]} {xyzs[i, 0]} {xyzs[i, 1]} {xyzs[i, 2]}")
+            if qs is not None:
+                f.write(f" {qs[i]}")
+            if i < (N - 1):
+                f.write("\n")
+
 
 def loadGeometryIN(fname):
-    Zs = []; xyzs = []; lvec = []
+    Zs = []
+    xyzs = []
+    lvec = []
     with open(fname) as f:
         for line in f:
             ws = line.strip().split()
-            if (len(ws) > 0 and ws[0][0] != '#'):
-                if (ws[0] == 'atom'):
+            if len(ws) > 0 and ws[0][0] != "#":
+                if ws[0] == "atom":
                     xyzs.append([float(ws[1]), float(ws[2]), float(ws[3])])
                     Zs.append(elements.ELEMENT_DICT[ws[4]][0])
-                elif (ws[0] == 'lattice_vector'):
+                elif ws[0] == "lattice_vector":
                     lvec.append([float(ws[1]), float(ws[2]), float(ws[3])])
-                elif(ws[0] == 'atom_frac' and len(lvec)==3):
-                    xyzs.append(np.array(lvec) @ np.array([float(ws[1]),float(ws[2]),float(ws[3])]))
+                elif ws[0] == "atom_frac" and len(lvec) == 3:
+                    xyzs.append(
+                        np.array(lvec)
+                        @ np.array([float(ws[1]), float(ws[2]), float(ws[3])])
+                    )
                     Zs.append(elements.ELEMENT_DICT[ws[4]][0])
-                elif (ws[0] == 'trust_radius'):
+                elif ws[0] == "trust_radius":
                     break
 
     xyzs = np.array(xyzs)
     Zs = np.array(Zs, dtype=np.int32)
-    if (lvec != []):
-        lvec = np.stack([[0.,0.,0.]] + lvec, axis=0)
+    if lvec != []:
+        lvec = np.stack([[0.0, 0.0, 0.0]] + lvec, axis=0)
+    else:
+        lvec = None
     return xyzs, Zs, lvec
 
+
 def loadPOSCAR(file_path):
-
     with open(file_path) as f:
-
-        f.readline()                # Comment line
-        scale = float(f.readline()) # Scaling constant
+        f.readline()  # Comment line
+        scale = float(f.readline())  # Scaling constant
 
         # Lattice
         lvec = np.zeros((4, 3))
         for i in range(3):
-            lvec[i+1] = np.array([float(v) for v in f.readline().strip().split()])
+            lvec[i + 1] = np.array([float(v) for v in f.readline().strip().split()])
 
         # Elements
         elems = [elements.ELEMENT_DICT[e][0] for e in f.readline().strip().split()]
@@ -158,12 +175,12 @@ def loadPOSCAR(file_path):
 
         # Coordinate type
         line = f.readline()
-        if line[0] in 'Ss':
-            line = f.readline() # Ignore optional selective dynamics line
-        if line[0] in 'CcKk':
-            coord_type = 'cartesian'
+        if line[0] in "Ss":
+            line = f.readline()  # Ignore optional selective dynamics line
+        if line[0] in "CcKk":
+            coord_type = "cartesian"
         else:
-            coord_type = 'direct'
+            coord_type = "direct"
 
         # Atom coordinates
         xyzs = []
@@ -173,99 +190,136 @@ def loadPOSCAR(file_path):
 
         # Scale coordinates
         lvec *= scale
-        if coord_type == 'cartesian':
+        if coord_type == "cartesian":
             xyzs *= scale
         else:
-            xyzs = np.outer(xyzs[:, 0], lvec[1]) + np.outer(xyzs[:, 1], lvec[2]) + np.outer(xyzs[:, 2], lvec[3])
+            xyzs = (
+                np.outer(xyzs[:, 0], lvec[1])
+                + np.outer(xyzs[:, 1], lvec[2])
+                + np.outer(xyzs[:, 2], lvec[3])
+            )
 
     return xyzs, Zs, lvec
 
-def writeMatrix( fout, mat ):
-    for v in mat:
-        for num in v: fout.write(' %f ' %num )
-        fout.write('\n')
 
-def saveGeomXSF( fname,elems,xyzs, primvec, convvec=None, bTransposed=False ):
+def writeMatrix(fout, mat):
+    for v in mat:
+        for num in v:
+            fout.write(" %f " % num)
+        fout.write("\n")
+
+
+def saveGeomXSF(fname, elems, xyzs, primvec, convvec=None, bTransposed=False):
     if convvec is None:
         primvec = convvec
-    with open(fname,'w') as f:
-        f.write( 'CRYSTAL\n' )
-        f.write( 'PRIMVEC\n' )
-        writeMatrix( f, primvec )
-        f.write( 'CONVVEC\n' )
-        writeMatrix( f, convvec )
-        f.write( 'PRIMCOORD\n' )
-        f.write( '%i %i\n' %(len(elems),1) )
+    with open(fname, "w") as f:
+        f.write("CRYSTAL\n")
+        f.write("PRIMVEC\n")
+        writeMatrix(f, primvec)
+        f.write("CONVVEC\n")
+        writeMatrix(f, convvec)
+        f.write("PRIMCOORD\n")
+        f.write("%i %i\n" % (len(elems), 1))
         if bTransposed:
             xs = xyzs[0]
             ys = xyzs[1]
             zs = xyzs[2]
             for i in range(len(elems)):
-                f.write( str(elems[i] ) );
-                f.write( f" {xs[i]:10.10f} {ys[i]:10.10f} {zs[i]:10.10f}\n" )
+                f.write(str(elems[i]))
+                f.write(f" {xs[i]:10.10f} {ys[i]:10.10f} {zs[i]:10.10f}\n")
         else:
             for i in range(len(elems)):
                 xyzsi = xyzs[i]
-                f.write( str(elems[i] ) );
-                f.write( f" {xyzsi[0]:10.10f} {xyzsi[1]:10.10f} {xyzsi[2]:10.10f}\n" )
-        f.write( '\n' )
+                f.write(str(elems[i]))
+                f.write(f" {xyzsi[0]:10.10f} {xyzsi[1]:10.10f} {xyzsi[2]:10.10f}\n")
+        f.write("\n")
 
-def loadXSFGeom( fname ):
-    f = open(fname )
-    e=[];x=[];y=[]; z=[]; q=[]
+
+def loadXSFGeom(fname):
+    f = open(fname)
+    e = []
+    x = []
+    y = []
+    z = []
+    q = []
     nDim = []
     lvec = []
     for i in range(10000):
-        if 'PRIMCOORD' in f.readline():
+        if "PRIMCOORD" in f.readline():
             break
     n = int(f.readline().split()[0])
     for j in range(n):
-        ws = f.readline().split();
-        e.append(int(ws[0])); x.append(float(ws[1])); y.append(float(ws[2])); z.append(float(ws[3])); q.append(0);
+        ws = f.readline().split()
+        e.append(int(ws[0]))
+        x.append(float(ws[1]))
+        y.append(float(ws[2]))
+        z.append(float(ws[3]))
+        q.append(0)
     for i in range(10000):
         line = f.readline()
-        if ('BEGIN_DATAGRID_3D') in line:
+        if ("BEGIN_DATAGRID_3D") in line:
             break
-        elif ('DATAGRID_3D_DENSITY') in line:
+        elif ("DATAGRID_3D_DENSITY") in line:
             break
-        elif ('BEGIN_DATAGRID_3D_CONTCAR_v2xsf') in line:
+        elif ("BEGIN_DATAGRID_3D_CONTCAR_v2xsf") in line:
             break
-    ws = f.readline().split(); nDim = [int(ws[0]),int(ws[1]),int(ws[2])]
+    ws = f.readline().split()
+    nDim = [int(ws[0]), int(ws[1]), int(ws[2])]
     for j in range(4):
-        ws = f.readline().split(); lvec.append( [float(ws[0]),float(ws[1]),float(ws[2])] )
+        ws = f.readline().split()
+        lvec.append([float(ws[0]), float(ws[1]), float(ws[2])])
     f.close()
-    if(verbose>0): print("nDim+1", nDim)
-    nDim = (nDim[0]-1,nDim[1]-1,nDim[2]-1)
-    if(verbose>0): print("lvec", lvec)
-    if(verbose>0): print("reading ended")
-    return [ e,x,y,z,q ], nDim, lvec
+    if verbose > 0:
+        print("nDim+1", nDim)
+    nDim = (nDim[0] - 1, nDim[1] - 1, nDim[2] - 1)
+    if verbose > 0:
+        print("lvec", lvec)
+    if verbose > 0:
+        print("reading ended")
+    return [e, x, y, z, q], nDim, lvec
 
-def loadNPYGeom( fname ):
-    if(verbose>0): print("loading atoms")
-    tmp = np.load(fname+"_atoms.npy" )
-    e=tmp[0];x=tmp[1];y=tmp[2]; z=tmp[3]; q=tmp[4];
-    del tmp;
-    if(verbose>0): print("loading lvec")
-    lvec = np.load(fname+"_vec.npy" )
-    if(verbose>0): print("loading nDim")
-    tmp = np.load(fname+"_z.npy")
+
+def loadNPYGeom(fname):
+    if verbose > 0:
+        print("loading atoms")
+    tmp = np.load(fname + "_atoms.npy")
+    e = tmp[0]
+    x = tmp[1]
+    y = tmp[2]
+    z = tmp[3]
+    q = tmp[4]
+    del tmp
+    if verbose > 0:
+        print("loading lvec")
+    lvec = np.load(fname + "_vec.npy")
+    if verbose > 0:
+        print("loading nDim")
+    tmp = np.load(fname + "_z.npy")
     nDim = tmp.shape
-    del tmp;
-    if(verbose>0): print("nDim", nDim)
-    if(verbose>0): print("lvec", lvec)
-    if(verbose>0): print("e,x,y,z", e,x,y,z)
-    return [ e,x,y,z,q ], nDim, lvec
+    del tmp
+    if verbose > 0:
+        print("nDim", nDim)
+    if verbose > 0:
+        print("lvec", lvec)
+    if verbose > 0:
+        print("e,x,y,z", e, x, y, z)
+    return [e, x, y, z, q], nDim, lvec
 
-def loadAtomsCUBE( fname ):
-    bohrRadius2angstroem = 0.5291772109217 # find a good place for this
-    e=[];x=[];y=[]; z=[]; q=[]
-    f = open(fname )
-    #First two lines of the header are comments
+
+def loadAtomsCUBE(fname):
+    bohrRadius2angstroem = 0.5291772109217  # find a good place for this
+    e = []
+    x = []
+    y = []
+    z = []
+    q = []
+    f = open(fname)
+    # First two lines of the header are comments
     f.readline()
     f.readline()
-    #The third line has the number of atoms included in the file followed by the position of the origin of the volumetric data.
+    # The third line has the number of atoms included in the file followed by the position of the origin of the volumetric data.
     sth0 = f.readline().split()
-    #The next three lines give the number of voxels along each axis (x, y, z) followed by the axis vector
+    # The next three lines give the number of voxels along each axis (x, y, z) followed by the axis vector
     f.readline().split()
     f.readline().split()
     f.readline().split()
@@ -273,92 +327,113 @@ def loadAtomsCUBE( fname ):
     shift = [float(sth0[1]), float(sth0[2]), float(sth0[3])]
     nlines = int(sth0[0])
     for i in range(nlines):
-        l=f.readline().split()
-        r=[float(l[2]),float(l[3]),float(l[4])]
-        x.append( (r[0] - shift[0]) * bohrRadius2angstroem )
-        y.append( (r[1] - shift[1]) * bohrRadius2angstroem )
-        z.append( (r[2] - shift[2]) * bohrRadius2angstroem )
-        #print float(l[2])*bohrRadius2angstroem, float(l[3])*bohrRadius2angstroem, float(l[4])*bohrRadius2angstroem
-        e.append( int(  l[0]) )
+        l = f.readline().split()
+        r = [float(l[2]), float(l[3]), float(l[4])]
+        x.append((r[0] - shift[0]) * bohrRadius2angstroem)
+        y.append((r[1] - shift[1]) * bohrRadius2angstroem)
+        z.append((r[2] - shift[2]) * bohrRadius2angstroem)
+        # print float(l[2])*bohrRadius2angstroem, float(l[3])*bohrRadius2angstroem, float(l[4])*bohrRadius2angstroem
+        e.append(int(l[0]))
         q.append(0.0)
     f.close()
-    return [ e,x,y,z,q ]
+    return [e, x, y, z, q]
 
-def primcoords2Xsf( iZs, xyzs, lvec ):
+
+def primcoords2Xsf(iZs, xyzs, lvec):
     import io as SIO
-    if(verbose>0): print("lvec: ", lvec)
-    sio=SIO.StringIO()
+
+    if verbose > 0:
+        print("lvec: ", lvec)
+    sio = SIO.StringIO()
     sio.write("CRYSTAL\n")
     sio.write("PRIMVEC\n")
-    sio.write("%f %f %f\n" %( lvec[1][0],lvec[1][1],lvec[1][2]) );
-    sio.write("%f %f %f\n" %( lvec[2][0],lvec[2][1],lvec[2][2]) );
-    sio.write("%f %f %f\n" %( lvec[3][0],lvec[3][1],lvec[3][2]) );
+    sio.write(f"{lvec[1][0]:f} {lvec[1][1]:f} {lvec[1][2]:f}\n")
+    sio.write(f"{lvec[2][0]:f} {lvec[2][1]:f} {lvec[2][2]:f}\n")
+    sio.write(f"{lvec[3][0]:f} {lvec[3][1]:f} {lvec[3][2]:f}\n")
     sio.write("CONVVEC\n")
-    sio.write("%f %f %f\n" %( lvec[1][0],lvec[1][1],lvec[1][2]) );
-    sio.write("%f %f %f\n" %( lvec[2][0],lvec[2][1],lvec[2][2]) );
-    sio.write("%f %f %f\n" %( lvec[3][0],lvec[3][1],lvec[3][2]) );
+    sio.write(f"{lvec[1][0]:f} {lvec[1][1]:f} {lvec[1][2]:f}\n")
+    sio.write(f"{lvec[2][0]:f} {lvec[2][1]:f} {lvec[2][2]:f}\n")
+    sio.write(f"{lvec[3][0]:f} {lvec[3][1]:f} {lvec[3][2]:f}\n")
     sio.write("PRIMCOORD\n")
     n = len(iZs)
-    sio.write("%i 1\n" %n )
+    sio.write("%i 1\n" % n)
     for i in range(n):
-        sio.write("%i %5.6f %5.6f %5.6f\n" %(iZs[i],xyzs[0][i],xyzs[1][i],xyzs[2][i]) )
+        sio.write(
+            "%i %5.6f %5.6f %5.6f\n" % (iZs[i], xyzs[0][i], xyzs[1][i], xyzs[2][i])
+        )
     sio.write("\n")
-    sio.write("BEGIN_BLOCK_DATAGRID_3D\n");
-    sio.write("some_datagrid\n");
-    sio.write("BEGIN_DATAGRID_3D_whatever\n");
+    sio.write("BEGIN_BLOCK_DATAGRID_3D\n")
+    sio.write("some_datagrid\n")
+    sio.write("BEGIN_DATAGRID_3D_whatever\n")
     s = sio.getvalue()
-    #print s; exit()
+    # print s; exit()
     return s
 
-def loadCellCUBE( fname ):
-    bohrRadius2angstroem = 0.5291772109217 # find a good place for this
-    f = open(fname )
-    #First two lines of the header are comments
+
+def loadCellCUBE(fname):
+    bohrRadius2angstroem = 0.5291772109217  # find a good place for this
+    f = open(fname)
+    # First two lines of the header are comments
     f.readline()
     f.readline()
-    #The third line has the number of atoms included in the file followed by the position of the origin of the volumetric data.
+    # The third line has the number of atoms included in the file followed by the position of the origin of the volumetric data.
     line = f.readline().split()
     int(line[0])
-    c0 =[ float(s) for s in line[1:4] ]
+    c0 = [float(s) for s in line[1:4]]
 
-    #The next three lines give the number of voxels along each axis (x, y, z) followed by the axis vector
+    # The next three lines give the number of voxels along each axis (x, y, z) followed by the axis vector
     line = f.readline().split()
     n1 = int(line[0])
-    c1 =[ float(s) for s in line[1:4] ]
+    c1 = [float(s) for s in line[1:4]]
 
     line = f.readline().split()
     n2 = int(line[0])
-    c2 =[ float(s) for s in line[1:4] ]
+    c2 = [float(s) for s in line[1:4]]
 
     line = f.readline().split()
     n3 = int(line[0])
-    c3 =[ float(s) for s in line[1:4] ]
+    c3 = [float(s) for s in line[1:4]]
 
-#    cell0 = [c0[0]*   bohrRadius2angstroem, c0[1]   *bohrRadius2angstroem, c0[2]   *bohrRadius2angstroem]
+    #    cell0 = [c0[0]*   bohrRadius2angstroem, c0[1]   *bohrRadius2angstroem, c0[2]   *bohrRadius2angstroem]
     cell0 = [0.0, 0.0, 0.0]
-    cell1 = [c1[0]*n1*bohrRadius2angstroem, c1[1]*n1*bohrRadius2angstroem, c1[2]*n1*bohrRadius2angstroem]
-    cell2 = [c2[0]*n2*bohrRadius2angstroem, c2[1]*n2*bohrRadius2angstroem, c2[2]*n2*bohrRadius2angstroem]
-    cell3 = [c3[0]*n3*bohrRadius2angstroem, c3[1]*n3*bohrRadius2angstroem, c3[2]*n3*bohrRadius2angstroem]
+    cell1 = [
+        c1[0] * n1 * bohrRadius2angstroem,
+        c1[1] * n1 * bohrRadius2angstroem,
+        c1[2] * n1 * bohrRadius2angstroem,
+    ]
+    cell2 = [
+        c2[0] * n2 * bohrRadius2angstroem,
+        c2[1] * n2 * bohrRadius2angstroem,
+        c2[2] * n2 * bohrRadius2angstroem,
+    ]
+    cell3 = [
+        c3[0] * n3 * bohrRadius2angstroem,
+        c3[1] * n3 * bohrRadius2angstroem,
+        c3[2] * n3 * bohrRadius2angstroem,
+    ]
     f.close()
-    return [ cell0, cell1, cell2, cell3 ]
+    return [cell0, cell1, cell2, cell3]
 
-def loadNCUBE( fname ):
-    bohrRadius2angstroem = 0.5291772109217 # find a good place for this
-    f = open(fname )
-    #First two lines of the header are comments
+
+def loadNCUBE(fname):
+    bohrRadius2angstroem = 0.5291772109217  # find a good place for this
+    f = open(fname)
+    # First two lines of the header are comments
     f.readline()
     f.readline()
-    #The third line has the number of atoms included in the file followed by the position of the origin of the volumetric data.
+    # The third line has the number of atoms included in the file followed by the position of the origin of the volumetric data.
     f.readline().split()
-    #The next three lines give the number of voxels along each axis (x, y, z) followed by the axis vector
+    # The next three lines give the number of voxels along each axis (x, y, z) followed by the axis vector
     sth1 = f.readline().split()
     sth2 = f.readline().split()
     sth3 = f.readline().split()
     f.close()
-    return [ int(sth1[0]), int(sth2[0]), int(sth3[0]) ]
+    return [int(sth1[0]), int(sth2[0]), int(sth3[0])]
 
-def loadGeometry(fname=None,format=None,params=None):
-    if(verbose>0): print("loadGeometry ", fname)
+
+def loadGeometry(fname=None, format=None, params=None):
+    if verbose > 0:
+        print("loadGeometry ", fname)
     if fname == None:
         raise ValueError("Please provide the name of the file with coordinates")
     if params == None:
@@ -377,39 +452,105 @@ def loadGeometry(fname=None,format=None,params=None):
         if fname.startswith("POSCAR") or fname.startswith("CONTCAR"):
             format = "poscar"
     else:
-        format = format.lower() #prevent format from being case sensitive, e.g. "XYZ" and "xyz" should be the same
-    if(format=="xyz"):
+        format = (
+            format.lower()
+        )  # prevent format from being case sensitive, e.g. "XYZ" and "xyz" should be the same
+    if format == "xyz":
         xyzs, Zs, qs, comment = loadXYZ(fname)
-        nDim = params['gridN'].copy()
+        nDim = params["gridN"].copy()
         lvec = parseLvecASE(comment)
-        if lvec is None:
-            lvec  = np.zeros((4,3))
-            lvec[ 1,:  ] = params['gridA'].copy()
-            lvec[ 2,:  ] = params['gridB'].copy()
-            lvec[ 3,:  ] = params['gridC'].copy()
-        atoms = [list(Zs), list(xyzs[:, 0]), list(xyzs[:, 1]), list(xyzs[:, 2]), list(qs)]
-    elif(format=="cube"):
+        atoms = [
+            list(Zs),
+            list(xyzs[:, 0]),
+            list(xyzs[:, 1]),
+            list(xyzs[:, 2]),
+            list(qs),
+        ]
+    elif format == "cube":
         atoms = loadAtomsCUBE(fname)
-        lvec  = loadCellCUBE(fname)
-        nDim  = loadNCUBE(fname)
-    elif(format=="xsf"):
+        lvec = loadCellCUBE(fname)
+        nDim = loadNCUBE(fname)
+    elif format == "xsf":
         atoms, nDim, lvec = loadXSFGeom(fname)
-    elif(format=="npy"):
-        atoms, nDim, lvec = loadNPYGeom(fname) # under development
-    elif(format=="poscar"):
+    elif format == "npy":
+        atoms, nDim, lvec = loadNPYGeom(fname)  # under development
+    elif format == "poscar":
         atoms, nDim, lvec = loadPOSCAR(fname)
-    elif(format=="in"):
+    elif format == "in":
         atoms, nDim, lvec = loadGeometryIN(fname)
-    #TODO: introduce a function which reads the geometry from the .npy file
+    # TODO: introduce a function which reads the geometry from the .npy file
     else:
-        if(format is None):
-            raise ValueError ('ERROR!!! Input geometry format was neither specified nor could it be determined automatically.')
+        if format is None:
+            raise ValueError(
+                "ERROR!!! Input geometry format was neither specified nor could it be determined automatically."
+            )
         else:
-            raise ValueError ('ERROR!!! Unknown format %s of input geometry.' % (format))
-    return atoms,nDim,lvec
+            raise ValueError("ERROR!!! Unknown format %s of input geometry." % (format))
+
+    # Make sure lvec is a 4x3 array. Use default grid parameters if needed
+    if (lvec is None) or (len(lvec) == 0):
+        lvec = np.zeros((4, 3))
+        lvec[1, :] = params["gridA"].copy()
+        lvec[2, :] = params["gridB"].copy()
+        lvec[3, :] = params["gridC"].copy()
+    else:
+        if len(lvec) == 1:
+            lvec.append(params["gridA"].copy())
+        if len(lvec) == 2:
+            lvec.append(params["gridB"].copy())
+        if len(lvec) == 3:
+            lvec.append(params["gridC"].copy())
+    lvec = np.array(lvec)
+
+    # Shift scanning coordinates to such that actually make sense (being directly comparable to coordinates of atoms)
+    params["scanMin"][0] += params["r0Probe"][0]
+    params["scanMin"][1] += params["r0Probe"][1]
+    params["scanMin"][2] -= params["r0Probe"][2]
+    params["scanMax"][0] += params["r0Probe"][0]
+    params["scanMax"][1] += params["r0Probe"][1]
+    params["scanMax"][2] -= params["r0Probe"][2]
+
+    # Generate automatic lattice vectors and grid dimensions if needed
+    pad = 3.0
+    default_grid_step = 0.1
+    for i in range(3):
+        # Zero lattice vector is considered undefined and triggers creation of an automatic one.
+        # The automatic generated lattice vector should enclose the whole area filled with atoms as well as the whole scanning area, plus the default padding.
+        if np.allclose(lvec[i + 1, :], 0):
+            if not params["PBC"]:
+                lvec[i + 1, i] = (
+                    max(max(atoms[i + 1]), params["scanMax"][i])
+                    - min(min(atoms[i + 1]), params["scanMin"][i])
+                    + 2 * pad
+                )
+            else:
+                lvec[i + 1, i] = max(max(atoms[i + 1]), params["scanMax"][i]) + pad
+
+        # Generate automatic grid using the default step if the grid dimension specified so far is not a positive number
+        if not nDim[i] > 0:
+            nDim[i] = round(np.linalg.norm(lvec[i + 1, :]) / default_grid_step)
+
+    # Shift scanning coordinates back because, unfortunately, we have to keep backward compatibility
+    params["scanMin"][0] -= params["r0Probe"][0]
+    params["scanMin"][1] -= params["r0Probe"][1]
+    params["scanMin"][2] += params["r0Probe"][2]
+    params["scanMax"][0] -= params["r0Probe"][0]
+    params["scanMax"][1] -= params["r0Probe"][1]
+    params["scanMax"][2] += params["r0Probe"][2]
+
+    # Copy lattice vectors and grid dimensions to the global parameters
+    # so as to guarantee compatibility between the local variables and global parameters
+    for i in range(3):
+        params["gridA"][i] = lvec[1][i]
+        params["gridB"][i] = lvec[2][i]
+        params["gridC"][i] = lvec[3][i]
+        params["gridN"][i] = nDim[i]
+
+    return atoms, nDim, lvec
+
 
 def parseLvecASE(comment):
-    '''
+    """
     Try to parse the lattice vectors in an xyz file comment line according to the extended xyz
     file format used by ASE. The origin is always at zero.
 
@@ -419,160 +560,200 @@ def parseLvecASE(comment):
     Returns:
         lvec: np.array of shape (4, 3) or None. The found lattice vectors or None if the
             comment line does not match the extended xyz file format.
-    '''
-    match = re.match('.*Lattice=\"\\s*((?:[+-]?(?:[0-9]*\\.)?[0-9]+\\s*){9})\"', comment)
+    """
+    match = re.match('.*Lattice="\\s*((?:[+-]?(?:[0-9]*\\.)?[0-9]+\\s*){9})"', comment)
     if match:
         lvec = np.zeros(12, dtype=np.float32)
-        lvec[3:] = np.array([float(s) for s in match.group(1).split()], dtype=np.float32)
+        lvec[3:] = np.array(
+            [float(s) for s in match.group(1).split()], dtype=np.float32
+        )
         lvec = lvec.reshape(4, 3)
     else:
         lvec = None
     return lvec
 
+
 # =================== XSF
 
-def _readUpTo( filein, keyword ):
+
+def _readUpTo(filein, keyword):
     i = 0
     linelist = []
-    while True :
+    while True:
         line = filein.readline()
         linelist.append(line)
-        i=i+1
-        if ((not line) or (keyword in line)): break
+        i = i + 1
+        if (not line) or (keyword in line):
+            break
     return i, linelist
+
 
 def _readmat(filein, n):
     temp = []
     for i in range(n):
-        temp.append( [ float(iii) for iii in filein.readline().split() ] )
+        temp.append([float(iii) for iii in filein.readline().split()])
     return np.array(temp)
+
 
 def _writeArr(f, arr):
     f.write(" ".join(str(x) for x in arr) + "\n")
 
+
 def _writeArr2D(f, arr):
     for vec in arr:
-        _writeArr(f,vec)
+        _writeArr(f, vec)
 
-def _orthoLvec( sh, dd ):
+
+def _orthoLvec(sh, dd):
     return [
-        [0,0,0],
-        [sh[2]*dd[0],0,0],
-        [0,sh[1]*dd[1],0],
-        [0,0,sh[0]*dd[2]]
+        [0, 0, 0],
+        [sh[2] * dd[0], 0, 0],
+        [0, sh[1] * dd[1], 0],
+        [0, 0, sh[0] * dd[2]],
     ]
 
-XSF_HEAD_DEFAULT = headScan='''
+
+XSF_HEAD_DEFAULT = headScan = """
 ATOMS
  1   0.0   0.0   0.0
 
 BEGIN_BLOCK_DATAGRID_3D
    some_datagrid
    BEGIN_DATAGRID_3D_whatever
-'''
+"""
 
-def saveXSF(fname, data, lvec=None, dd=None, head=XSF_HEAD_DEFAULT, verbose=1 ):
-    if verbose > 0: print("Saving xsf", fname)
-    fileout = open(fname, 'w')
+
+def saveXSF(fname, data, lvec=None, dd=None, head=XSF_HEAD_DEFAULT, verbose=1):
+    if verbose > 0:
+        print("Saving xsf", fname)
+    fileout = open(fname, "w")
     if lvec is None:
         if dd is None:
-            dd=[1.0,1.0,1.0]
-        lvec = _orthoLvec( data.shape, dd )
+            dd = [1.0, 1.0, 1.0]
+        lvec = _orthoLvec(data.shape, dd)
     for line in head:
         fileout.write(line)
     nDim = np.shape(data)
-    _writeArr (fileout, (nDim[2]+1,nDim[1]+1,nDim[0]+1) )
-    _writeArr2D(fileout,lvec)
-    data2 = np.zeros(np.array(nDim)+1);   # These crazy 3 lines are here since the first and the last cube
-    data2[:-1,:-1,:-1] = data;  # in XSF in every direction is the same
-    data2[-1,:,:]=data2[0,:,:];data2[:,-1,:]=data2[:,0,:];data2[:,:,-1]=data2[:,:,0];
+    _writeArr(fileout, (nDim[2] + 1, nDim[1] + 1, nDim[0] + 1))
+    _writeArr2D(fileout, lvec)
+    data2 = np.zeros(np.array(nDim) + 1)
+    # These crazy 3 lines are here since the first and the last cube
+    data2[:-1, :-1, :-1] = data
+    # in XSF in every direction is the same
+    data2[-1, :, :] = data2[0, :, :]
+    data2[:, -1, :] = data2[:, 0, :]
+    data2[:, :, -1] = data2[:, :, 0]
     for r in data2.flat:
-        fileout.write( "%10.5e\n" % r )
-    fileout.write ("   END_DATAGRID_3D\n")
-    fileout.write ("END_BLOCK_DATAGRID_3D\n")
+        fileout.write("%10.5e\n" % r)
+    fileout.write("   END_DATAGRID_3D\n")
+    fileout.write("END_BLOCK_DATAGRID_3D\n")
+
 
 def loadXSF(fname, xyz_order=False, verbose=True):
-    filein = open( fname )
-    startline, head = _readUpTo(filein, "BEGIN_DATAGRID_3D")              # startline - number of the line with DATAGRID_3D_. Dinensions are located in the next line
-    nDim = [ int(iii) for iii in filein.readline().split() ]        # reading 1 line with dimensions
+    filein = open(fname)
+    startline, head = _readUpTo(
+        filein, "BEGIN_DATAGRID_3D"
+    )  # startline - number of the line with DATAGRID_3D_. Dinensions are located in the next line
+    nDim = [
+        int(iii) for iii in filein.readline().split()
+    ]  # reading 1 line with dimensions
     nDim.reverse()
-    nDim = np.array( nDim)
-    lvec = _readmat(filein, 4)                                      # reading 4 lines where 1st line is origin of datagrid and 3 next lines are the cell vectors
+    nDim = np.array(nDim)
+    lvec = _readmat(
+        filein, 4
+    )  # reading 4 lines where 1st line is origin of datagrid and 3 next lines are the cell vectors
     filein.close()
-    if verbose: print("nDim xsf (= nDim + [1,1,1] ):", nDim)
-    if verbose: print("io | Load "+fname+" using readNumsUpTo ")
-    F = readNumsUpTo(fname,nDim.astype(np.int32).copy(), startline+5)
-    if verbose: print("io | Done")
-    FF = np.reshape(F, nDim)[:-1,:-1,:-1]
+    if verbose:
+        print("nDim xsf (= nDim + [1,1,1] ):", nDim)
+    if verbose:
+        print("io | Load " + fname + " using readNumsUpTo ")
+    F = readNumsUpTo(fname, nDim.astype(np.int32).copy(), startline + 5)
+    if verbose:
+        print("io | Done")
+    FF = np.reshape(F, nDim)[:-1, :-1, :-1]
     if xyz_order:
         FF = FF.transpose((2, 1, 0))
     # FF is not C_CONTIGUOUS without copy
     FF = FF.copy()
-    return FF, lvec, nDim-1, head
+    return FF, lvec, nDim - 1, head
 
-def getFromHead_PRIMCOORD( head ):
-    Zs = None; Rs = None;
-    for i,line in enumerate( head ):
+
+def getFromHead_PRIMCOORD(head):
+    Zs = None
+    Rs = None
+    for i, line in enumerate(head):
         if "PRIMCOORD" in line:
-            natoms = int( head[i+1].split()[0] )
-            Zs = np.zeros( natoms, dtype='int32' ); Rs = np.zeros( (natoms,3) )
+            natoms = int(head[i + 1].split()[0])
+            Zs = np.zeros(natoms, dtype="int32")
+            Rs = np.zeros((natoms, 3))
             for j in range(natoms):
-                words = head[i+j+2].split()
-                Zs[j  ]    = int  ( words[ 0 ] )
-                Rs[j,0] = float( words[ 1 ] )
-                Rs[j,1] = float( words[ 2 ] )
-                Rs[j,2] = float( words[ 3 ] )
+                words = head[i + j + 2].split()
+                Zs[j] = int(words[0])
+                Rs[j, 0] = float(words[1])
+                Rs[j, 1] = float(words[2])
+                Rs[j, 2] = float(words[3])
     return Zs, Rs
+
 
 # =================== Cube
 
+
 def loadCUBE(fname, xyz_order=False, verbose=True):
-    filein = open(fname )
-    #First two lines of the header are comments
+    filein = open(fname)
+    # First two lines of the header are comments
     filein.readline()
     filein.readline()
-    #The third line has the number of atoms included in the file followed by the position of the origin of the volumetric data.
+    # The third line has the number of atoms included in the file followed by the position of the origin of the volumetric data.
     sth0 = filein.readline().split()
-    #The next three lines give the number of voxels along each axis (x, y, z) followed by the axis vector
+    # The next three lines give the number of voxels along each axis (x, y, z) followed by the axis vector
     sth1 = filein.readline().split()
     sth2 = filein.readline().split()
     sth3 = filein.readline().split()
     filein.close()
-    nDim = np.array( [int(sth1[0]),int(sth2[0]),int(sth3[0])] )
+    nDim = np.array([int(sth1[0]), int(sth2[0]), int(sth3[0])])
     lvec = np.zeros((4, 3))
     for jj in range(3):
-        lvec[0,jj]=float(sth0[jj+1])*bohrRadius2angstroem
-        lvec[1,jj]=float(sth1[jj+1])*int(sth1[0])*bohrRadius2angstroem  # bohr_radius ?
-        lvec[2,jj]=float(sth2[jj+1])*int(sth2[0])*bohrRadius2angstroem
-        lvec[3,jj]=float(sth3[jj+1])*int(sth3[0])*bohrRadius2angstroem
+        lvec[0, jj] = float(sth0[jj + 1]) * bohrRadius2angstroem
+        lvec[1, jj] = (
+            float(sth1[jj + 1]) * int(sth1[0]) * bohrRadius2angstroem
+        )  # bohr_radius ?
+        lvec[2, jj] = float(sth2[jj + 1]) * int(sth2[0]) * bohrRadius2angstroem
+        lvec[3, jj] = float(sth3[jj + 1]) * int(sth3[0]) * bohrRadius2angstroem
 
-    if verbose: print("io | Load "+fname+" using readNumsUpTo")
-    noline = 6+int(sth0[0])
-    F = readNumsUpTo(fname,nDim.astype(np.int32).copy(),noline)
-    if verbose: print("io | np.shape(F): ",np.shape(F))
-    if verbose: print("io | nDim: ", nDim)
+    if verbose:
+        print("io | Load " + fname + " using readNumsUpTo")
+    noline = 6 + int(sth0[0])
+    F = readNumsUpTo(fname, nDim.astype(np.int32).copy(), noline)
+    if verbose:
+        print("io | np.shape(F): ", np.shape(F))
+    if verbose:
+        print("io | nDim: ", nDim)
 
     FF = np.reshape(F, nDim)
     if not xyz_order:
-        FF = FF.transpose((2,1,0)).copy()  # Transposition of the array to have the same order of data as in XSF file
+        FF = FF.transpose(
+            (2, 1, 0)
+        ).copy()  # Transposition of the array to have the same order of data as in XSF file
 
-    nDim=[nDim[2],nDim[1],nDim[0]]                          # Setting up the corresponding dimensions.
+    nDim = [nDim[2], nDim[1], nDim[0]]  # Setting up the corresponding dimensions.
     head = []
     head.append("BEGIN_BLOCK_DATAGRID_3D \n")
     head.append("g98_3D_unknown \n")
     head.append("DATAGRID_3D_g98Cube \n")
-    FF*=Hartree2eV
-    return FF,lvec, nDim, head
+    FF *= Hartree2eV
+    return FF, lvec, nDim, head
+
 
 # ================ WSxM output
 
+
 def saveWSxM_2D(name_file, data, Xs, Ys):
-    tmp_data=data.flatten()
-    out_data=np.zeros((len(tmp_data),3))
-    out_data[:,0]=Xs.flatten()
-    out_data[:,1]=Ys.flatten()
-    out_data[:,2]=tmp_data    #.copy()
-    f=open(name_file,'w')
+    tmp_data = data.flatten()
+    out_data = np.zeros((len(tmp_data), 3))
+    out_data[:, 0] = Xs.flatten()
+    out_data[:, 1] = Ys.flatten()
+    out_data[:, 2] = tmp_data  # .copy()
+    f = open(name_file, "w")
     print("WSxM file copyright Nanotec Electronica", file=f)
     print("WSxM ASCII XYZ file", file=f)
     print("X[A]  Y[A]  df[Hz]", file=f)
@@ -580,22 +761,25 @@ def saveWSxM_2D(name_file, data, Xs, Ys):
     np.savetxt(f, out_data)
     f.close()
 
-def saveWSxM_3D( prefix, data, extent, slices=None ):
-    nDim=np.shape(data)
+
+def saveWSxM_3D(prefix, data, extent, slices=None):
+    nDim = np.shape(data)
     if slices is None:
-        slices=list(range( nDim[0]))
-    xs=np.linspace( extent[0], extent[1], nDim[2] )
-    ys=np.linspace( extent[2], extent[3], nDim[1] )
-    Xs, Ys = np.meshgrid(xs,ys)
+        slices = list(range(nDim[0]))
+    xs = np.linspace(extent[0], extent[1], nDim[2])
+    ys = np.linspace(extent[2], extent[3], nDim[1])
+    Xs, Ys = np.meshgrid(xs, ys)
     for i in slices:
         print("slice no: ", i)
-        fname = prefix+'_%03d.xyz' %i
+        fname = prefix + "_%03d.xyz" % i
         saveWSxM_2D(fname, data[i], Xs, Ys)
+
 
 # ================ Npy
 
-def saveNpy(fname, data, lvec , atomic_info):
-    '''
+
+def saveNpy(fname, data, lvec, atomic_info):
+    """
     Function for saving scalar grid data, together with its lattice_vector and information about original atoms and the original lattice vector (lvec0) in numpy format
 
     Arguments:
@@ -603,12 +787,14 @@ def saveNpy(fname, data, lvec , atomic_info):
         data: np.ndarray of shape (n_z, n_y, n_x) with scallar data
         lvec: np.ndarray of shape (4, 3). Lattice vector of the data
         atomic_info: tuple of shape (2). First part is [e, x, y, z] of atoms, the second is lvec of the atoms from the original geometry file, named as lvec0;
-    '''
-    np.savez(fname+'.npz', data=data, lvec=lvec, atoms=atomic_info[0], lvec0=atomic_info[1])
+    """
+    np.savez(
+        fname + ".npz", data=data, lvec=lvec, atoms=atomic_info[0], lvec0=atomic_info[1]
+    )
 
 
 def loadNpy(fname):
-    '''
+    """
     Function for loading scalar grid data, together with its lattice_vector and information about original atoms and the original lattice vector (lvec0) in numpy format
 
     Arguments:
@@ -618,35 +804,43 @@ def loadNpy(fname):
         data: np.array of shape(nz, ny, nx) with volumetric (scaler data) we want to save
         lvec: np.array of shape(4,3) with lattice vector of the volumetric data
         atomic_info tuple of shape (2) with 2 np.arrays - one is np.array([e,x,y,z]) with atoms positions and the second one is np.array(lvec0) of shape (4,3) with saved information about lattice vector.
-    '''
-    tmp_input = np.load(fname+'.npz')
-    data = tmp_input['data']
-    lvec = tmp_input['lvec']
-    atomic_info = (tmp_input['atoms'],tmp_input['lvec0'])
-    return data.copy(), lvec, atomic_info;    #necessary for being 'C_CONTINUOS'
+    """
+    tmp_input = np.load(fname + ".npz")
+    data = tmp_input["data"]
+    lvec = tmp_input["lvec"]
+    atomic_info = (tmp_input["atoms"], tmp_input["lvec0"])
+    return data.copy(), lvec, atomic_info
+    # necessary for being 'C_CONTINUOS'
+
 
 # =============== Vector Field
 
-def packVecGrid( Fx, Fy, Fz, FF = None ):
+
+def packVecGrid(Fx, Fy, Fz, FF=None):
     if FF is None:
-        nDim = np.shape( Fx )
-        FF = np.zeros( (nDim[0],nDim[1],nDim[2],3) )
-    FF[:,:,:,0]=Fx;     FF[:,:,:,1]=Fy;    FF[:,:,:,2]=Fz
+        nDim = np.shape(Fx)
+        FF = np.zeros((nDim[0], nDim[1], nDim[2], 3))
+    FF[:, :, :, 0] = Fx
+    FF[:, :, :, 1] = Fy
+    FF[:, :, :, 2] = Fz
     return FF
 
-def unpackVecGrid( FF ):
-    return FF[:,:,:,0].copy(), FF[:,:,:,1].copy(), FF[:,:,:,2].copy()
 
-def loadVecFieldXsf( fname, FF = None ):
-    Fx,lvec,nDim,head=loadXSF(fname+'_x.xsf')
-    Fy,lvec,nDim,head=loadXSF(fname+'_y.xsf')
-    Fz,lvec,nDim,head=loadXSF(fname+'_z.xsf')
-    FF = packVecGrid( Fx, Fy, Fz, FF )
-    del Fx,Fy,Fz
+def unpackVecGrid(FF):
+    return FF[:, :, :, 0].copy(), FF[:, :, :, 1].copy(), FF[:, :, :, 2].copy()
+
+
+def loadVecFieldXsf(fname, FF=None):
+    Fx, lvec, nDim, head = loadXSF(fname + "_x.xsf")
+    Fy, lvec, nDim, head = loadXSF(fname + "_y.xsf")
+    Fz, lvec, nDim, head = loadXSF(fname + "_z.xsf")
+    FF = packVecGrid(Fx, Fy, Fz, FF)
+    del Fx, Fy, Fz
     return FF, lvec, nDim, head
 
-def loadVecFieldNpy( fname, FF = None ):
-    '''
+
+def loadVecFieldNpy(fname, FF=None):
+    """
     Function for loading vector grid data, together with its lattice_vector and information about original atoms and the original lattice vector (lvec0) in numpy format.
 
     Arguments:
@@ -656,20 +850,22 @@ def loadVecFieldNpy( fname, FF = None ):
         FF: np.array of shape(nz, ny, nx, 3) with volumetric (vector data) we want to load.
         lvec: np.array of shape(4,3) with lattice vector of the volumetric data.
         atomic_info: tuple of shape (2) with 2 np.arrays, one is np.array([e,x,y,z]) with atoms positions and the second one is np.array(lvec0) of shape (4,3) with saved information about lattice vector.
-    '''
-    tmp_input = np.load(fname+'.npz')
-    FF = tmp_input['FF']
-    lvec = tmp_input['lvec']
-    atomic_info = (tmp_input['atoms'],tmp_input['lvec0'])
+    """
+    tmp_input = np.load(fname + ".npz")
+    FF = tmp_input["FF"]
+    lvec = tmp_input["lvec"]
+    atomic_info = (tmp_input["atoms"], tmp_input["lvec0"])
     return FF, lvec, atomic_info
 
-def saveVecFieldXsf( fname, FF, lvec, head = XSF_HEAD_DEFAULT ):
-    saveXSF(fname+'_x.xsf', FF[:,:,:,0], lvec, head=head )
-    saveXSF(fname+'_y.xsf', FF[:,:,:,1], lvec, head=head )
-    saveXSF(fname+'_z.xsf', FF[:,:,:,2], lvec, head=head )
 
-def saveVecFieldNpy( fname, FF, lvec , atomic_info ):
-    '''
+def saveVecFieldXsf(fname, FF, lvec, head=XSF_HEAD_DEFAULT):
+    saveXSF(fname + "_x.xsf", FF[:, :, :, 0], lvec, head=head)
+    saveXSF(fname + "_y.xsf", FF[:, :, :, 1], lvec, head=head)
+    saveXSF(fname + "_z.xsf", FF[:, :, :, 2], lvec, head=head)
+
+
+def saveVecFieldNpy(fname, FF, lvec, atomic_info):
+    """
     Function for saving vector grid data, together with its lattice_vector and information about original atoms and the original lattice vector (lvec0) in numpy format.
 
     Arguments:
@@ -677,25 +873,31 @@ def saveVecFieldNpy( fname, FF, lvec , atomic_info ):
         FF: np.array of shape(nz, ny, nx, 3) with volumetric (vector data) we want to load.
         lvec: np.array of shape(4,3) with lattice vector of the volumetric data.
         atomic_info: tuple of shape (2) with 2 np.arrays, one is np.array([e,x,y,z]) with atoms positions and the second one is np.array(lvec0) of shape (4,3) with saved information about lattice vector.
-    '''
-    np.savez(fname+'.npz', FF=FF, lvec=lvec, atoms=atomic_info[0], lvec0=atomic_info[1])
+    """
+    np.savez(
+        fname + ".npz", FF=FF, lvec=lvec, atoms=atomic_info[0], lvec0=atomic_info[1]
+    )
 
-def limit_vec_field( FF, Fmax=100.0 ):
-    '''
+
+def limit_vec_field(FF, Fmax=100.0):
+    """
     remove too large values; preserves direction of vectors.
 
     Arguments:
         FF: np.array of shape(nz, ny, nx, 3) with volumetric (vector data) we want to be limited.
         Fmax: float maximum value to which all the larger values will be lowered to.
-    '''
-    FR   = np.sqrt( FF[:,:,:,0]**2  +  FF[:,:,:,1]**2  + FF[:,:,:,2]**2 ).flat
-    mask = ( FR > Fmax )
-    FF[:,:,:,0].flat[mask] *= Fmax/FR[mask]
-    FF[:,:,:,1].flat[mask] *= Fmax/FR[mask]
-    FF[:,:,:,2].flat[mask] *= Fmax/FR[mask]
+    """
+    FR = np.sqrt(FF[:, :, :, 0] ** 2 + FF[:, :, :, 1] ** 2 + FF[:, :, :, 2] ** 2).flat
+    mask = FR > Fmax
+    FF[:, :, :, 0].flat[mask] *= Fmax / FR[mask]
+    FF[:, :, :, 1].flat[mask] *= Fmax / FR[mask]
+    FF[:, :, :, 2].flat[mask] *= Fmax / FR[mask]
 
-def save_vec_field(fname, data, lvec, data_format="xsf", head=XSF_HEAD_DEFAULT , atomic_info = None):
-    '''
+
+def save_vec_field(
+    fname, data, lvec, data_format="xsf", head=XSF_HEAD_DEFAULT, atomic_info=None
+):
+    """
     Saving vector fields into xsf, or npy
 
     Arguments:
@@ -705,17 +907,20 @@ def save_vec_field(fname, data, lvec, data_format="xsf", head=XSF_HEAD_DEFAULT ,
         data_format: string "xsf" or "npy"
         head: string header of the XSF file
         atomic_info: tuple of shape (2) with 2 np.arrays - one is np.array([e,x,y,z]) with atoms positions and the second one is np.array(lvec) of shape (4,3) with saved information about lattice vector.
-    '''
-    if (data_format=="xsf"):
-        saveVecFieldXsf(fname, data, lvec, head = head )
-    elif (data_format=="npy"):
-        atomic_info = atomic_info if atomic_info is not None else (np.zeros((4,1)),lvec)
-        saveVecFieldNpy(fname, data, lvec, atomic_info )
+    """
+    if data_format == "xsf":
+        saveVecFieldXsf(fname, data, lvec, head=head)
+    elif data_format == "npy":
+        atomic_info = (
+            atomic_info if atomic_info is not None else (np.zeros((4, 1)), lvec)
+        )
+        saveVecFieldNpy(fname, data, lvec, atomic_info)
     else:
         print("I cannot save this format!")
 
+
 def load_vec_field(fname, data_format="xsf"):
-    '''
+    """
     Loading Vector fields from xsf, or npy
 
     Arguments:
@@ -729,22 +934,25 @@ def load_vec_field(fname, data_format="xsf"):
         atomic_info_or_head: tuple or string. If tupple then shape (2) with 2 np.arrays,
              one is np.array([e,x,y,z]) with atoms positions and the second one is np.array(lvec0) of shape (4,3) with saved information about lattice vector.
              if string, the same information is basically stored as the header of xsf
-    '''
+    """
     atomic_info_or_head = None
-    if (data_format=="xsf"):
+    if data_format == "xsf":
         data, lvec, ndim, atomic_info_or_head = loadVecFieldXsf(fname)
-    elif (data_format=="npy"):
+    elif data_format == "npy":
         data, lvec, atomic_info_or_head = loadVecFieldNpy(fname)
         ndim = data.shape
     else:
         print("I cannot load this format!")
-    return data.copy(), lvec, ndim, atomic_info_or_head;
+    return data.copy(), lvec, ndim, atomic_info_or_head
 
 
 # =============== Scalar Fields
 
-def save_scal_field(fname, data, lvec, data_format="xsf", head = XSF_HEAD_DEFAULT , atomic_info = None):
-    '''
+
+def save_scal_field(
+    fname, data, lvec, data_format="xsf", head=XSF_HEAD_DEFAULT, atomic_info=None
+):
+    """
     Saving scalar fields into xsf, or npy
 
     Arguments:
@@ -754,18 +962,20 @@ def save_scal_field(fname, data, lvec, data_format="xsf", head = XSF_HEAD_DEFAUL
         data_format: str "xsf" or "npy".
         head: string header of the XSF file
         atomic_info: tuple of shape (2) with 2 np.arrays - one is np.array([e,x,y,z]) with atoms positions and the second one is np.array(lvec) of shape (4,3) with saved information about lattice vector.
-    '''
-    if (data_format=="xsf"):
-        saveXSF(fname+".xsf", data, lvec, head = head)
-    elif (data_format=="npy"):
-        atomic_info = atomic_info if atomic_info is not None else (np.zeros((4,1)),lvec)
+    """
+    if data_format == "xsf":
+        saveXSF(fname + ".xsf", data, lvec, head=head)
+    elif data_format == "npy":
+        atomic_info = (
+            atomic_info if atomic_info is not None else (np.zeros((4, 1)), lvec)
+        )
         saveNpy(fname, data, lvec, atomic_info)
     else:
         print("I cannot save this format!")
 
 
 def load_scal_field(fname, data_format="xsf"):
-    '''
+    """
     Loading Vector fields from xsf, or npy
 
     Arguments:
@@ -778,23 +988,23 @@ def load_scal_field(fname, data_format="xsf"):
         atomic_info_or_head: tuple or string. If tupple then shape (2) with 2 np.arrays,
              one is np.array([e,x,y,z]) with atoms positions and the second one is np.array(lvec0) of shape (4,3) with saved information about lattice vector.
              if string, the same information is basically stored as the header of xsf
-    '''
+    """
     atomic_info_or_head = None
-    if (data_format=="xsf"):
-        data, lvec, ndim, atomic_info_or_head =loadXSF(fname+".xsf")
-    elif (data_format=="npy"):
+    if data_format == "xsf":
+        data, lvec, ndim, atomic_info_or_head = loadXSF(fname + ".xsf")
+    elif data_format == "npy":
         data, lvec, atomic_info_or_head = loadNpy(fname)
         ndim = data.shape
-    elif (data_format=="cube"):
-        data,lvec, ndim, atomic_info_or_head = loadCUBE(fname+".cube")
+    elif data_format == "cube":
+        data, lvec, ndim, atomic_info_or_head = loadCUBE(fname + ".cube")
     else:
         print("I cannot load this format!")
-    return data.copy(), lvec, ndim, atomic_info_or_head;
+    return data.copy(), lvec, ndim, atomic_info_or_head
 
 
 # ================ POV-Ray
 
-DEFAULT_POV_HEAD_NO_CAM='''
+DEFAULT_POV_HEAD_NO_CAM = """
 background      { color rgb <1.0,1.0,1.0> }
 //background      { color rgb <0.5,0.5,0.5> }
 //global_settings { ambient_light rgb< 0.2, 0.2, 0.2> }
@@ -835,9 +1045,10 @@ background      { color rgb <1.0,1.0,1.0> }
   no_shadow // comment this out if you want include shadows
   }
 #end
-'''
+"""
 
-DEFAULT_POV_HEAD='''
+DEFAULT_POV_HEAD = (
+    """
 // ***********************************************
 // Camera & other global settings
 // ***********************************************
@@ -852,40 +1063,101 @@ camera{
   up       < 0, Zoom, 0 >
   look_at  < .0.0,  0.0,  0.0 >
 }
-'''+DEFAULT_POV_HEAD_NO_CAM
+"""
+    + DEFAULT_POV_HEAD_NO_CAM
+)
 
-def makePovCam( pos, up=[0.0,1.0,0.0], rg=[-1.0, 0.0, 0.0], fw=[0.0, 0.0, 100.0], lpos=[0.0, 0.0,-100.0], W=10.0, H=10.0 ):
-    return '''
+
+def makePovCam(
+    pos,
+    up=[0.0, 1.0, 0.0],
+    rg=[-1.0, 0.0, 0.0],
+    fw=[0.0, 0.0, 100.0],
+    lpos=[0.0, 0.0, -100.0],
+    W=10.0,
+    H=10.0,
+):
+    return """
     // ***********************************************
     // Camera & other global settings
     // ***********************************************
     #declare Zoom   = 30.0;
     #declare Width  = 800;
     #declare Height = 800;
-    camera{
+    camera{{
       orthographic
-      right    %f
-      up       %f
-      sky      < %f, %f, %f >
-      location < %f, %f, %f >
-      look_at  < %f, %f, %f >
-    }
-    light_source    { < %f,%f,%f>  rgb <0.5,0.5,0.5> }
-    ''' %(  W,H, up[0],up[1],up[2],      pos[0]-fw[0],pos[1]-fw[1],pos[2]-fw[2],    pos[0],pos[1],pos[2],    lpos[0],lpos[1],lpos[2]    )
+      right    {:f}
+      up       {:f}
+      sky      < {:f}, {:f}, {:f} >
+      location < {:f}, {:f}, {:f} >
+      look_at  < {:f}, {:f}, {:f} >
+    }}
+    light_source    {{ < {:f},{:f},{:f}>  rgb <0.5,0.5,0.5> }}
+    """.format(
+        W,
+        H,
+        up[0],
+        up[1],
+        up[2],
+        pos[0] - fw[0],
+        pos[1] - fw[1],
+        pos[2] - fw[2],
+        pos[0],
+        pos[1],
+        pos[2],
+        lpos[0],
+        lpos[1],
+        lpos[2],
+    )
 
-def writePov( fname, xyzs, Zs, bonds=None, HEAD=DEFAULT_POV_HEAD, bondw=0.1, spherescale=0.25, ELEMENTS = elements.ELEMENTS ):
-    fout = open( fname,"w")
+
+def writePov(
+    fname,
+    xyzs,
+    Zs,
+    bonds=None,
+    HEAD=DEFAULT_POV_HEAD,
+    bondw=0.1,
+    spherescale=0.25,
+    ELEMENTS=elements.ELEMENTS,
+):
+    fout = open(fname, "w")
     n = len(xyzs)
-    fout.write( HEAD )
+    fout.write(HEAD)
     for i in range(n):
-        clr = ELEMENTS[Zs[i]-1][8]
-        R   = ELEMENTS[Zs[i]-1][7]
-        s = 'a( %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f ) \n' %( xyzs[i][0],xyzs[i][1],xyzs[i][2], spherescale*R, clr[0]/255.0,clr[1]/255.0,clr[2]/255.0,0.0 )
+        clr = ELEMENTS[Zs[i] - 1][8]
+        R = ELEMENTS[Zs[i] - 1][7]
+        s = "a( {:10.5f}, {:10.5f}, {:10.5f}, {:10.5f}, {:10.5f}, {:10.5f}, {:10.5f}, {:10.5f} ) \n".format(
+            xyzs[i][0],
+            xyzs[i][1],
+            xyzs[i][2],
+            spherescale * R,
+            clr[0] / 255.0,
+            clr[1] / 255.0,
+            clr[2] / 255.0,
+            0.0,
+        )
         fout.write(s)
     if bonds is not None:
         for b in bonds:
-            i = b[0]; j = b[1]
-            clr = [128,128,128]
-            s   =  'b( %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f,0.0 ) \n' %( xyzs[i][0],xyzs[i][1],xyzs[i][2], bondw, xyzs[j][0],xyzs[j][1],xyzs[j][2], bondw, clr[0]/255.0,clr[1]/255.0,clr[2]/255.0 )
-            fout.write(s);
+            i = b[0]
+            j = b[1]
+            clr = [128, 128, 128]
+            s = (
+                "b( %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f, %10.5f,0.0 ) \n"
+                % (
+                    xyzs[i][0],
+                    xyzs[i][1],
+                    xyzs[i][2],
+                    bondw,
+                    xyzs[j][0],
+                    xyzs[j][1],
+                    xyzs[j][2],
+                    bondw,
+                    clr[0] / 255.0,
+                    clr[1] / 255.0,
+                    clr[2] / 255.0,
+                )
+            )
+            fout.write(s)
     fout.close()

--- a/ppafm/io.py
+++ b/ppafm/io.py
@@ -517,7 +517,7 @@ def loadGeometry(fname=None, format=None, params=None):
         # Zero lattice vector is considered undefined and triggers creation of an automatic one.
         # The automatic generated lattice vector should enclose the whole area filled with atoms as well as the whole scanning area, plus the default padding.
         if np.allclose(lvec[i + 1, :], 0):
-            if not params["PBC"]:
+            if params["PBC"]:
                 lvec[i + 1, i] = (
                     max(max(atoms[i + 1]), params["scanMax"][i])
                     - min(min(atoms[i + 1]), params["scanMin"][i])

--- a/ppafm/ocl/relax.py
+++ b/ppafm/ocl/relax.py
@@ -11,130 +11,170 @@ from .. import common as PPU
 cl_program = None
 oclu = None
 
-DEFAULT_dTip         = np.array( [ 0.0 , 0.0 , -0.1 , 0.0 ], dtype=np.float32 );
-DEFAULT_stiffness    = np.array( [-0.03,-0.03, -0.03,-1.0 ], dtype=np.float32 );
-DEFAULT_dpos0        = np.array( [ 0.0 , 0.0 , -4.0 , 4.0 ], dtype=np.float32 );
-DEFAULT_relax_params = np.array( [ 0.5 , 0.1 ,  0.02, 0.5 ], dtype=np.float32 );
+DEFAULT_dTip = np.array([0.0, 0.0, -0.1, 0.0], dtype=np.float32)
+DEFAULT_stiffness = np.array([-0.03, -0.03, -0.03, -1.0], dtype=np.float32)
+DEFAULT_dpos0 = np.array([0.0, 0.0, -4.0, 4.0], dtype=np.float32)
+DEFAULT_relax_params = np.array([0.5, 0.1, 0.02, 0.5], dtype=np.float32)
 
 verbose = 0
 
 # ========== Functions
 
+
 def init(env):
     global cl_program
     global oclu
-    cl_program = env.loadProgram(env.CL_PATH / 'relax.cl')
+    cl_program = env.loadProgram(env.CL_PATH / "relax.cl")
     oclu = env
 
-def mat3x3to4f( M ):
-    a = np.zeros( 4, dtype=np.float32); a[0:3] = M[0]
-    b = np.zeros( 4, dtype=np.float32); b[0:3] = M[1]
-    c = np.zeros( 4, dtype=np.float32); c[0:3] = M[2]
+
+def mat3x3to4f(M):
+    a = np.zeros(4, dtype=np.float32)
+    a[0:3] = M[0]
+    b = np.zeros(4, dtype=np.float32)
+    b[0:3] = M[1]
+    c = np.zeros(4, dtype=np.float32)
+    c[0:3] = M[2]
     return (a, b, c)
 
-def getInvCell( lvec ):
-    cell = lvec[1:4,0:3]
-    invCell = np.transpose( np.linalg.inv(cell) )
-    if(verbose>0): print(invCell)
-    return mat3x3to4f( invCell )
 
-def preparePoss( scan_dim, z0, start=(0.0,0.0), end=(10.0,10.0) ):
-    ys    = np.linspace(start[0],end[0],scan_dim[0])
-    xs    = np.linspace(start[1],end[1],scan_dim[1])
-    Xs,Ys = np.meshgrid(xs,ys)
-    poss  = np.zeros(Xs.shape+(4,), dtype=np.float32)
-    poss[:,:,0] = Ys
-    poss[:,:,1] = Xs
-    poss[:,:,2] = z0
+def getInvCell(lvec):
+    cell = lvec[1:4, 0:3]
+    invCell = np.transpose(np.linalg.inv(cell))
+    if verbose > 0:
+        print(invCell)
+    return mat3x3to4f(invCell)
+
+
+def preparePoss(scan_dim, z0, start=(0.0, 0.0), end=(10.0, 10.0)):
+    ys = np.linspace(start[0], end[0], scan_dim[0])
+    xs = np.linspace(start[1], end[1], scan_dim[1])
+    Xs, Ys = np.meshgrid(xs, ys)
+    poss = np.zeros(Xs.shape + (4,), dtype=np.float32)
+    poss[:, :, 0] = Ys
+    poss[:, :, 1] = Xs
+    poss[:, :, 2] = z0
     return poss
 
-def preparePossRot( scan_dim, pos0, avec, bvec, start=(-5.0,-5.0), end=(5.0,5.0) ):
-    xs    = np.linspace(start[0],end[0],scan_dim[0])
-    ys    = np.linspace(start[1],end[1],scan_dim[1])
-    As,Bs = np.meshgrid(xs,ys, indexing='ij')
-    poss  = np.zeros(As.shape+(4,), dtype=np.float32)
-    poss[:,:,0] = pos0[0] + As*avec[0] + Bs*bvec[0]
-    poss[:,:,1] = pos0[1] + As*avec[1] + Bs*bvec[1]
-    poss[:,:,2] = pos0[2] + As*avec[2] + Bs*bvec[2]
+
+def preparePossRot(scan_dim, pos0, avec, bvec, start=(-5.0, -5.0), end=(5.0, 5.0)):
+    xs = np.linspace(start[0], end[0], scan_dim[0])
+    ys = np.linspace(start[1], end[1], scan_dim[1])
+    As, Bs = np.meshgrid(xs, ys, indexing="ij")
+    poss = np.zeros(As.shape + (4,), dtype=np.float32)
+    poss[:, :, 0] = pos0[0] + As * avec[0] + Bs * bvec[0]
+    poss[:, :, 1] = pos0[1] + As * avec[1] + Bs * bvec[1]
+    poss[:, :, 2] = pos0[2] + As * avec[2] + Bs * bvec[2]
     return poss
 
-def rotTip(rot,zstep,tipR0=[0.0,0.0,4.0]):
-    dTip         = np.zeros(4,dtype=np.float32)
-    dTip [:3]    = rot[2]*-zstep
-    tipRot       = mat3x3to4f( rot )
+
+def rotTip(rot, zstep, tipR0=[0.0, 0.0, 4.0]):
+    dTip = np.zeros(4, dtype=np.float32)
+    dTip[:3] = rot[2] * -zstep
+    tipRot = mat3x3to4f(rot)
     tipRot[2][3] = -zstep
 
-    dpos0Tip = np.zeros(4,dtype=np.float32);
-    dpos0Tip[0]  =   tipR0[0];
-    dpos0Tip[1]  =   tipR0[1];
-    dpos0Tip[2]  =  -np.sqrt(tipR0[2]**2 - tipR0[0]**2 - tipR0[1]**2);
-    dpos0Tip[3]  =   tipR0[2]
+    dpos0Tip = np.zeros(4, dtype=np.float32)
+    dpos0Tip[0] = tipR0[0]
+    dpos0Tip[1] = tipR0[1]
+    dpos0Tip[2] = -np.sqrt(tipR0[2] ** 2 - tipR0[0] ** 2 - tipR0[1] ** 2)
+    dpos0Tip[3] = tipR0[2]
 
-    dpos0    = np.zeros(4,dtype=np.float32);
-    dpos0[:3] = np.dot( rot.transpose(), dpos0Tip[:3] );
-    dpos0[3]  = tipR0[2]
-    return dTip, tipRot,dpos0Tip,dpos0
+    dpos0 = np.zeros(4, dtype=np.float32)
+    dpos0[:3] = np.dot(rot.transpose(), dpos0Tip[:3])
+    dpos0[3] = tipR0[2]
+    return dTip, tipRot, dpos0Tip, dpos0
+
 
 ## ============= Relax Class:
 
-class RelaxedScanner:
 
+class RelaxedScanner:
     verbose = 0
 
-    def __init__( self ):
-        self.queue  = oclu.queue
-        self.ctx    = oclu.ctx
-        self.stiffness    = DEFAULT_stiffness.copy()
+    def __init__(self):
+        self.queue = oclu.queue
+        self.ctx = oclu.ctx
+        self.stiffness = DEFAULT_stiffness.copy()
         self.relax_params = DEFAULT_relax_params.copy()
 
-        self.zstep = 0.1              # step of tip approach in scan [Angstroem]
-        self.start = (-5.0,-5.0)      # scan region start
-        self.end   = ( 5.0, 5.0)      # scan region end
-        self.tipR0 = 4.0              # equlibirum distance of ProbeParticle form ancoring point
+        self.zstep = 0.1  # step of tip approach in scan [Angstroem]
+        self.start = (-5.0, -5.0)  # scan region start
+        self.end = (5.0, 5.0)  # scan region end
+        self.tipR0 = 4.0  # equlibirum distance of ProbeParticle form ancoring point
 
-        self.surfFF = np.zeros(4,dtype=np.float32);
+        self.surfFF = np.zeros(4, dtype=np.float32)
 
         self.cl_atoms = None
         self.cl_zMap = None
         self.cl_feMap = None
 
-    def updateFEin(self, FEin_cl, bFinish=False ):
-        if(verbose>0): print(" updateFEin ", FEin_cl, self.cl_ImgIn, self.FEin_shape)
-        if(bFinish): self.queue.finish()
-        cl.enqueue_copy( queue=self.queue, src=FEin_cl, dest=self.cl_ImgIn, offset=0, origin=(0,0,0), region=self.FEin_shape[:3] )
-        if(bFinish): self.queue.finish()
-        self.FEin_cl=FEin_cl
+    def updateFEin(self, FEin_cl, bFinish=False):
+        if verbose > 0:
+            print(" updateFEin ", FEin_cl, self.cl_ImgIn, self.FEin_shape)
+        if bFinish:
+            self.queue.finish()
+        cl.enqueue_copy(
+            queue=self.queue,
+            src=FEin_cl,
+            dest=self.cl_ImgIn,
+            offset=0,
+            origin=(0, 0, 0),
+            region=self.FEin_shape[:3],
+        )
+        if bFinish:
+            self.queue.finish()
+        self.FEin_cl = FEin_cl
 
     def updateAtoms(self, atoms):
         if self.cl_atoms:
             self.cl_atoms.release()
-        self.nAtoms   = np.int32( len(atoms) )
-        self.cl_atoms = cl.Buffer(self.ctx, cl.mem_flags.READ_ONLY  | cl.mem_flags.COPY_HOST_PTR, hostbuf=atoms );
+        self.nAtoms = np.int32(len(atoms))
+        self.cl_atoms = cl.Buffer(
+            self.ctx, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=atoms
+        )
 
     def prepareAuxMapBuffers(self, bZMap=False, bFEmap=False, atoms=None):
         nbytes = 0
-        mf     = cl.mem_flags
-        fsize  = np.dtype(np.float32).itemsize
-        nxy    =  self.scan_dim[0] * self.scan_dim[1]
+        mf = cl.mem_flags
+        fsize = np.dtype(np.float32).itemsize
+        nxy = self.scan_dim[0] * self.scan_dim[1]
         if bZMap:
             if self.cl_zMap:
                 self.cl_zMap.release()
-            self.cl_zMap  = cl.Buffer(self.ctx, mf.WRITE_ONLY, nxy*fsize   ); nbytes += nxy*fsize
+            self.cl_zMap = cl.Buffer(self.ctx, mf.WRITE_ONLY, nxy * fsize)
+            nbytes += nxy * fsize
         if bFEmap:
             if self.cl_feMap:
                 self.cl_feMap.release()
-            self.cl_feMap = cl.Buffer(self.ctx, mf.WRITE_ONLY, nxy*fsize*4 ); nbytes += nxy*fsize*4
+            self.cl_feMap = cl.Buffer(self.ctx, mf.WRITE_ONLY, nxy * fsize * 4)
+            nbytes += nxy * fsize * 4
         if atoms is not None:
             if self.cl_atoms:
                 self.cl_atoms.release()
-            self.nAtoms   = np.int32( len(atoms) )
-            self.cl_atoms = cl.Buffer(self.ctx, cl.mem_flags.READ_ONLY  | cl.mem_flags.COPY_HOST_PTR, hostbuf=atoms )
-            nbytes+=atoms.nbytes
-        if(self.verbose>0): print("prepareAuxMapBuffers.nbytes: ", nbytes)
+            self.nAtoms = np.int32(len(atoms))
+            self.cl_atoms = cl.Buffer(
+                self.ctx,
+                cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR,
+                hostbuf=atoms,
+            )
+            nbytes += atoms.nbytes
+        if self.verbose > 0:
+            print("prepareAuxMapBuffers.nbytes: ", nbytes)
 
-    def prepareBuffers(self, FEin_np=None, lvec=None, FEin_cl=None, FEin_shape=None, scan_dim=None, nDimConv=None,
-            nDimConvOut=None, bZMap=False, bFEmap=False, atoms=None):
-
+    def prepareBuffers(
+        self,
+        FEin_np=None,
+        lvec=None,
+        FEin_cl=None,
+        FEin_shape=None,
+        scan_dim=None,
+        nDimConv=None,
+        nDimConvOut=None,
+        bZMap=False,
+        bFEmap=False,
+        atoms=None,
+    ):
         nbytes = 0
         mf = cl.mem_flags
 
@@ -142,56 +182,96 @@ class RelaxedScanner:
             self.lvec = lvec
             self.invCell = getInvCell(lvec)
         if FEin_np is not None:
-            self.cl_ImgIn = cl.image_from_array(self.ctx,FEin_np,num_channels=4,mode='r');  nbytes+=FEin_np.nbytes        # TODO make this re-uploadable
-            if(self.verbose>0): print("prepareBuffers made self.cl_ImgIn ", self.cl_ImgIn)
+            self.cl_ImgIn = cl.image_from_array(
+                self.ctx, FEin_np, num_channels=4, mode="r"
+            )
+            nbytes += FEin_np.nbytes  # TODO make this re-uploadable
+            if self.verbose > 0:
+                print("prepareBuffers made self.cl_ImgIn ", self.cl_ImgIn)
         else:
             if FEin_shape is not None:
-                self.FEin_shape   = FEin_shape
-                self.image_format = cl.ImageFormat( cl.channel_order.RGBA, cl.channel_type.FLOAT )
-                self.cl_ImgIn     = cl.Image(self.ctx, mf.READ_ONLY, self.image_format, shape=FEin_shape[:3],
-                    pitches=None, hostbuf=None, is_array=False, buffer=None)
-                if(self.verbose>0): print("prepareBuffers made self.cl_ImgIn ", self.cl_ImgIn)
+                self.FEin_shape = FEin_shape
+                self.image_format = cl.ImageFormat(
+                    cl.channel_order.RGBA, cl.channel_type.FLOAT
+                )
+                self.cl_ImgIn = cl.Image(
+                    self.ctx,
+                    mf.READ_ONLY,
+                    self.image_format,
+                    shape=FEin_shape[:3],
+                    pitches=None,
+                    hostbuf=None,
+                    is_array=False,
+                    buffer=None,
+                )
+                if self.verbose > 0:
+                    print("prepareBuffers made self.cl_ImgIn ", self.cl_ImgIn)
             if FEin_cl is not None:
-                self.updateFEin( FEin_cl )
-                self.FEin_cl=FEin_cl
+                self.updateFEin(FEin_cl)
+                self.FEin_cl = FEin_cl
 
         # see: https://stackoverflow.com/questions/39533635/pyopencl-3d-rgba-image-from-numpy-array
         if scan_dim is not None:
             self.scan_dim = scan_dim
-            fsize  = np.dtype(np.float32).itemsize
+            fsize = np.dtype(np.float32).itemsize
             f4size = fsize * 4
-            nxy    = self.scan_dim[0] * self.scan_dim[1]
-            bsz    = f4size * nxy
-            self.cl_poss  = cl.Buffer(self.ctx, mf.READ_ONLY , bsz                    );   nbytes+=bsz                  # float4
-            self.cl_FEout = cl.Buffer(self.ctx, mf.READ_WRITE, bsz * self.scan_dim[2] );   nbytes+=bsz*self.scan_dim[2]
-            self.cl_paths = cl.Buffer(self.ctx, mf.READ_WRITE, bsz * self.scan_dim[2] );   nbytes+=bsz*self.scan_dim[2]
+            nxy = self.scan_dim[0] * self.scan_dim[1]
+            bsz = f4size * nxy
+            self.cl_poss = cl.Buffer(self.ctx, mf.READ_ONLY, bsz)
+            nbytes += bsz  # float4
+            self.cl_FEout = cl.Buffer(self.ctx, mf.READ_WRITE, bsz * self.scan_dim[2])
+            nbytes += bsz * self.scan_dim[2]
+            self.cl_paths = cl.Buffer(self.ctx, mf.READ_WRITE, bsz * self.scan_dim[2])
+            nbytes += bsz * self.scan_dim[2]
             if nDimConv is not None:
-                self.nDimConv    = nDimConv
+                self.nDimConv = nDimConv
                 self.nDimConvOut = nDimConvOut
-                self.cl_FEconv = cl.Buffer(self.ctx, mf.WRITE_ONLY, bsz   * self.nDimConvOut ); nbytes += bsz   * self.nDimConvOut
-                self.cl_WZconv = cl.Buffer(self.ctx, mf.READ_ONLY,  fsize * self.nDimConv    ); nbytes += fsize * self.nDimConv
-                self.FEconv = np.empty(  self.scan_dim[:2]+(self.nDimConvOut,4,), dtype=np.float32 )
+                self.cl_FEconv = cl.Buffer(
+                    self.ctx, mf.WRITE_ONLY, bsz * self.nDimConvOut
+                )
+                nbytes += bsz * self.nDimConvOut
+                self.cl_WZconv = cl.Buffer(
+                    self.ctx, mf.READ_ONLY, fsize * self.nDimConv
+                )
+                nbytes += fsize * self.nDimConv
+                self.FEconv = np.empty(
+                    self.scan_dim[:2]
+                    + (
+                        self.nDimConvOut,
+                        4,
+                    ),
+                    dtype=np.float32,
+                )
 
         if bZMap:
-            self.cl_zMap    = cl.Buffer(self.ctx, mf.WRITE_ONLY, nxy*fsize   ); nbytes += nxy*fsize
+            self.cl_zMap = cl.Buffer(self.ctx, mf.WRITE_ONLY, nxy * fsize)
+            nbytes += nxy * fsize
         if bFEmap:
-            self.cl_feMap  = cl.Buffer(self.ctx, mf.WRITE_ONLY, nxy*fsize*4  ); nbytes += nxy*fsize*4
+            self.cl_feMap = cl.Buffer(self.ctx, mf.WRITE_ONLY, nxy * fsize * 4)
+            nbytes += nxy * fsize * 4
         if atoms is not None:
-            self.updateAtoms(atoms); nbytes+=atoms.nbytes
+            self.updateAtoms(atoms)
+            nbytes += atoms.nbytes
 
-        if(self.verbose>0): print("prepareBuffers.nbytes: ", nbytes)
+        if self.verbose > 0:
+            print("prepareBuffers.nbytes: ", nbytes)
 
     def releaseBuffers(self):
-        if(self.verbose>0): print("tryReleaseBuffers self.cl_ImgIn ", self.cl_ImgIn)
+        if self.verbose > 0:
+            print("tryReleaseBuffers self.cl_ImgIn ", self.cl_ImgIn)
         self.cl_ImgIn.release()
         self.cl_poss.release()
         self.cl_FEout.release()
-        if self.cl_zMap  is not None: self.cl_zMap.release()
-        if self.cl_feMap is not None: self.cl_feMap.release()
-        if self.cl_atoms is not None: self.cl_atoms.release()
+        if self.cl_zMap is not None:
+            self.cl_zMap.release()
+        if self.cl_feMap is not None:
+            self.cl_feMap.release()
+        if self.cl_atoms is not None:
+            self.cl_atoms.release()
 
     def tryReleaseBuffers(self):
-        if(self.verbose>0): print("tryReleaseBuffers self.cl_ImgIn ", self.cl_ImgIn)
+        if self.verbose > 0:
+            print("tryReleaseBuffers self.cl_ImgIn ", self.cl_ImgIn)
         try:
             self.cl_ImgIn.release()
         except:
@@ -217,51 +297,59 @@ class RelaxedScanner:
         except:
             pass
 
-    def preparePosBasis(self, start=(-5.0,-5.0), end=(5.0,5.0) ):
-        self.start       = start
-        self.end         = end
-        self.xs          = np.linspace(start[0], end[0], self.scan_dim[0])
-        self.ys          = np.linspace(start[1], end[1], self.scan_dim[1])
-        self.As, self.Bs = np.meshgrid(self.xs, self.ys, indexing='ij')
-        self.poss        = np.zeros(self.As.shape+(4,), dtype=np.float32)
+    def preparePosBasis(self, start=(-5.0, -5.0), end=(5.0, 5.0)):
+        self.start = start
+        self.end = end
+        self.xs = np.linspace(start[0], end[0], self.scan_dim[0])
+        self.ys = np.linspace(start[1], end[1], self.scan_dim[1])
+        self.As, self.Bs = np.meshgrid(self.xs, self.ys, indexing="ij")
+        self.poss = np.zeros(self.As.shape + (4,), dtype=np.float32)
 
-    def preparePossRot(self, pos0, avec, bvec ):
-        self.poss[:,:,0] = pos0[0] + self.As*avec[0] + self.Bs*bvec[0]
-        self.poss[:,:,1] = pos0[1] + self.As*avec[1] + self.Bs*bvec[1]
-        self.poss[:,:,2] = pos0[2] + self.As*avec[2] + self.Bs*bvec[2]
+    def preparePossRot(self, pos0, avec, bvec):
+        self.poss[:, :, 0] = pos0[0] + self.As * avec[0] + self.Bs * bvec[0]
+        self.poss[:, :, 1] = pos0[1] + self.As * avec[1] + self.Bs * bvec[1]
+        self.poss[:, :, 2] = pos0[2] + self.As * avec[2] + self.Bs * bvec[2]
         return self.poss
 
-    def setScanRot(self, pos0, rot=None, zstep=None, tipR0=[0.0,0.0,4.0] ):
+    def setScanRot(self, pos0, rot=None, zstep=None, tipR0=[0.0, 0.0, 4.0]):
         if rot is None:
             rot = np.eye(3)
         if zstep:
             self.zstep = zstep
-        self.dTip, self.tipRot, self.dpos0Tip, self.dpos0 = rotTip(rot,self.zstep,tipR0)
-        poss = self.preparePossRot( pos0, rot[0], rot[1] )
-        cl.enqueue_copy( self.queue, self.cl_poss, poss  )
+        self.dTip, self.tipRot, self.dpos0Tip, self.dpos0 = rotTip(
+            rot, self.zstep, tipR0
+        )
+        poss = self.preparePossRot(pos0, rot[0], rot[1])
+        cl.enqueue_copy(self.queue, self.cl_poss, poss)
         return poss
 
-    def updateBuffers(self, FEin=None, lvec=None, WZconv=None ):
-        if lvec is not None: self.invCell = getInvCell(lvec)
+    def updateBuffers(self, FEin=None, lvec=None, WZconv=None):
+        if lvec is not None:
+            self.invCell = getInvCell(lvec)
         if FEin is not None:
-            region = FEin.shape[:3]; region = region[::-1];
-            if(self.verbose>0): print("region : ", region)
-            cl.enqueue_copy( self.queue, self.cl_ImgIn, FEin, origin=(0,0,0), region=region )
+            region = FEin.shape[:3]
+            region = region[::-1]
+            if self.verbose > 0:
+                print("region : ", region)
+            cl.enqueue_copy(
+                self.queue, self.cl_ImgIn, FEin, origin=(0, 0, 0), region=region
+            )
         if WZconv is not None:
-            cl.enqueue_copy( self.queue, self.cl_WZconv, WZconv )
+            cl.enqueue_copy(self.queue, self.cl_WZconv, WZconv)
 
     def downloadPaths(self):
-        '''
+        """
         Get probe particle path array from device.
 
         Returns:
             paths: np.ndarray of shape scan_dim + (3,). xyz positions of probe particle at all scan points.
-        '''
+        """
 
         # Make numpy array. Last axis is bigger by one because OCL aligns to multiples of 4 floats.
-        paths = np.empty(self.scan_dim + (4,), dtype=np.float32, order='C')
+        paths = np.empty(self.scan_dim + (4,), dtype=np.float32, order="C")
 
-        if self.verbose: print("paths.shape ", paths.shape)
+        if self.verbose:
+            print("paths.shape ", paths.shape)
 
         # Copy from device to host
         cl.enqueue_copy(self.queue, paths, self.cl_paths)
@@ -275,71 +363,96 @@ class RelaxedScanner:
 
         return paths
 
-    def run(self, FEout=None, FEin=None, lvec=None, nz=None ):
-        '''
+    def run(self, FEout=None, FEin=None, lvec=None, nz=None):
+        """
         calculate force on relaxing probe particle approaching from top (z-direction)
-        '''
-        if nz is None: nz=self.scan_dim[2]
-        self.updateBuffers( FEin=FEin, lvec=lvec )
-        if FEout is None:    FEout = np.empty( self.scan_dim+(4,), dtype=np.float32 )
+        """
+        if nz is None:
+            nz = self.scan_dim[2]
+        self.updateBuffers(FEin=FEin, lvec=lvec)
+        if FEout is None:
+            FEout = np.empty(self.scan_dim + (4,), dtype=np.float32)
         kargs = (
             self.cl_ImgIn,
             self.cl_poss,
             self.cl_FEout,
-            self.invCell[0], self.invCell[1], self.invCell[2],
+            self.invCell[0],
+            self.invCell[1],
+            self.invCell[2],
             self.dTip,
             self.stiffness,
             self.dpos0,
             self.relax_params,
-            np.int32(nz) )
-        #print kargs
-        cl_program.relaxStrokes( self.queue, ( int(self.scan_dim[0]*self.scan_dim[1]),), None, *kargs )
-        cl.enqueue_copy( self.queue, FEout, self.cl_FEout )
+            np.int32(nz),
+        )
+        # print kargs
+        cl_program.relaxStrokes(
+            self.queue, (int(self.scan_dim[0] * self.scan_dim[1]),), None, *kargs
+        )
+        cl.enqueue_copy(self.queue, FEout, self.cl_FEout)
         self.queue.finish()
         return FEout
 
-    def run_relaxStrokesTilted(self, FEout=None, FEin=None, lvec=None, nz=None,     bCopy=True, bFinish=True ):
-        '''
+    def run_relaxStrokesTilted(
+        self, FEout=None, FEin=None, lvec=None, nz=None, bCopy=True, bFinish=True
+    ):
+        """
         calculate force on relaxing probe particle approaching from particular direction
-        '''
-        if nz is None: nz=self.scan_dim[2]
-        if bCopy and (FEout is None):    FEout = np.empty( self.scan_dim+(4,), dtype=np.float32 )
-        self.updateBuffers( FEin=FEin, lvec=lvec )
+        """
+        if nz is None:
+            nz = self.scan_dim[2]
+        if bCopy and (FEout is None):
+            FEout = np.empty(self.scan_dim + (4,), dtype=np.float32)
+        self.updateBuffers(FEin=FEin, lvec=lvec)
         kargs = (
             self.cl_ImgIn,
             self.cl_poss,
             self.cl_FEout,
             self.cl_paths,
-            self.invCell[0], self.invCell[1], self.invCell[2],
-            self.tipRot[0],  self.tipRot[1],  self.tipRot[2],
+            self.invCell[0],
+            self.invCell[1],
+            self.invCell[2],
+            self.tipRot[0],
+            self.tipRot[1],
+            self.tipRot[2],
             self.stiffness,
             self.dpos0Tip,
             self.relax_params,
             self.surfFF,
-            np.int32(nz) )
-        cl_program.relaxStrokesTilted( self.queue, ( int(self.scan_dim[0]*self.scan_dim[1]),), None, *kargs )
-        if(bCopy  ): cl.enqueue_copy( self.queue, FEout, self.cl_FEout )
-        if(bFinish): self.queue.finish()
+            np.int32(nz),
+        )
+        cl_program.relaxStrokesTilted(
+            self.queue, (int(self.scan_dim[0] * self.scan_dim[1]),), None, *kargs
+        )
+        if bCopy:
+            cl.enqueue_copy(self.queue, FEout, self.cl_FEout)
+        if bFinish:
+            self.queue.finish()
         return FEout
 
-    def run_relaxStrokesTilted_convZ(self, FEconv=None, FEin=None, lvec=None, nz=None ):
-        '''
+    def run_relaxStrokesTilted_convZ(self, FEconv=None, FEin=None, lvec=None, nz=None):
+        """
         calculate force on relaxing probe particle approaching from particular direction
-        '''
-        if nz is None: nz=self.scan_dim[2]
+        """
+        if nz is None:
+            nz = self.scan_dim[2]
         if FEconv is None:
             if self.FEconv is not None:
                 FEconv = self.FEconv
             else:
                 FEconv = self.prepareFEConv()
-        self.updateBuffers( FEin=FEin, lvec=lvec )
+        self.updateBuffers(FEin=FEin, lvec=lvec)
         kargs = (
             self.cl_ImgIn,
             self.cl_poss,
             self.cl_WZconv,
             self.cl_FEconv,
-            self.invCell[0], self.invCell[1], self.invCell[2],
-            self.tipRot[0],  self.tipRot[1],  self.tipRot[2],
+            self.invCell[0],
+            self.invCell[1],
+            self.invCell[2],
+            self.tipRot[0],
+            self.tipRot[1],
+            self.tipRot[2],
             self.stiffness,
             self.dpos0Tip,
             self.relax_params,
@@ -347,63 +460,97 @@ class RelaxedScanner:
             np.int32(nz),
             np.int32(self.nDimConvOut),
         )
-        cl_program.relaxStrokesTilted_convZ( self.queue, ( int(self.scan_dim[0]*self.scan_dim[1]),), None, *kargs )
-        cl.enqueue_copy( self.queue, FEconv, self.cl_FEconv )
+        cl_program.relaxStrokesTilted_convZ(
+            self.queue, (int(self.scan_dim[0] * self.scan_dim[1]),), None, *kargs
+        )
+        cl.enqueue_copy(self.queue, FEconv, self.cl_FEconv)
         self.queue.finish()
         return FEconv
 
-    def run_getFEinStrokes(self, FEout=None, FEconv=None, FEin=None, lvec=None, nz=None, WZconv=None, bDoConv=False ):
-        '''
+    def run_getFEinStrokes(
+        self,
+        FEout=None,
+        FEconv=None,
+        FEin=None,
+        lvec=None,
+        nz=None,
+        WZconv=None,
+        bDoConv=False,
+    ):
+        """
         un-relaxed sampling of FE values from input Force-field (cl_ImgIn) store to cl_FEout
-        '''
-        if nz is None: nz=self.scan_dim[2]
-        self.updateBuffers( FEin=FEin, lvec=lvec, WZconv=WZconv )
+        """
+        if nz is None:
+            nz = self.scan_dim[2]
+        self.updateBuffers(FEin=FEin, lvec=lvec, WZconv=WZconv)
         kargs = (
             self.cl_ImgIn,
             self.cl_poss,
             self.cl_FEout,
-            self.invCell[0], self.invCell[1], self.invCell[2],
+            self.invCell[0],
+            self.invCell[1],
+            self.invCell[2],
             self.dTip,
             self.dpos0,
-            np.int32(nz) )
-        cl_program.getFEinStrokes( self.queue, ( int(self.scan_dim[0]*self.scan_dim[1]),), None, *kargs )
+            np.int32(nz),
+        )
+        cl_program.getFEinStrokes(
+            self.queue, (int(self.scan_dim[0] * self.scan_dim[1]),), None, *kargs
+        )
         if bDoConv:
-            FEout = runZConv(self, FEconv=FEconv, nz=nz )
+            FEout = runZConv(self, FEconv=FEconv, nz=nz)
         else:
-            if FEout is None:    FEout = np.empty( self.scan_dim+(4,), dtype=np.float32 )
-            cl.enqueue_copy( self.queue, FEout, self.cl_FEout )
+            if FEout is None:
+                FEout = np.empty(self.scan_dim + (4,), dtype=np.float32)
+            cl.enqueue_copy(self.queue, FEout, self.cl_FEout)
         self.queue.finish()
         return FEout
 
-    def run_getFEinStrokesTilted(self, FEout=None, FEin=None, lvec=None, nz=None ):
-        '''
+    def run_getFEinStrokesTilted(self, FEout=None, FEin=None, lvec=None, nz=None):
+        """
         un-relaxed sampling of FE values from input Force-field (cl_ImgIn) store to cl_FEout
         operates in coordinates rotated by tipRot
-        '''
-        if nz is None: nz=self.scan_dim[2]
-        self.updateBuffers( FEin=FEin, lvec=lvec )
+        """
+        if nz is None:
+            nz = self.scan_dim[2]
+        self.updateBuffers(FEin=FEin, lvec=lvec)
         kargs = (
             self.cl_ImgIn,
             self.cl_poss,
             self.cl_FEout,
-            self.invCell[0], self.invCell[1], self.invCell[2],
-            self.tipRot[0],  self.tipRot[1],  self.tipRot[2],
+            self.invCell[0],
+            self.invCell[1],
+            self.invCell[2],
+            self.tipRot[0],
+            self.tipRot[1],
+            self.tipRot[2],
             self.dTip,
             self.dpos0,
-            np.int32(nz) )
-        cl_program.getFEinStrokesTilted( self.queue, ( int(self.scan_dim[0]*self.scan_dim[1]),), None, *kargs )
-        cl.enqueue_copy( self.queue, FEout, self.cl_FEout )
+            np.int32(nz),
+        )
+        cl_program.getFEinStrokesTilted(
+            self.queue, (int(self.scan_dim[0] * self.scan_dim[1]),), None, *kargs
+        )
+        cl.enqueue_copy(self.queue, FEout, self.cl_FEout)
         self.queue.finish()
         return FEout
 
-    def prepareFEConv( ):
-        return np.empty( self.scan_dim[:2]+(self.nDimConvOut,4,), dtype=np.float32 )
+    def prepareFEConv(self):
+        return np.empty(
+            self.scan_dim[:2]
+            + (
+                self.nDimConvOut,
+                4,
+            ),
+            dtype=np.float32,
+        )
 
-    def run_convolveZ(self, FEconv=None, nz=None ):
-        '''
+    def run_convolveZ(self, FEconv=None, nz=None):
+        """
         convolve 3D forcefield in FEout with 1D weight mask WZconv
-        '''
-        if nz is None: nz=self.scan_dim[2]
+        """
+        if nz is None:
+            nz = self.scan_dim[2]
         if FEconv is None:
             if self.FEconv is not None:
                 FEconv = self.FEconv
@@ -413,66 +560,85 @@ class RelaxedScanner:
             self.cl_FEout,
             self.cl_FEconv,
             self.cl_WZconv,
-            np.int32(nz), np.int32( self.nDimConvOut )
+            np.int32(nz),
+            np.int32(self.nDimConvOut),
         )
-        cl_program.convolveZ( self.queue, ( int(self.scan_dim[0]*self.scan_dim[1]),), None, *kargs )
-        cl.enqueue_copy( self.queue, FEconv, self.cl_FEconv )
+        cl_program.convolveZ(
+            self.queue, (int(self.scan_dim[0] * self.scan_dim[1]),), None, *kargs
+        )
+        cl.enqueue_copy(self.queue, FEconv, self.cl_FEconv)
         self.queue.finish()
         return FEconv
 
-    def run_izoZ(self, zMap=None, iso=0.0, nz=None ):
-        '''
+    def run_izoZ(self, zMap=None, iso=0.0, nz=None):
+        """
         get isosurface of input 3D field from top (z)
         used to generate HeightMap
         if cl_FEout is Forcefield it takes "z" where ( F(z) > iso )
-        '''
-        if nz is None: nz=self.scan_dim[2]
-        if zMap is None: zMap = np.empty( self.scan_dim[:2], dtype=np.float32 )
-        kargs = (
-            self.cl_FEout,
-            self.cl_zMap,
-            np.int32(nz), np.float32( iso ) )
-        cl_program.izoZ( self.queue, ( int(self.scan_dim[0]*self.scan_dim[1]),), None, *kargs )
-        cl.enqueue_copy( self.queue, zMap, self.cl_zMap )
+        """
+        if nz is None:
+            nz = self.scan_dim[2]
+        if zMap is None:
+            zMap = np.empty(self.scan_dim[:2], dtype=np.float32)
+        kargs = (self.cl_FEout, self.cl_zMap, np.int32(nz), np.float32(iso))
+        cl_program.izoZ(
+            self.queue, (int(self.scan_dim[0] * self.scan_dim[1]),), None, *kargs
+        )
+        cl.enqueue_copy(self.queue, zMap, self.cl_zMap)
         self.queue.finish()
         return zMap
 
-    def run_getZisoTilted(self, zMap=None, iso=0.0, nz=None ):
-        '''
+    def run_getZisoTilted(self, zMap=None, iso=0.0, nz=None):
+        """
         get isosurface of input 3D field from given direction
         used to generate HeightMap
         operates in coordinates rotated by tipRot
-        '''
-        if nz is None: nz=self.scan_dim[2]
-        if zMap is None: zMap = np.empty( self.scan_dim[:2], dtype=np.float32 )
+        """
+        if nz is None:
+            nz = self.scan_dim[2]
+        if zMap is None:
+            zMap = np.empty(self.scan_dim[:2], dtype=np.float32)
         kargs = (
             self.cl_ImgIn,
             self.cl_poss,
             self.cl_zMap,
-            self.invCell[0], self.invCell[1], self.invCell[2],
-            self.tipRot[0],  self.tipRot[1],  self.tipRot[2],
+            self.invCell[0],
+            self.invCell[1],
+            self.invCell[2],
+            self.tipRot[0],
+            self.tipRot[1],
+            self.tipRot[2],
             self.dTip,
             self.dpos0,
-            np.int32(nz), np.float32( iso ) )
+            np.int32(nz),
+            np.float32(iso),
+        )
         local_size = (1,)
-        cl_program.getZisoTilted( self.queue, ( int(self.scan_dim[0]*self.scan_dim[1]),), local_size, *kargs )
-        cl.enqueue_copy( self.queue, zMap, self.cl_zMap )
+        cl_program.getZisoTilted(
+            self.queue, (int(self.scan_dim[0] * self.scan_dim[1]),), local_size, *kargs
+        )
+        cl.enqueue_copy(self.queue, zMap, self.cl_zMap)
         self.queue.finish()
         return zMap
 
-    def run_getZisoFETilted(self, zMap=None, feMap=None, iso=0.0, nz=None ):
-        '''
+    def run_getZisoFETilted(self, zMap=None, feMap=None, iso=0.0, nz=None):
+        """
         get isosurface of input 3D field from given direction
         get map of 3D volume FE (e.g. electrostatic field) maped on 2D isosurface
         used to generate ElectrostaticMap
         returns zMap, feMap
         operates in coordinates rotated by tipRot
-        '''
+        """
         if self.cl_atoms is None:
-            raise ValueError('Atoms must be set before calculating the Electrostatic Map')
-        if nz is None: nz=self.scan_dim[2]
-        if zMap is None:  zMap  = np.empty( self.scan_dim[:2], dtype=np.float32 )
-        if feMap is None: feMap = np.empty( self.scan_dim[:2]+(4,), dtype=np.float32 )
+            raise ValueError(
+                "Atoms must be set before calculating the Electrostatic Map"
+            )
+        if nz is None:
+            nz = self.scan_dim[2]
+        if zMap is None:
+            zMap = np.empty(self.scan_dim[:2], dtype=np.float32)
+        if feMap is None:
+            feMap = np.empty(self.scan_dim[:2] + (4,), dtype=np.float32)
         kargs = (
             self.cl_ImgIn,
             self.cl_poss,
@@ -480,14 +646,25 @@ class RelaxedScanner:
             self.cl_feMap,
             self.nAtoms,
             self.cl_atoms,
-            self.invCell[0], self.invCell[1], self.invCell[2],
-            self.tipRot[0],  self.tipRot[1],  self.tipRot[2],
+            self.invCell[0],
+            self.invCell[1],
+            self.invCell[2],
+            self.tipRot[0],
+            self.tipRot[1],
+            self.tipRot[2],
             self.dTip,
             self.dpos0,
-            np.int32(nz), np.float32( iso ) )
+            np.int32(nz),
+            np.float32(iso),
+        )
         local_size = (1,)
-        cl_program.getZisoFETilted( self.queue, ( np.int32(self.scan_dim[0]*self.scan_dim[1]),), local_size, *kargs )
-        cl.enqueue_copy( self.queue,  zMap, self.cl_zMap  )
-        cl.enqueue_copy( self.queue, feMap, self.cl_feMap )
+        cl_program.getZisoFETilted(
+            self.queue,
+            (np.int32(self.scan_dim[0] * self.scan_dim[1]),),
+            local_size,
+            *kargs,
+        )
+        cl.enqueue_copy(self.queue, zMap, self.cl_zMap)
+        cl.enqueue_copy(self.queue, feMap, self.cl_feMap)
         self.queue.finish()
         return zMap, feMap


### PR DESCRIPTION
This can close #52
If the lattice vectors are specified neither in `params.ini` (as `gridA`, `grdB`, `gridC`) nor in the geometry input file (typically `input.xyz` but the FHI-AIMS's `geometry.in` can be, in principle, also given without lattice vectors), the code should propose suitable cell dimensions automatically and work with them thereafter. The logic followed to create the automatic cell is this: it should be large enough to encompass all atoms as well as the whole scanning space defined by `scanMin` and `scanMax`, plus some padding. I have currently put the hard-wired value of `3.0` (angstrom) for the padding in there but we can change it or make it more flexible if anyone prefers so.
The piece of code to implemented this is rather easy. My problem was where to place it to make it work reliably. I eventually decided to make it part of the `loadGeometry` function in `ppafm/io.py`. Implementing it as a separate function which gets called after `loadGeometry` might have been a somewhat cleaner solution regarding the code structure, but we would probably want to call it *every time* after `loadGeometry` anyway and would just have to always remember doing it, so I thought we might as well spare ourselves the hassle.
The main piece of the added code is here https://github.com/Probe-Particle/ppafm/blob/052ad8ed6dd5f686557f0895718d65cf479c7dca/ppafm/io.py#L490-L548
In my recent comment under #52, I have complained about a complicated code structure when it comes to handling the `lvec` array, the `grid` parameters etc. The most troubling feature with respect to implementing this part was the repeated shuffling of information about lattice vectors between the local variable(s) `lvec` and the global parameters `gridA`, `gridB`, `gridC`. I tried really hard to figure out when I should work with the former and when with the latter, but I gave up when I was still not sure after an insanely long time. (I do not think the time was completely wasted, it was probably necessary that I spend it to really understand the structure of the code, and why we should probably make it better.) Anyway, as you can see, I finally made this new snippet of code a bit more complex than strictly necessary for its core function, just to make really really sure that the `grid` parameters and the lattice vectors returned as `lvec` are mutually consistent once the work is done.
In my definition of the default lattice vectors, I treat the periodic and non-periodic cases differently. Essentially, the difference between the minimal and maximal coordinates that should be inside the cell defines the (length of) the lattice vectors in the periodic case. For a non-periodic structure, zero is always taken as the minimal coordinate. This is because the origin of the cell will be zero in any case, which does not really matter for periodic structures but makes a difference for non-periodic structures. In the non-periodic structures, anything with negative coordinates becomes inaccessible. This is actually described on our Wiki page under the caption **Cell definitions**, so it is strictly speaking not a bug, but I would still like to do something to alleviate this restriction eventually. So far, however, I am leaving it as it is.