### PR TITLE
Improve Fz2df conversion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,11 @@ repos:
       hooks:
           - id: pyupgrade
             args: [--py36-plus]
+    - repo: https://github.com/psf/black
+      rev: 23.3.0
+      hooks:
+          - id: black
+            language_version: python3
     # - repo: https://github.com/PyCQA/flake8
     #   rev: 6.0.0
     #   hooks:

--- a/ppafm/cli/fitting/plotLine.py
+++ b/ppafm/cli/fitting/plotLine.py
@@ -91,18 +91,17 @@ parser.add_option(
 (options, args) = parser.parse_args()
 opt_dict = vars(options)
 if options.points == []:
-    sys.exit(HELP_MSG)
+    sys.exit("Error!! The '-p' or '--points' argument is required\npython plotLine.py -p XMINxYMINxZMIN XMAXxYMAXxZMAX")
 
-FFparams = None
+PPU.loadParams("params.ini")
 if os.path.isfile("atomtypes.ini"):
     print(">> LOADING LOCAL atomtypes.ini")
     FFparams = PPU.loadSpecies("atomtypes.ini")
 else:
     import ppafm.cpp_utils as cpp_utils
 
-    FFparams = PPU.loadSpecies(cpp_utils.PACKAGE_PATH + "/defaults/atomtypes.ini")
+    FFparams = PPU.loadSpecies(cpp_utils.PACKAGE_PATH.joinpath("defaults/atomtypes.ini"))
 print(" >> OVEWRITING SETTINGS by params.ini  ")
-PPU.loadParams("params.ini", FFparams=FFparams)
 dz = PPU.params["scanStep"][2]
 Amp = [PPU.params["Amplitude"]]
 scan_min = PPU.params["scanMin"]
@@ -126,7 +125,11 @@ fzs, lvec, nDim, atomic_info_or_head = io.load_scal_field(
     dirname + "/OutFz", data_format=options.data_format
 )
 dfs = PPU.Fz2df(
-    fzs, dz=dz, k0=PPU.params["kCantilever"], f0=PPU.params["f0Cantilever"], A=Amp
+    fzs,
+    dz=dz,
+    k0=PPU.params["kCantilever"],
+    f0=PPU.params["f0Cantilever"],
+    amplitude=Amp,
 )
 for p in options.points:
     xmin = float(p[0].split("x")[0])
@@ -140,7 +143,9 @@ for p in options.points:
     print(opt_dict["disp"])
     if opt_dict["disp"]:
         print("Displacment {}".format(opt_dict["disp"][0]))
-        disp_all, lvec, nDim, atomic_info_or_head = io.load_vec_field(dirname + "/PPdisp_")
+        disp_all, lvec, nDim, atomic_info_or_head = io.load_vec_field(
+            dirname + "/PPdisp_"
+        )
         disp_x, disp_y, disp_z = io.unpackVecGrid(disp_all)
         del disp_all
         if opt_dict["disp"][0] == "x":

--- a/ppafm/cli/fitting/plotLine.py
+++ b/ppafm/cli/fitting/plotLine.py
@@ -126,7 +126,7 @@ fzs, lvec, nDim, atomic_info_or_head = io.load_scal_field(
     dirname + "/OutFz", data_format=options.data_format
 )
 dfs = PPU.Fz2df(
-    fzs, dz=dz, k0=PPU.params["kCantilever"], f0=PPU.params["f0Cantilever"], n=Amp / dz
+    fzs, dz=dz, k0=PPU.params["kCantilever"], f0=PPU.params["f0Cantilever"], A=Amp
 )
 for p in options.points:
     xmin = float(p[0].split("x")[0])

--- a/ppafm/cli/fitting/plotZ.py
+++ b/ppafm/cli/fitting/plotZ.py
@@ -94,7 +94,7 @@ for iq,Q in enumerate( Qs ):
         print(f"Working in {dirname} directory")
 
         fzs,lvec,nDim,atomic_info_or_head=io.load_scal_field(dirname+'/OutFz', format=format)
-        dfs = PPU.Fz2df( fzs, dz = dz, k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], n=Amp/dz )
+        dfs = PPU.Fz2df( fzs, dz = dz, k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], A=Amp )
         for p in options.points:
             x=float(p.split('x')[0])
             y=float(p.split('x')[1])

--- a/ppafm/cli/fitting/plotZ.py
+++ b/ppafm/cli/fitting/plotZ.py
@@ -14,146 +14,201 @@ import ppafm as PPU
 from ppafm import io
 
 
-def find_minimum(array,precision=0.0001):
-    i=1
-    while i<  len(array):
-        if (array[i-1] - array[i]) > precision  and ( array[i+1] - array[i]) > precision:
+def find_minimum(array, precision=0.0001):
+    i = 1
+    while i < len(array):
+        if (array[i - 1] - array[i]) > precision and (
+            array[i + 1] - array[i]
+        ) > precision:
             return i
-        i+=1
+        i += 1
 
 
-
-HELP_MSG="""Use this program in the following way:
-"""+os.path.basename(main.__file__) +""" -p "X1xY1" [-p "X2xY2" ...]  """
+HELP_MSG = (
+    """Use this program in the following way:
+"""
+    + os.path.basename(main.__file__)
+    + """ -p "X1xY1" [-p "X2xY2" ...]  """
+)
 
 parser = OptionParser()
-parser.add_option( "-k",       action="store", type="float", help="tip stiffenss [N/m]" )
-parser.add_option( "--krange", action="store", type="float", help="tip stiffenss range (min,max,n) [N/m]", nargs=3)
-parser.add_option( "-q",       action="store", type="float", help="tip charge [e]" )
-parser.add_option( "--qrange", action="store", type="float", help="tip charge range (min,max,n) [e]", nargs=3)
-parser.add_option( "-a",       action="store", type="float", help="oscilation amplitude [A]" )
-parser.add_option( "--arange", action="store", type="float", help="oscilation amplitude range (min,max,n) [A]", nargs=3)
+parser.add_option("-k", action="store", type="float", help="tip stiffenss [N/m]")
+parser.add_option(
+    "--krange",
+    action="store",
+    type="float",
+    help="tip stiffenss range (min,max,n) [N/m]",
+    nargs=3,
+)
+parser.add_option("-q", action="store", type="float", help="tip charge [e]")
+parser.add_option(
+    "--qrange",
+    action="store",
+    type="float",
+    help="tip charge range (min,max,n) [e]",
+    nargs=3,
+)
+parser.add_option("-a", action="store", type="float", help="oscilation amplitude [A]")
+parser.add_option(
+    "--arange",
+    action="store",
+    type="float",
+    help="oscilation amplitude range (min,max,n) [A]",
+    nargs=3,
+)
 
 
+parser.add_option(
+    "-p",
+    "--points",
+    default=[],
+    type=str,
+    help="Point where to perform Z-scan",
+    action="append",
+)
+parser.add_option(
+    "--npy",
+    action="store_true",
+    help="load and save fields in npy instead of xsf",
+    default=False,
+)
 
-parser.add_option("-p", "--points", default=[], type=str, help="Point where to perform Z-scan", action="append")
-parser.add_option( "--npy" , action="store_true" ,  help="load and save fields in npy instead of xsf"     , default=False)
-
-#parser.add_option( "-y", action="store", type="float", help="format of input file")
-#parser.add_option( "--yrange", action="store", type="float", help="y positions of the tip range (min,max,n) [A]", nargs=3)
+# parser.add_option( "-y", action="store", type="float", help="format of input file")
+# parser.add_option( "--yrange", action="store", type="float", help="y positions of the tip range (min,max,n) [A]", nargs=3)
 
 
 (options, args) = parser.parse_args()
 opt_dict = vars(options)
 print(options)
 if options.npy:
-    format ="npy"
+    format = "npy"
 else:
-    format ="xsf"
+    format = "xsf"
 
-if options.points==[]:
+if options.points == []:
     sys.exit(HELP_MSG)
 
 print(" >> OVEWRITING SETTINGS by params.ini  ")
-PPU.loadParams( 'params.ini' )
-dz  = PPU.params['scanStep'][2]
-Amp = [ PPU.params['Amplitude'] ]
-scan_max=PPU.params['scanMax'][2]
-scan_min=PPU.params['scanMin'][2]
-scan_step=PPU.params['scanStep'][2]
+PPU.loadParams("params.ini")
+dz = PPU.params["scanStep"][2]
+Amp = [PPU.params["Amplitude"]]
+scan_max = PPU.params["scanMax"][2]
+scan_min = PPU.params["scanMin"][2]
+scan_step = PPU.params["scanStep"][2]
 
 print(" >> OVEWRITING SETTINGS by command line arguments  ")
 
-if opt_dict['krange'] is not None:
-    Ks = np.linspace( opt_dict['krange'][0], opt_dict['krange'][1], opt_dict['krange'][2] )
-elif opt_dict['k'] is not None:
-    Ks = [ opt_dict['k'] ]
+if opt_dict["krange"] is not None:
+    Ks = np.linspace(
+        opt_dict["krange"][0], opt_dict["krange"][1], opt_dict["krange"][2]
+    )
+elif opt_dict["k"] is not None:
+    Ks = [opt_dict["k"]]
 else:
-    Ks = [ PPU.params['klat'] ]
+    Ks = [PPU.params["klat"]]
 # Qs
-if opt_dict['qrange'] is not None:
-    Qs = np.linspace( opt_dict['qrange'][0], opt_dict['qrange'][1], opt_dict['qrange'][2] )
-elif opt_dict['q'] is not None:
-    Qs = [ opt_dict['q'] ]
+if opt_dict["qrange"] is not None:
+    Qs = np.linspace(
+        opt_dict["qrange"][0], opt_dict["qrange"][1], opt_dict["qrange"][2]
+    )
+elif opt_dict["q"] is not None:
+    Qs = [opt_dict["q"]]
 else:
-    Qs = [ PPU.params['charge'] ]
+    Qs = [PPU.params["charge"]]
 # Amps
-if opt_dict['arange'] is not None:
-    Amps = np.linspace( opt_dict['arange'][0], opt_dict['arange'][1], opt_dict['arange'][2] )
-elif opt_dict['a'] is not None:
-    Amps = [ opt_dict['a'] ]
+if opt_dict["arange"] is not None:
+    Amps = np.linspace(
+        opt_dict["arange"][0], opt_dict["arange"][1], opt_dict["arange"][2]
+    )
+elif opt_dict["a"] is not None:
+    Amps = [opt_dict["a"]]
 else:
-    Amps = [ PPU.params['Amplitude'] ]
+    Amps = [PPU.params["Amplitude"]]
 
 
-
-for iq,Q in enumerate( Qs ):
-    for ik,K in enumerate( Ks ):
-        dirname = "Q%1.2fK%1.2f" %(Q,K)
+for iq, Q in enumerate(Qs):
+    for ik, K in enumerate(Ks):
+        dirname = "Q%1.2fK%1.2f" % (Q, K)
 
         print(f"Working in {dirname} directory")
 
-        fzs,lvec,nDim,atomic_info_or_head=io.load_scal_field(dirname+'/OutFz', format=format)
-        dfs = PPU.Fz2df( fzs, dz = dz, k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], A=Amp )
+        fzs, lvec, nDim, atomic_info_or_head = io.load_scal_field(
+            dirname + "/OutFz", data_format=format
+        )
+        dfs = PPU.Fz2df(
+            fzs,
+            dz=dz,
+            k0=PPU.params["kCantilever"],
+            f0=PPU.params["f0Cantilever"],
+            amplitude=Amp,
+        )
         for p in options.points:
-            x=float(p.split('x')[0])
-            y=float(p.split('x')[1])
-            x_pos=int(x/scan_step)
-            y_pos=int(y/scan_step)
+            x = float(p.split("x")[0])
+            y = float(p.split("x")[1])
+            x_pos = int(x / scan_step)
+            y_pos = int(y / scan_step)
 
-            Zplot=np.zeros(fzs.shape[0])
-            Fplot=np.zeros(fzs.shape[0])
-            DFplot=np.zeros(fzs.shape[0])
+            Zplot = np.zeros(fzs.shape[0])
+            Fplot = np.zeros(fzs.shape[0])
+            DFplot = np.zeros(fzs.shape[0])
 
-
-            for k in range(0,fzs.shape[0]):
-                    Fplot[k]=fzs[-k-1][y_pos][x_pos]
-                    Zplot[k]=scan_max-scan_step*k
-
+            for k in range(0, fzs.shape[0]):
+                Fplot[k] = fzs[-k - 1][y_pos][x_pos]
+                Zplot[k] = scan_max - scan_step * k
 
             # shifting the df plot
-            for k in range(0,dfs.shape[0]-1):
-                    DFplot[k+(int)(Amp/scan_step/2)]=dfs[-k-1][y_pos][x_pos]
-
+            for k in range(0, dfs.shape[0] - 1):
+                DFplot[k + (int)(Amp / scan_step / 2)] = dfs[-k - 1][y_pos][x_pos]
 
             xnew = np.linspace(Zplot[0], Zplot[-1], num=41, endpoint=True)
-            F_interp=interp1d(Zplot, Fplot,kind='cubic')
-            fig,ax1 = plt.subplots()
-            ax1.plot(Zplot, Fplot, 'ko', xnew, F_interp(xnew), 'k--')
-            ax1.set_xlabel(r'Z coordinate of the tip ($\AA$)')
-            ax1.set_ylabel(r'Force (eV/$\AA$)', color='black')
+            F_interp = interp1d(Zplot, Fplot, kind="cubic")
+            fig, ax1 = plt.subplots()
+            ax1.plot(Zplot, Fplot, "ko", xnew, F_interp(xnew), "k--")
+            ax1.set_xlabel(r"Z coordinate of the tip ($\AA$)")
+            ax1.set_ylabel(r"Force (eV/$\AA$)", color="black")
             for tl in ax1.get_yticklabels():
-                tl.set_color('black')
+                tl.set_color("black")
 
+            F_interp = interp1d(Zplot, DFplot, kind="cubic")
 
-
-
-            F_interp=interp1d(Zplot, DFplot,kind='cubic')
-
-            ax2=ax1.twinx()
-#                   min_index= np.argmin(DFplot)
-            min_index= find_minimum(DFplot)
-#                    print "MIN", min_index
-#                    print DFplot
-            ax2.plot(Zplot, DFplot,'bo', xnew, F_interp(xnew), 'b--')
+            ax2 = ax1.twinx()
+            #                   min_index= np.argmin(DFplot)
+            min_index = find_minimum(DFplot)
+            #                    print "MIN", min_index
+            #                    print DFplot
+            ax2.plot(Zplot, DFplot, "bo", xnew, F_interp(xnew), "b--")
             axes = plt.gca()
-            ax2.set_ylabel('Frequency shift (Hz)', color='b')
+            ax2.set_ylabel("Frequency shift (Hz)", color="b")
             for tl in ax2.get_yticklabels():
-                tl.set_color('b')
-            ax2.text(Zplot[min_index]+0.02, DFplot[min_index]-1.0,
-                        r'x:{:4.2f} ($\AA$); y:{:4.2f} (Hz)'.format(Zplot[min_index],
-                        DFplot[min_index]), style='italic',
-                        bbox={'facecolor':'blue', 'alpha':0.5, 'pad':0})
+                tl.set_color("b")
+            ax2.text(
+                Zplot[min_index] + 0.02,
+                DFplot[min_index] - 1.0,
+                r"x:{:4.2f} ($\AA$); y:{:4.2f} (Hz)".format(
+                    Zplot[min_index], DFplot[min_index]
+                ),
+                style="italic",
+                bbox={"facecolor": "blue", "alpha": 0.5, "pad": 0},
+            )
 
-            plt.axhline(y=0, color='black', ls='-.')
-            perplane=fig.add_axes([0.65, 0.6, 0.25, 0.25])
-#                    perplane.imshow(dfs[min_index+int(0.5/scan_step),:, :], origin='upper', cmap='gray')
-#                    perplane.imshow(dfs[len(Zplot)-min_index-(int)(Amp/scan_step/2)-5, :, :], origin='upper', cmap='gray')
-            perplane.imshow(dfs[len(Zplot)-min_index-(int)(Amp/scan_step/2)-int(1.0/scan_step), :, :], origin='upper', cmap='gray')
+            plt.axhline(y=0, color="black", ls="-.")
+            perplane = fig.add_axes([0.65, 0.6, 0.25, 0.25])
+            #                    perplane.imshow(dfs[min_index+int(0.5/scan_step),:, :], origin='upper', cmap='gray')
+            #                    perplane.imshow(dfs[len(Zplot)-min_index-(int)(Amp/scan_step/2)-5, :, :], origin='upper', cmap='gray')
+            perplane.imshow(
+                dfs[
+                    len(Zplot)
+                    - min_index
+                    - (int)(Amp / scan_step / 2)
+                    - int(1.0 / scan_step),
+                    :,
+                    :,
+                ],
+                origin="upper",
+                cmap="gray",
+            )
 
-            perplane.scatter(x=x_pos, y=y_pos, s=50, c='red', alpha=0.8)
-            perplane.axis('off')
-
-
+            perplane.scatter(x=x_pos, y=y_pos, s=50, c="red", alpha=0.8)
+            perplane.axis("off")
 
             plt.show()

--- a/ppafm/cli/plot_results.py
+++ b/ppafm/cli/plot_results.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -13,241 +14,464 @@ import ppafm.HighLevel as PPH
 import ppafm.PPPlot as PPPlot
 from ppafm import elements, io
 
-import matplotlib as mpl;  mpl.use('Agg'); print("plot WITHOUT Xserver"); # this makes it run without Xserver (e.g. on supercomputer) # see http://stackoverflow.com/questions/4931376/generating-matplotlib-graphs-without-a-running-x-server
+mpl.use("Agg")
+print("plot WITHOUT Xserver")
+# this makes it run without Xserver (e.g. on supercomputer) # see http://stackoverflow.com/questions/4931376/generating-matplotlib-graphs-without-a-running-x-server
 
 
 def main():
-
     parser = PPU.CLIParser(
-        description='Plot results for a scan with a specified charge, amplitude, and spring constant. '
-            'Images are saved in folder Q{charge}K{klat}/Amp{Amplitude}.'
+        description="Plot results for a scan with a specified charge, amplitude, and spring constant. "
+        "Images are saved in folder Q{charge}K{klat}/Amp{Amplitude}."
     )
-    parser.add_arguments(['output_format', 'Amplitude', 'arange', 'klat', 'krange', 'charge', 'qrange', 'Vbias', 'Vrange', 'noPBC'])
-    parser.add_argument( "--iets", action="store", type=float, help="Mass [a.u.]; Bias offset [eV]; Peak width [eV] ", nargs=3 )
-    parser.add_argument( "--LCPD_maps", action="store_true", help="Print LCPD maps")
-    parser.add_argument("--z0", action="store", type=float, default=0.0, help="Height of the topmost layer of metallic substrate for E to V conversion (Ang)")
-    parser.add_argument("--V0", action="store", type=float, default=0.0, help="Empirical LCPD maxima shift due to mesoscopic workfunction diference")
+    parser.add_arguments(
+        [
+            "output_format",
+            "Amplitude",
+            "arange",
+            "klat",
+            "krange",
+            "charge",
+            "qrange",
+            "Vbias",
+            "Vrange",
+            "noPBC",
+        ]
+    )
+    parser.add_argument(
+        "--iets",
+        action="store",
+        type=float,
+        help="Mass [a.u.]; Bias offset [eV]; Peak width [eV] ",
+        nargs=3,
+    )
+    parser.add_argument("--LCPD_maps", action="store_true", help="Print LCPD maps")
+    parser.add_argument(
+        "--z0",
+        action="store",
+        type=float,
+        default=0.0,
+        help="Height of the topmost layer of metallic substrate for E to V conversion (Ang)",
+    )
+    parser.add_argument(
+        "--V0",
+        action="store",
+        type=float,
+        default=0.0,
+        help="Empirical LCPD maxima shift due to mesoscopic workfunction diference",
+    )
 
-    parser.add_argument( "--df",       action="store_true", help="Plot images for dfz " )
-    parser.add_argument( "--save_df" , action="store_true", help="Save frequency shift as df.xsf " )
-    parser.add_argument( "--Laplace",  action="store_true", help="Plot Laplace-filtered images and save them " )
-    parser.add_argument( "--pos",      action="store_true", help="Save probe particle positions" )
-    parser.add_argument( "--atoms",    action="store_true", help="Plot atoms to images" )
-    parser.add_argument( "--bonds",    action="store_true", help="Plot bonds to images" )
-    parser.add_argument( "--cbar",     action="store_true", help="Plot colorbars to images" )
-    parser.add_argument( "--WSxM",     action="store_true", help="Save frequency shift into WsXM *.dat files" )
-    parser.add_argument( "--bI",       action="store_true", help="Plot images for Boltzmann current" )
+    parser.add_argument("--df", action="store_true", help="Plot images for dfz ")
+    parser.add_argument(
+        "--save_df", action="store_true", help="Save frequency shift as df.xsf "
+    )
+    parser.add_argument(
+        "--Laplace",
+        action="store_true",
+        help="Plot Laplace-filtered images and save them ",
+    )
+    parser.add_argument(
+        "--pos", action="store_true", help="Save probe particle positions"
+    )
+    parser.add_argument("--atoms", action="store_true", help="Plot atoms to images")
+    parser.add_argument("--bonds", action="store_true", help="Plot bonds to images")
+    parser.add_argument("--cbar", action="store_true", help="Plot colorbars to images")
+    parser.add_argument(
+        "--WSxM", action="store_true", help="Save frequency shift into WsXM *.dat files"
+    )
+    parser.add_argument(
+        "--bI", action="store_true", help="Plot images for Boltzmann current"
+    )
 
     args = parser.parse_args()
     opt_dict = vars(args)
 
-    PPU.loadParams( 'params.ini' )
+    PPU.loadParams("params.ini")
     PPU.apply_options(opt_dict)
 
-    if opt_dict['Laplace']:
+    if opt_dict["Laplace"]:
         from scipy.ndimage import laplace
 
     print(" >> OVEWRITING SETTINGS by command line arguments  ")
     # Ks
-    if opt_dict['krange'] is not None:
-        Ks = np.linspace( opt_dict['krange'][0], opt_dict['krange'][1], int(opt_dict['krange'][2]) )
-    elif opt_dict['klat'] is not None:
-        Ks = [ opt_dict['klat'] ]
-    elif PPU.params['stiffness'][0] > 0.0:
-        Ks = [PPU.params['stiffness'][0]]
+    if opt_dict["krange"] is not None:
+        Ks = np.linspace(
+            opt_dict["krange"][0], opt_dict["krange"][1], int(opt_dict["krange"][2])
+        )
+    elif opt_dict["klat"] is not None:
+        Ks = [opt_dict["klat"]]
+    elif PPU.params["stiffness"][0] > 0.0:
+        Ks = [PPU.params["stiffness"][0]]
     else:
-        Ks = [ PPU.params['klat']]
+        Ks = [PPU.params["klat"]]
     # Qs
-    if opt_dict['qrange'] is not None:
-        Qs = np.linspace( opt_dict['qrange'][0], opt_dict['qrange'][1], int(opt_dict['qrange'][2]) )
-    elif opt_dict['charge'] is not None:
-        Qs = [ opt_dict['charge'] ]
+    if opt_dict["qrange"] is not None:
+        Qs = np.linspace(
+            opt_dict["qrange"][0], opt_dict["qrange"][1], int(opt_dict["qrange"][2])
+        )
+    elif opt_dict["charge"] is not None:
+        Qs = [opt_dict["charge"]]
     else:
-        Qs = [ PPU.params['charge'] ]
+        Qs = [PPU.params["charge"]]
     # Amps
-    if opt_dict['arange'] is not None:
-        Amps = np.linspace( opt_dict['arange'][0], opt_dict['arange'][1], int(opt_dict['arange'][2]) )
-    elif opt_dict['Amplitude'] is not None:
-        Amps = [ opt_dict['Amplitude'] ]
+    if opt_dict["arange"] is not None:
+        Amps = np.linspace(
+            opt_dict["arange"][0], opt_dict["arange"][1], int(opt_dict["arange"][2])
+        )
+    elif opt_dict["Amplitude"] is not None:
+        Amps = [opt_dict["Amplitude"]]
     else:
-        Amps = [ PPU.params['Amplitude'] ]
+        Amps = [PPU.params["Amplitude"]]
     # Applied biases
     applied_bias = False
-    if opt_dict['Vrange'] is not None:
-        Vs = np.linspace( opt_dict['Vrange'][0], opt_dict['Vrange'][1], int(opt_dict['Vrange'][2]) )
-    elif opt_dict['Vbias'] is not None:
-        Vs = [ opt_dict['Vbias'] ]
+    if opt_dict["Vrange"] is not None:
+        Vs = np.linspace(
+            opt_dict["Vrange"][0], opt_dict["Vrange"][1], int(opt_dict["Vrange"][2])
+        )
+    elif opt_dict["Vbias"] is not None:
+        Vs = [opt_dict["Vbias"]]
     else:
         Vs = [0.0]
-    for iV,Vx in enumerate(Vs):
-        if ( abs(Vx) > 1e-7):
-            applied_bias=True
+    for iV, Vx in enumerate(Vs):
+        if abs(Vx) > 1e-7:
+            applied_bias = True
 
-    if (applied_bias == True):
+    if applied_bias == True:
         print("Vs   =", Vs)
     print("Ks   =", Ks)
     print("Qs   =", Qs)
     print("Amps =", Amps)
     print(" ============= RUN  ")
 
-    dz  = PPU.params['scanStep'][2]
-    xTips,yTips,zTips,lvecScan = PPU.prepareScanGrids( )
-    extent = ( xTips[0], xTips[-1], yTips[0], yTips[-1] )
+    dz = PPU.params["scanStep"][2]
+    xTips, yTips, zTips, lvecScan = PPU.prepareScanGrids()
+    extent = (xTips[0], xTips[-1], yTips[0], yTips[-1])
 
-    atoms_str=""
+    atoms_str = ""
     atoms = None
     bonds = None
     FFparams = None
-    if opt_dict['atoms'] or opt_dict['bonds']:
-        speciesFile=None
-        if os.path.isfile( 'atomtypes.ini' ):
-            speciesFile='atomtypes.ini'
-        FFparams=PPU.loadSpecies( speciesFile )
-        atoms_str="_atoms"
-        xyzs, Zs, qs, _ = io.loadXYZ('input_plot.xyz')
-        atoms = [list(Zs), list(xyzs[:, 0]), list(xyzs[:, 1]), list(xyzs[:, 2]), list(qs)]
-        FFparams            = PPU.loadSpecies( )
-        elem_dict           = PPU.getFFdict(FFparams)
-        iZs,Rs,Qs_tmp=PPU.parseAtoms(atoms, elem_dict, autogeom = False, PBC = PPU.params['PBC'] )
-        atom_colors = au.getAtomColors(iZs,FFparams=FFparams)
-        Rs=Rs.transpose().copy()
-        atoms= [iZs,Rs[0],Rs[1],Rs[2],atom_colors]
-    if opt_dict['bonds']:
-        bonds = au.findBonds(atoms,iZs,1.0,FFparams=FFparams)
+    if opt_dict["atoms"] or opt_dict["bonds"]:
+        speciesFile = None
+        if os.path.isfile("atomtypes.ini"):
+            speciesFile = "atomtypes.ini"
+        FFparams = PPU.loadSpecies(speciesFile)
+        atoms_str = "_atoms"
+        xyzs, Zs, qs, _ = io.loadXYZ("input_plot.xyz")
+        atoms = [
+            list(Zs),
+            list(xyzs[:, 0]),
+            list(xyzs[:, 1]),
+            list(xyzs[:, 2]),
+            list(qs),
+        ]
+        FFparams = PPU.loadSpecies()
+        elem_dict = PPU.getFFdict(FFparams)
+        iZs, Rs, Qs_tmp = PPU.parseAtoms(
+            atoms, elem_dict, autogeom=False, PBC=PPU.params["PBC"]
+        )
+        atom_colors = au.getAtomColors(iZs, FFparams=FFparams)
+        Rs = Rs.transpose().copy()
+        atoms = [iZs, Rs[0], Rs[1], Rs[2], atom_colors]
+    if opt_dict["bonds"]:
+        bonds = au.findBonds(atoms, iZs, 1.0, FFparams=FFparams)
     atomSize = 0.15
 
-    cbar_str =""
-    if opt_dict['cbar']:
-        cbar_str="_cbar"
+    cbar_str = ""
+    if opt_dict["cbar"]:
+        cbar_str = "_cbar"
 
-    for iq,Q in enumerate( Qs ):
-        for ik,K in enumerate( Ks ):
-            dirname = "Q%1.2fK%1.2f" %(Q,K)
-            for iv,Vx in enumerate( Vs ):
+    for iq, Q in enumerate(Qs):
+        for ik, K in enumerate(Ks):
+            dirname = f"Q{Q:1.2f}K{K:1.2f}"
+            for iv, Vx in enumerate(Vs):
                 if applied_bias:
-                    dirname = "Q%1.2fK%1.2fV%1.2f" %(Q,K,Vx)
-                if opt_dict['pos']:
+                    dirname = f"Q{Q:1.2f}K{K:1.2f}V{Vx:1.2f}"
+                if opt_dict["pos"]:
                     try:
-                        PPpos, lvec, nDim , atomic_info_or_head = io.load_vec_field(dirname+'/PPpos' ,data_format=args.output_format)
+                        PPpos, lvec, nDim, atomic_info_or_head = io.load_vec_field(
+                            dirname + "/PPpos", data_format=args.output_format
+                        )
                         print(" plotting PPpos : ")
                         PPPlot.plotDistortions(
-                            dirname+"/xy"+atoms_str+cbar_str, PPpos[:,:,:,0], PPpos[:,:,:,1], slices = list(range( 0, len(PPpos))), BG=PPpos[:,:,:,2],
-                            extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, markersize=2.0, cbar=opt_dict['cbar']
+                            dirname + "/xy" + atoms_str + cbar_str,
+                            PPpos[:, :, :, 0],
+                            PPpos[:, :, :, 1],
+                            slices=list(range(0, len(PPpos))),
+                            BG=PPpos[:, :, :, 2],
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            markersize=2.0,
+                            cbar=opt_dict["cbar"],
                         )
                         del PPpos
                     except:
                         print("error: ", sys.exc_info())
-                        print("cannot load : " + ( dirname+'/PPpos_?.' + args.output_format ))
-                if opt_dict['iets'] is not None:
-                    try :
-                        eigvalK, lvec, nDim = io.load_vec_field( dirname+'/eigvalKs' ,data_format=args.output_format)
-                        M  = opt_dict['iets'][0]
-                        E0 = opt_dict['iets'][1]
-                        w  = opt_dict['iets'][2]
-                        print(" plotting IETS M=%f V=%f w=%f " %(M,E0,w))
-                        hbar       = 6.58211951440e-16 # [eV.s]
-                        aumass     = 1.66053904020e-27 # [kg]
-                        eVA2_to_Nm = 16.0217662        # [eV/A^2] / [N/m]
-                        Evib = hbar * np.sqrt( ( eVA2_to_Nm * eigvalK )/( M * aumass ) )
-                        IETS = PPH.symGauss(Evib[:,:,:,0], E0, w) + PPH.symGauss(Evib[:,:,:,1], E0, w) + PPH.symGauss(Evib[:,:,:,2], E0, w)
-                        PPPlot.plotImages( dirname+"/IETS"+atoms_str+cbar_str, IETS, slices = list(range(0,len(IETS))), zs=zTips, extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'] )
-                        PPPlot.plotImages( dirname+"/Evib"+atoms_str+cbar_str, Evib[:,:,:,0], slices = list(range(0,len(IETS))), zs=zTips, extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'] )
-                        PPPlot.plotImages( dirname+"/Kvib"+atoms_str+cbar_str, 16.0217662 * eigvalK[:,:,:,0], slices = list(range(0,len(IETS))), zs=zTips, extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'] )
-                        del eigvalK; del Evib; del IETS
+                        print(
+                            "cannot load : "
+                            + (dirname + "/PPpos_?." + args.output_format)
+                        )
+                if opt_dict["iets"] is not None:
+                    try:
+                        eigvalK, lvec, nDim = io.load_vec_field(
+                            dirname + "/eigvalKs", data_format=args.output_format
+                        )
+                        M = opt_dict["iets"][0]
+                        E0 = opt_dict["iets"][1]
+                        w = opt_dict["iets"][2]
+                        print(f" plotting IETS M={M:f} V={E0:f} w={w:f} ")
+                        hbar = 6.58211951440e-16  # [eV.s]
+                        aumass = 1.66053904020e-27  # [kg]
+                        eVA2_to_Nm = 16.0217662  # [eV/A^2] / [N/m]
+                        Evib = hbar * np.sqrt((eVA2_to_Nm * eigvalK) / (M * aumass))
+                        IETS = (
+                            PPH.symGauss(Evib[:, :, :, 0], E0, w)
+                            + PPH.symGauss(Evib[:, :, :, 1], E0, w)
+                            + PPH.symGauss(Evib[:, :, :, 2], E0, w)
+                        )
+                        PPPlot.plotImages(
+                            dirname + "/IETS" + atoms_str + cbar_str,
+                            IETS,
+                            slices=list(range(0, len(IETS))),
+                            zs=zTips,
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            cbar=opt_dict["cbar"],
+                        )
+                        PPPlot.plotImages(
+                            dirname + "/Evib" + atoms_str + cbar_str,
+                            Evib[:, :, :, 0],
+                            slices=list(range(0, len(IETS))),
+                            zs=zTips,
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            cbar=opt_dict["cbar"],
+                        )
+                        PPPlot.plotImages(
+                            dirname + "/Kvib" + atoms_str + cbar_str,
+                            16.0217662 * eigvalK[:, :, :, 0],
+                            slices=list(range(0, len(IETS))),
+                            zs=zTips,
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            cbar=opt_dict["cbar"],
+                        )
+                        del eigvalK
+                        del Evib
+                        del IETS
                     except:
                         print("error: ", sys.exc_info())
-                        print("cannot load : ", dirname+'/PPpos_?.' + args.output_format)
-                if (  opt_dict['df'] or opt_dict['save_df'] or opt_dict['WSxM']  ):
-                    try :
-                        for iA,Amp in enumerate( Amps ):
-                            PPU.params['Amplitude'] = Amp
-                            AmpStr = "/Amp%2.2f" %Amp
-                            print("Amp= ",AmpStr)
-                            dirNameAmp = dirname+AmpStr
-                            if not os.path.exists( dirNameAmp ):
-                                os.makedirs( dirNameAmp )
+                        print(
+                            "cannot load : ", dirname + "/PPpos_?." + args.output_format
+                        )
+                if opt_dict["df"] or opt_dict["save_df"] or opt_dict["WSxM"]:
+                    try:
+                        for iA, Amp in enumerate(Amps):
+                            PPU.params["Amplitude"] = Amp
+                            AmpStr = "/Amp%2.2f" % Amp
+                            print("Amp= ", AmpStr)
+                            dirNameAmp = dirname + AmpStr
+                            if not os.path.exists(dirNameAmp):
+                                os.makedirs(dirNameAmp)
 
-                            if PPU.params['tiltedScan']:
-                                Fout, lvec, nDim , atomic_info_or_head = io.load_vec_field(dirname+'/OutF' , data_format=args.output_format)
-                                dfs = PPU.Fz2df_tilt( Fout, PPU.params['scanTilt'], k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], amplitude = Amp)
+                            if PPU.params["tiltedScan"]:
+                                (
+                                    Fout,
+                                    lvec,
+                                    nDim,
+                                    atomic_info_or_head,
+                                ) = io.load_vec_field(
+                                    dirname + "/OutF", data_format=args.output_format
+                                )
+                                dfs = PPU.Fz2df_tilt(
+                                    Fout,
+                                    PPU.params["scanTilt"],
+                                    k0=PPU.params["kCantilever"],
+                                    f0=PPU.params["f0Cantilever"],
+                                    amplitude=Amp,
+                                )
                                 lvec_df = np.array(lvec.copy())
-                                l=np.linalg.norm(lvec[3])
+                                l = np.linalg.norm(lvec[3])
                                 lvec_df[0] = lvec_df[0] + lvec_df[3] / l * Amp / 2
                                 lvec_df[3] = lvec_df[3] / l * (l - Amp)
                             else:
-                                fzs, lvec, nDim , atomic_info_or_head = io.load_scal_field(dirname+'/OutFz' , data_format=args.output_format)
-                                if (applied_bias):
-                                    Rtip = PPU.params['Rtip']
-                                    for iz,z in enumerate( zTips ):
-                                        fzs[iz,:,:] = fzs[iz,:,:] - np.pi*PPU.params['permit']*((Rtip*Rtip)/((z-args.z0)*(z+Rtip)))*(Vx-args.V0)*(Vx-args.V0)
-                                dfs = PPU.Fz2df( fzs, dz = dz, k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], amplitude = Amp)
+                                (
+                                    fzs,
+                                    lvec,
+                                    nDim,
+                                    atomic_info_or_head,
+                                ) = io.load_scal_field(
+                                    dirname + "/OutFz", data_format=args.output_format
+                                )
+                                if applied_bias:
+                                    Rtip = PPU.params["Rtip"]
+                                    for iz, z in enumerate(zTips):
+                                        fzs[iz, :, :] = fzs[
+                                            iz, :, :
+                                        ] - np.pi * PPU.params["permit"] * (
+                                            (Rtip * Rtip) / ((z - args.z0) * (z + Rtip))
+                                        ) * (
+                                            Vx - args.V0
+                                        ) * (
+                                            Vx - args.V0
+                                        )
+                                dfs = PPU.Fz2df(
+                                    fzs,
+                                    dz=dz,
+                                    k0=PPU.params["kCantilever"],
+                                    f0=PPU.params["f0Cantilever"],
+                                    amplitude=Amp,
+                                )
                                 lvec_df = np.array(lvec.copy())
-                                lvec_df[0][2] += Amp/2
+                                lvec_df[0][2] += Amp / 2
                                 lvec_df[3][2] -= Amp
 
-                            if opt_dict['save_df']:
-                                io.save_scal_field(dirNameAmp+'/df', dfs, lvec_df, data_format=args.output_format, head = atomic_info_or_head, atomic_info = atomic_info_or_head)
-                            if opt_dict['df']:
+                            if opt_dict["save_df"]:
+                                io.save_scal_field(
+                                    dirNameAmp + "/df",
+                                    dfs,
+                                    lvec_df,
+                                    data_format=args.output_format,
+                                    head=atomic_info_or_head,
+                                    atomic_info=atomic_info_or_head,
+                                )
+                            if opt_dict["df"]:
                                 print(" plotting df : ")
                                 PPPlot.plotImages(
-                                    dirNameAmp+"/df"+atoms_str+cbar_str, dfs,  slices = list(range( 0, len(dfs))), zs=zTips+PPU.params['Amplitude']/2.0,
-                                    extent=extent,cmap=PPU.params['colorscale'], atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar']
+                                    dirNameAmp + "/df" + atoms_str + cbar_str,
+                                    dfs,
+                                    slices=list(range(0, len(dfs))),
+                                    zs=zTips + PPU.params["Amplitude"] / 2.0,
+                                    extent=extent,
+                                    cmap=PPU.params["colorscale"],
+                                    atoms=atoms,
+                                    bonds=bonds,
+                                    atomSize=atomSize,
+                                    cbar=opt_dict["cbar"],
                                 )
-                            if opt_dict['Laplace']:
+                            if opt_dict["Laplace"]:
                                 print("plotting Laplace-filtered df : ")
                                 df_LaplaceFiltered = dfs.copy()
-                                laplace( dfs, output = df_LaplaceFiltered )
-                                io.save_scal_field(dirNameAmp+'/df_laplace', df_LaplaceFiltered, lvec,data_format=args.output_format , head = atomic_info_or_head , atomic_info = atomic_info_or_head)
-                                PPPlot.plotImages(
-                                    dirNameAmp+"/df_laplace"+atoms_str+cbar_str, df_LaplaceFiltered, slices = list(range( 0, len(dfs))), zs=zTips+PPU.params['Amplitude']/2.0,
-                                    extent=extent,cmap=PPU.params['colorscale'], atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar']
+                                laplace(dfs, output=df_LaplaceFiltered)
+                                io.save_scal_field(
+                                    dirNameAmp + "/df_laplace",
+                                    df_LaplaceFiltered,
+                                    lvec,
+                                    data_format=args.output_format,
+                                    head=atomic_info_or_head,
+                                    atomic_info=atomic_info_or_head,
                                 )
-                            if opt_dict['WSxM']:
+                                PPPlot.plotImages(
+                                    dirNameAmp + "/df_laplace" + atoms_str + cbar_str,
+                                    df_LaplaceFiltered,
+                                    slices=list(range(0, len(dfs))),
+                                    zs=zTips + PPU.params["Amplitude"] / 2.0,
+                                    extent=extent,
+                                    cmap=PPU.params["colorscale"],
+                                    atoms=atoms,
+                                    bonds=bonds,
+                                    atomSize=atomSize,
+                                    cbar=opt_dict["cbar"],
+                                )
+                            if opt_dict["WSxM"]:
                                 print(" printing df into WSxM files :")
-                                io.saveWSxM_3D( dirNameAmp+"/df" , dfs , extent , slices=None)
-                            if  opt_dict['LCPD_maps']:
-                                if (iv == 0):
-                                    LCPD_b = - dfs
-                                if (iv == (Vs.shape[0]-1)):
-                                    LCPD_b = (LCPD_b + dfs)/(2*Vx)
+                                io.saveWSxM_3D(
+                                    dirNameAmp + "/df", dfs, extent, slices=None
+                                )
+                            if opt_dict["LCPD_maps"]:
+                                if iv == 0:
+                                    LCPD_b = -dfs
+                                if iv == (Vs.shape[0] - 1):
+                                    LCPD_b = (LCPD_b + dfs) / (2 * Vx)
 
-                                if (iv == 0):
+                                if iv == 0:
                                     LCPD_a = dfs
-                                if (Vx == 0.0):
-                                    LCPD_a = LCPD_a - 2*dfs
-                                if (iv == (Vs.shape[0]-1)):
-                                    LCPD_a = (LCPD_a + dfs)/(2*Vx**2)
+                                if Vx == 0.0:
+                                    LCPD_a = LCPD_a - 2 * dfs
+                                if iv == (Vs.shape[0] - 1):
+                                    LCPD_a = (LCPD_a + dfs) / (2 * Vx**2)
                             del dfs
                         del fzs
                     except:
                         print("error: ", sys.exc_info())
-                        print("cannot load : ",dirname+'/OutFz.'+args.output_format)
-                if opt_dict['bI']:
+                        print(
+                            "cannot load : ", dirname + "/OutFz." + args.output_format
+                        )
+                if opt_dict["bI"]:
                     try:
-                        I, lvec, nDim , atomic_info_or_head = io.load_scal_field(dirname+'/OutI_boltzmann', data_format=args.output_format )
+                        I, lvec, nDim, atomic_info_or_head = io.load_scal_field(
+                            dirname + "/OutI_boltzmann", data_format=args.output_format
+                        )
                         print(" plotting Boltzmann current: ")
-                        PPPlot.plotImages( dirname+"/OutI"+atoms_str+cbar_str, I,  slices = list(range( 0,len(I))), zs=zTips, extent=extent, atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'] )
+                        PPPlot.plotImages(
+                            dirname + "/OutI" + atoms_str + cbar_str,
+                            I,
+                            slices=list(range(0, len(I))),
+                            zs=zTips,
+                            extent=extent,
+                            atoms=atoms,
+                            bonds=bonds,
+                            atomSize=atomSize,
+                            cbar=opt_dict["cbar"],
+                        )
                         del I
                     except:
                         print("error: ", sys.exc_info())
-                        print("cannot load : " + (dirname+'/OutI_boltzmann.'+args.output_format ))
-            if  opt_dict['LCPD_maps']:
-                LCPD = -LCPD_b/(2*LCPD_a)
+                        print(
+                            "cannot load : "
+                            + (dirname + "/OutI_boltzmann." + args.output_format)
+                        )
+            if opt_dict["LCPD_maps"]:
+                LCPD = -LCPD_b / (2 * LCPD_a)
                 PPPlot.plotImages(
-                    "./LCPD"+atoms_str+cbar_str, LCPD,  slices = list(range( 0, len(LCPD))), zs=zTips+PPU.params['Amplitude']/2.0,
-                    extent=extent,cmap=PPU.params['colorscale_kpfm'], atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'], symetric_map=True ,V0=args.V0
+                    "./LCPD" + atoms_str + cbar_str,
+                    LCPD,
+                    slices=list(range(0, len(LCPD))),
+                    zs=zTips + PPU.params["Amplitude"] / 2.0,
+                    extent=extent,
+                    cmap=PPU.params["colorscale_kpfm"],
+                    atoms=atoms,
+                    bonds=bonds,
+                    atomSize=atomSize,
+                    cbar=opt_dict["cbar"],
+                    symetric_map=True,
+                    V0=args.V0,
                 )
                 PPPlot.plotImages(
-                    "./_Asym-LCPD"+atoms_str+cbar_str, LCPD,  slices = list(range( 0, len(LCPD))), zs=zTips+PPU.params['Amplitude']/2.0,
-                    extent=extent,cmap=PPU.params['colorscale_kpfm'], atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'], symetric_map=False
+                    "./_Asym-LCPD" + atoms_str + cbar_str,
+                    LCPD,
+                    slices=list(range(0, len(LCPD))),
+                    zs=zTips + PPU.params["Amplitude"] / 2.0,
+                    extent=extent,
+                    cmap=PPU.params["colorscale_kpfm"],
+                    atoms=atoms,
+                    bonds=bonds,
+                    atomSize=atomSize,
+                    cbar=opt_dict["cbar"],
+                    symetric_map=False,
                 )
-                io.save_scal_field('./LCDP_HzperV', LCPD, lvec_df, data_format=args.output_format, head = atomic_info_or_head, atomic_info = atomic_info_or_head)
-                if opt_dict['WSxM']:
+                io.save_scal_field(
+                    "./LCDP_HzperV",
+                    LCPD,
+                    lvec_df,
+                    data_format=args.output_format,
+                    head=atomic_info_or_head,
+                    atomic_info=atomic_info_or_head,
+                )
+                if opt_dict["WSxM"]:
                     print(" printing LCPD_b into WSxM files :")
-                    io.saveWSxM_3D( "./LCPD"+atoms_str , LCPD , extent , slices=None)
-
+                    io.saveWSxM_3D("./LCPD" + atoms_str, LCPD, extent, slices=None)
 
     print(" ***** ALL DONE ***** ")
+
 
 if __name__ == "__main__":
     main()

--- a/ppafm/cli/plot_results.py
+++ b/ppafm/cli/plot_results.py
@@ -169,7 +169,7 @@ def main():
 
                             if PPU.params['tiltedScan']:
                                 Fout, lvec, nDim , atomic_info_or_head = io.load_vec_field(dirname+'/OutF' , data_format=args.output_format)
-                                dfs = PPU.Fz2df_tilt( Fout, PPU.params['scanTilt'], k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], A = Amp)
+                                dfs = PPU.Fz2df_tilt( Fout, PPU.params['scanTilt'], k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], amplitude = Amp)
                                 lvec_df = np.array(lvec.copy())
                                 l=np.linalg.norm(lvec[3])
                                 lvec_df[0] = lvec_df[0] + lvec_df[3] / l * Amp / 2
@@ -180,13 +180,13 @@ def main():
                                     Rtip = PPU.params['Rtip']
                                     for iz,z in enumerate( zTips ):
                                         fzs[iz,:,:] = fzs[iz,:,:] - np.pi*PPU.params['permit']*((Rtip*Rtip)/((z-args.z0)*(z+Rtip)))*(Vx-args.V0)*(Vx-args.V0)
-                                dfs = PPU.Fz2df( fzs, dz = dz, k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], A = Amp)
+                                dfs = PPU.Fz2df( fzs, dz = dz, k0 = PPU.params['kCantilever'], f0=PPU.params['f0Cantilever'], amplitude = Amp)
                                 lvec_df = np.array(lvec.copy())
                                 lvec_df[0][2] += Amp/2
                                 lvec_df[3][2] -= Amp
 
                             if opt_dict['save_df']:
-                                io.save_scal_field(dirNameAmp+'/df', dfs, lvec_df,data_format=args.output_format , head = atomic_info_or_head , atomic_info = atomic_info_or_head)
+                                io.save_scal_field(dirNameAmp+'/df', dfs, lvec_df, data_format=args.output_format, head = atomic_info_or_head, atomic_info = atomic_info_or_head)
                             if opt_dict['df']:
                                 print(" plotting df : ")
                                 PPPlot.plotImages(
@@ -241,7 +241,7 @@ def main():
                     "./_Asym-LCPD"+atoms_str+cbar_str, LCPD,  slices = list(range( 0, len(LCPD))), zs=zTips+PPU.params['Amplitude']/2.0,
                     extent=extent,cmap=PPU.params['colorscale_kpfm'], atoms=atoms, bonds=bonds, atomSize=atomSize, cbar=opt_dict['cbar'], symetric_map=False
                 )
-                io.save_scal_field('./LCDP_HzperV', LCPD, lvec_df,data_format=args.output_format , head = atomic_info_or_head , atomic_info = atomic_info_or_head)
+                io.save_scal_field('./LCDP_HzperV', LCPD, lvec_df, data_format=args.output_format, head = atomic_info_or_head, atomic_info = atomic_info_or_head)
                 if opt_dict['WSxM']:
                     print(" printing LCPD_b into WSxM files :")
                     io.saveWSxM_3D( "./LCPD"+atoms_str , LCPD , extent , slices=None)

--- a/ppafm/common.py
+++ b/ppafm/common.py
@@ -11,228 +11,232 @@ verbose = 0
 
 # ====================== constants
 
-eVA_Nm               =  16.0217657
-CoulombConst         = -14.3996448915;
+eVA_Nm = 16.0217657
+CoulombConst = -14.3996448915
 
 # default parameters of simulation
-params={
-    'PBC': True,
-    'nPBC' :       np.array( [      1,        1,        1 ] ),
-    'gridN':       np.array( [ -1,     -1,   -1   ] ).astype(int),
-    'gridA':       np.array( [ 12.798,  -7.3889,  0.00000 ] ),
-    'gridB':       np.array( [ 12.798,   7.3889,  0.00000 ] ),
-    'gridC':       np.array( [      0,        0,      5.0 ] ),
-    'FFgrid0':     np.array( [ -1.0, -1.0, -1.0 ] ),
-    'FFgridA':     np.array( [ -1.0, -1.0, -1.0 ] ),
-    'FFgridB':     np.array( [ -1.0, -1.0, -1.0 ] ),
-    'FFgridC':     np.array( [ -1.0, -1.0, -1.0 ] ),
-    'moleculeShift':  np.array( [  0.0,      0.0,    0.0 ] ),
-    'probeType':   'O',
-    'charge':      0.00,
-    'Apauli':    18.0,
-    'Bpauli':     1.0,
-    'ffModel':     'LJ',
-    'Rcore':    0.7,
-    'r0Probe'  :  np.array( [ 0.00, 0.00, 4.00] ),
-    'stiffness':  np.array( [ -1.0, -1.0, -1.0] ),
-    'klat': 0.5,
-    'krad': 20.00,
-    'tip':  's',
-    'sigma': 0.7,
-    'scanStep': np.array( [ 0.10, 0.10, 0.10 ] ),
-    'scanMin': np.array( [   0.0,     0.0,    5.0 ] ),
-    'scanMax': np.array( [  20.0,    20.0,    8.0 ] ),
-    'scanTilt': np.array( [  0.0,    0.0,   -0.1 ] ),
-    'tiltedScan': False,
-    'kCantilever'  :  1800.0,
-    'f0Cantilever' :  30300.0,
-    'Amplitude'    :  1.0,
-    'plotSliceFrom':  16,
-    'plotSliceTo'  :  22,
-    'plotSliceBy'  :  1,
-    'imageInterpolation': 'bicubic',
-    'colorscale'   : 'gray',
-    'colorscale_kpfm'   : 'seismic',
-    'ddisp'        :  0.05,
-    'aMorse'       :  -1.6,
-    'tip_base':  np.array( ['None', 0.00 ]),
-    'Rtip'         :  30.0,
-    'permit'       :  0.00552634959,
-    'vdWDampKind' : 2,
-    '#' : None
+params = {
+    "PBC": True,
+    "nPBC": np.array([1, 1, 1]),
+    "gridN": np.array([-1, -1, -1]).astype(int),
+    "gridA": np.array([12.798, -7.3889, 0.00000]),
+    "gridB": np.array([12.798, 7.3889, 0.00000]),
+    "gridC": np.array([0, 0, 5.0]),
+    "FFgrid0": np.array([-1.0, -1.0, -1.0]),
+    "FFgridA": np.array([-1.0, -1.0, -1.0]),
+    "FFgridB": np.array([-1.0, -1.0, -1.0]),
+    "FFgridC": np.array([-1.0, -1.0, -1.0]),
+    "moleculeShift": np.array([0.0, 0.0, 0.0]),
+    "probeType": "O",
+    "charge": 0.00,
+    "Apauli": 18.0,
+    "Bpauli": 1.0,
+    "ffModel": "LJ",
+    "Rcore": 0.7,
+    "r0Probe": np.array([0.00, 0.00, 4.00]),
+    "stiffness": np.array([-1.0, -1.0, -1.0]),
+    "klat": 0.5,
+    "krad": 20.00,
+    "tip": "s",
+    "sigma": 0.7,
+    "scanStep": np.array([0.10, 0.10, 0.10]),
+    "scanMin": np.array([0.0, 0.0, 5.0]),
+    "scanMax": np.array([20.0, 20.0, 8.0]),
+    "scanTilt": np.array([0.0, 0.0, -0.1]),
+    "tiltedScan": False,
+    "kCantilever": 1800.0,
+    "f0Cantilever": 30300.0,
+    "Amplitude": 1.0,
+    "plotSliceFrom": 16,
+    "plotSliceTo": 22,
+    "plotSliceBy": 1,
+    "imageInterpolation": "bicubic",
+    "colorscale": "gray",
+    "colorscale_kpfm": "seismic",
+    "ddisp": 0.05,
+    "aMorse": -1.6,
+    "tip_base": np.array(["None", 0.00]),
+    "Rtip": 30.0,
+    "permit": 0.00552634959,
+    "vdWDampKind": 2,
+    "#": None,
 }
 
+
 class CLIParser(ArgumentParser):
-    '''
+    """
     Subclass from the built-in ArgumentParser with functionality to easily add arguments commonly used in ppafm scripts.
-    '''
+    """
 
     _cli_args = None
     _params_args = {
-        'Amplitude': {
-            'short_name': '-a',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Oscillation amplitude [Å]'
+        "Amplitude": {
+            "short_name": "-a",
+            "action": "store",
+            "type": float,
+            "help": "Oscillation amplitude [Å]",
         },
-        'klat': {
-            'short_name': '-k',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Lateral tip stiffness [N/m]'
+        "klat": {
+            "short_name": "-k",
+            "action": "store",
+            "type": float,
+            "help": "Lateral tip stiffness [N/m]",
         },
-        'charge': {
-            'short_name': '-q',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Probe particle charge [e]'
+        "charge": {
+            "short_name": "-q",
+            "action": "store",
+            "type": float,
+            "help": "Probe particle charge [e]",
         },
-        'tip': {
-            'short_name': '-t',
-            'action'    : 'store',
-            'type'      : str,
-            'default'   : 's',
-            'help'      : 'Tip model (multipole) {s,pz,dz2,..}'
+        "tip": {
+            "short_name": "-t",
+            "action": "store",
+            "type": str,
+            "default": "s",
+            "help": "Tip model (multipole) {s,pz,dz2,..}",
         },
-        'Rcore': {
-            'action'    : 'store',
-            'type'      : float,
-            'default'   : params['Rcore'],
-            'help'      : 'Width of nuclear charge density blob to achieve charge neutrality [Å]'
+        "Rcore": {
+            "action": "store",
+            "type": float,
+            "default": params["Rcore"],
+            "help": "Width of nuclear charge density blob to achieve charge neutrality [Å]",
         },
-        'sigma': {
-            'short_name': '-w',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Gaussian width for convolution in Electrostatics [Å]'
+        "sigma": {
+            "short_name": "-w",
+            "action": "store",
+            "type": float,
+            "help": "Gaussian width for convolution in Electrostatics [Å]",
         },
-        'Apauli': {
-            'short_name': '-A',
-            'action'    : 'store',
-            'type'      : float,
-            'default'   : 1.0,
-            'help'      : 'Prefactor A in the density overlap integral.'
+        "Apauli": {
+            "short_name": "-A",
+            "action": "store",
+            "type": float,
+            "default": 1.0,
+            "help": "Prefactor A in the density overlap integral.",
         },
-        'Bpauli': {
-            'short_name': '-B',
-            'action'    : 'store',
-            'type'      : float,
-            'default'   : -1.0,
-            'help'      : 'Exponent B in the density overlap integral. Negative value is equivalent to B=1.'
+        "Bpauli": {
+            "short_name": "-B",
+            "action": "store",
+            "type": float,
+            "default": -1.0,
+            "help": "Exponent B in the density overlap integral. Negative value is equivalent to B=1.",
         },
-        'ffModel': {
-            'action'    : 'store',
-            'default'   : 'LJ',
-            'help'      : "Force field model ('LJ','Morse','vdW')"
+        "ffModel": {
+            "action": "store",
+            "default": "LJ",
+            "help": "Force field model ('LJ','Morse','vdW')",
         },
     }
     _extra_args = {
-        'input': {
-            'short_name': '-i',
-            'action'    : 'store',
-            'required'  : True,
-            'help'      : 'Input file path. Mandatory. Supported formats are: .xyz, .cube, .xsf.'
+        "input": {
+            "short_name": "-i",
+            "action": "store",
+            "required": True,
+            "help": "Input file path. Mandatory. Supported formats are: .xyz, .cube, .xsf.",
         },
-        'input_format' : {
-            'short_name': '-F',
-            'action'    : 'store',
-            'default'   : None,
-            'help'      : 'Specify the input file format. By default the format is inferred from the file extension.'
+        "input_format": {
+            "short_name": "-F",
+            "action": "store",
+            "default": None,
+            "help": "Specify the input file format. By default the format is inferred from the file extension.",
         },
-        'output_format' : {
-            'short_name': '-f',
-            'action'    : 'store',
-            'default'   : 'xsf',
-            'help'      : 'Specify the output format. Supported formats are: xsf, npy'
+        "output_format": {
+            "short_name": "-f",
+            "action": "store",
+            "default": "xsf",
+            "help": "Specify the output format. Supported formats are: xsf, npy",
         },
-        'noPBC': {
-            'action'    : 'store_false',
-            'dest'      : 'PBC',
-            'default'   : None,
-            'help'      : 'Disable periodic boundary conditions.'
+        "noPBC": {
+            "action": "store_false",
+            "dest": "PBC",
+            "default": None,
+            "help": "Disable periodic boundary conditions.",
         },
-        'energy': {
-            'short_name': '-E',
-            'action'    : 'store_true',
-            'default'   : False,
-            'help'      : 'Compute the potential energy in addition to the force.'
+        "energy": {
+            "short_name": "-E",
+            "action": "store_true",
+            "default": False,
+            "help": "Compute the potential energy in addition to the force.",
         },
-        'krange': {
-            'action'    : 'store',
-            'type'      : float,
-            'nargs'     : 3,
-            'metavar'   : ('k_min', 'k_max', 'n_k'),
-            'help'      : 'Do scan for a range of tip stiffnesses. Overrides --klat.'
+        "krange": {
+            "action": "store",
+            "type": float,
+            "nargs": 3,
+            "metavar": ("k_min", "k_max", "n_k"),
+            "help": "Do scan for a range of tip stiffnesses. Overrides --klat.",
         },
-        'qrange': {
-            'action'    : 'store',
-            'type'      : float,
-            'nargs'     : 3,
-            'metavar'   : ('q_min', 'q_max', 'n_q'),
-            'help'      : 'Do scan for a range of tip charges. Overrides --charge.'
+        "qrange": {
+            "action": "store",
+            "type": float,
+            "nargs": 3,
+            "metavar": ("q_min", "q_max", "n_q"),
+            "help": "Do scan for a range of tip charges. Overrides --charge.",
         },
-        'arange': {
-            'action'    : 'store',
-            'type'      : float,
-            'nargs'     : 3,
-            'metavar'   : ('A_min', 'A_max', 'n_A'),
-            'help'      : 'Do scan for a range of amplitudes. Overrides --Amplitude.'
+        "arange": {
+            "action": "store",
+            "type": float,
+            "nargs": 3,
+            "metavar": ("A_min", "A_max", "n_A"),
+            "help": "Do scan for a range of amplitudes. Overrides --Amplitude.",
         },
-        'Vbias': {
-            'short_name': '-V',
-            'action'    : 'store',
-            'type'      : float,
-            'help'      : 'Applied bias voltage [V].'
+        "Vbias": {
+            "short_name": "-V",
+            "action": "store",
+            "type": float,
+            "help": "Applied bias voltage [V].",
         },
-        'Vrange': {
-            'action'    : 'store',
-            'type'      : float,
-            'nargs'     : 3,
-            'metavar'   : ('V_min', 'V_max', 'n_V'),
-            'help'      : 'Do scan for a range of voltages. Overrides --Vbias.'
+        "Vrange": {
+            "action": "store",
+            "type": float,
+            "nargs": 3,
+            "metavar": ("V_min", "V_max", "n_V"),
+            "help": "Do scan for a range of voltages. Overrides --Vbias.",
         },
     }
 
     def _check_params_args(self):
         for arg in self._params_args:
             if arg not in params:
-                raise ValueError(f'Argument name `{arg}` does not match with any parameter in global parameters dictionary.')
+                raise ValueError(
+                    f"Argument name `{arg}` does not match with any parameter in global parameters dictionary."
+                )
 
     @property
     def cli_args(self):
-        '''Dictionary of arguments.'''
+        """Dictionary of arguments."""
         if self._cli_args is None:
             self._check_params_args()
             self._cli_args = {**self._params_args, **self._extra_args}
         return self._cli_args
 
     def add_arguments(self, arg_names):
-        '''
+        """
         Add CLI arguments from predefined dictionary :data:`cli_params`.
 
         Arguments:
             arg_names: list of str. Names of arguments to add.
-        '''
+        """
         for name in arg_names:
             if name not in self.cli_args:
-                raise ValueError(f'Invalid argument name `{name}`')
+                raise ValueError(f"Invalid argument name `{name}`")
             arg_dict = self.cli_args[name]
-            if 'help' not in arg_dict:
-                raise ValueError(f'No help message defined for `{name}`')
-            if 'short_name' in arg_dict:
-                arg_names = [arg_dict['short_name'], f'--{name}']
-                del arg_dict['short_name']
+            if "help" not in arg_dict:
+                raise ValueError(f"No help message defined for `{name}`")
+            if "short_name" in arg_dict:
+                arg_names = [arg_dict["short_name"], f"--{name}"]
+                del arg_dict["short_name"]
             else:
-                arg_names = [f'--{name}']
+                arg_names = [f"--{name}"]
             self.add_argument(*arg_names, **arg_dict)
+
 
 # ==============================
 # ============================== Pure python functions
 # ==============================
 
-def get_df_weight( Amp, dz = 0.1):
 
-    '''
+def get_df_weight(Amp, dz=0.1):
+    """
     Conversion of vertical force Fz to frequency shift
     Returns the discretized version of the required convolution kernel
 
@@ -271,30 +275,34 @@ def get_df_weight( Amp, dz = 0.1):
 
     and their discrete versions f[i] = f(t[i]); f2[i] = f2(t[i]).
     Note: we set f(t) = 0 and f2(t) = pi for t > +1.
-    '''
+    """
 
-    n = int(np.ceil(Amp/dz))
-    w = np.zeros(n+1)
-    f = np.zeros(n+1)
-    f2 = np.zeros(n+1)
-    #Note that, because of how the convolution is defined, the weight array w needs to be reversed:
-    #The largest index of w[i] corresponds to the smallest index i of force F[j+i].
-    #In contrast to the theoretical description above, we already reverse all the auxiliary arrays (t,f,f2,df,df2) in the code,
-    #starting from t[n+1-i] -> t[i], so that we do not need to reverse w explicitely in the end.
-    t = np.linspace(-1 + 2*n*dz/Amp, -1, n+1)
-    if(n>1):
-        f[1:-1] = np.sqrt(1 - t[1:-1]*t[1:-1])
-        f2[1:-1] = (np.arccos(-t[1:-1]) - t[1:-1]*f[1:-1]) / 2.0
-    f2[0] = np.pi/2 #end point for t>=1 must be as if t=1 even if t>1
-    df = f[:-1] - f[1:] #numerical derivative (first derivative integrated over one-step-long intervals) of function f(t)
-    df2 = f2[:-1] - f2[1:] #numerical derivative (first derivative integrated over one-step-long intervals) of f2(t)
-    w[1:] = t[:-1]*df + df2 #coefficients to multiply F[i]
-    w[:-1] -= t[1:]*df + df2 #coefficients to multiply F[i+1]
-    return w/(np.pi*dz)
+    n = int(np.ceil(Amp / dz))
+    w = np.zeros(n + 1)
+    f = np.zeros(n + 1)
+    f2 = np.zeros(n + 1)
+    # Note that, because of how the convolution is defined, the weight array w needs to be reversed:
+    # The largest index of w[i] corresponds to the smallest index i of force F[j+i].
+    # In contrast to the theoretical description above, we already reverse all the auxiliary arrays (t,f,f2,df,df2) in the code,
+    # starting from t[n+1-i] -> t[i], so that we do not need to reverse w explicitely in the end.
+    t = np.linspace(-1 + 2 * n * dz / Amp, -1, n + 1)
+    if n > 1:
+        f[1:-1] = np.sqrt(1 - t[1:-1] * t[1:-1])
+        f2[1:-1] = (np.arccos(-t[1:-1]) - t[1:-1] * f[1:-1]) / 2.0
+    f2[0] = np.pi / 2  # end point for t>=1 must be as if t=1 even if t>1
+    df = (
+        f[:-1] - f[1:]
+    )  # numerical derivative (first derivative integrated over one-step-long intervals) of function f(t)
+    df2 = (
+        f2[:-1] - f2[1:]
+    )  # numerical derivative (first derivative integrated over one-step-long intervals) of f2(t)
+    w[1:] = t[:-1] * df + df2  # coefficients to multiply F[i]
+    w[:-1] -= t[1:] * df + df2  # coefficients to multiply F[i+1]
+    return w / (np.pi * dz)
 
-def get_simple_df_weight( n=10, dz = 0.1):
 
-    '''
+def get_simple_df_weight(n=10, dz=0.1):
+    """
     Conversion of vertical force Fz to frequency shift
     Returns the discretized version of the required convolution kernel
 
@@ -302,96 +310,130 @@ def get_simple_df_weight( n=10, dz = 0.1):
     n = number of grid points involved in the convolution (peak-to-peak amplitude = n *dz)
 
     Simpler version of the above get_df_weight()
-    '''
+    """
     n = int(n)
-    if n<2:
-        n=2
-    t = np.linspace(-1 + 0.5/n, 1 - 0.5/n, n-1)
-    f = np.sqrt(1-t*t)
+    if n < 2:
+        n = 2
+    t = np.linspace(-1 + 0.5 / n, 1 - 0.5 / n, n - 1)
+    f = np.sqrt(1 - t * t)
     w = np.zeros(n)
     w[:-1] = f
     w[1:] -= f
 
-    #renormalization
+    # renormalization
     t = np.linspace(-1, 1, n)
-    w0 = np.sum(t*w) #pi/2 in the large n limit
-    return w/(w0*n*dz)
+    w0 = np.sum(t * w)  # pi/2 in the large n limit
+    return w / (w0 * n * dz)
 
-def Fz2df( F, dz=0.1, k0 = params['kCantilever'], f0=params['f0Cantilever'], amplitude=1.0, units=16.0217656 ):
-    '''
+
+def Fz2df(
+    F,
+    dz=0.1,
+    k0=params["kCantilever"],
+    f0=params["f0Cantilever"],
+    amplitude=1.0,
+    units=16.0217656,
+):
+    """
     conversion of vertical force Fz to frequency shift
     according to:
     Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
-    '''
-    W = get_df_weight( amplitude, dz=dz )
-    dFconv = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F )
-    return dFconv*units*f0/k0
+    """
+    W = get_df_weight(amplitude, dz=dz)
+    dFconv = np.apply_along_axis(
+        lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F
+    )
+    return dFconv * units * f0 / k0
 
-def Fz2df_tilt( F,  d=params['scanTilt'], k0 = params['kCantilever'], f0=params['f0Cantilever'], amplitude=1.0, units=16.0217656 ):
-    '''
+
+def Fz2df_tilt(
+    F,
+    d=params["scanTilt"],
+    k0=params["kCantilever"],
+    f0=params["f0Cantilever"],
+    amplitude=1.0,
+    units=16.0217656,
+):
+    """
     conversion of vertical force Fz to frequency shift
     according to:
     Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
-    '''
-    dr = np.sqrt( d[0]**2 + d[1]**2 + d[2]**2 )
-    W = get_df_weight( amplitude, dz=dr )
-    dFconv_x = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F[:,:,:,0] )
-    dFconv_y = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F[:,:,:,1] )
-    dFconv_z = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F[:,:,:,2] )
-    return (dFconv_x*d[0] + dFconv_y*d[1] + dFconv_z*d[2] )*units*f0/k0
+    """
+    dr = np.sqrt(d[0] ** 2 + d[1] ** 2 + d[2] ** 2)
+    W = get_df_weight(amplitude, dz=dr)
+    dFconv_x = np.apply_along_axis(
+        lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F[:, :, :, 0]
+    )
+    dFconv_y = np.apply_along_axis(
+        lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F[:, :, :, 1]
+    )
+    dFconv_z = np.apply_along_axis(
+        lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F[:, :, :, 2]
+    )
+    return (dFconv_x * d[0] + dFconv_y * d[1] + dFconv_z * d[2]) * units * f0 / k0
+
 
 def rotation_matrix(axis, theta):
     """
     Return the rotation matrix associated with counterclockwise rotation about
     the given axis by theta radians.
     """
-    axis    =  np.asarray(axis)
-    axis    =  axis/np.sqrt(np.dot(axis, axis))
-    a       =  np.cos(theta/2.0)
-    b, c, d = -axis*np.sin(theta/2.0)
-    aa, bb, cc, dd = a*a, b*b, c*c, d*d
-    bc, ad, ac, ab, bd, cd = b*c, a*d, a*c, a*b, b*d, c*d
-    return np.array([[aa+bb-cc-dd, 2*(bc+ad), 2*(bd-ac)],
-                     [2*(bc-ad), aa+cc-bb-dd, 2*(cd+ab)],
-                     [2*(bd+ac), 2*(cd-ab), aa+dd-bb-cc]])
+    axis = np.asarray(axis)
+    axis = axis / np.sqrt(np.dot(axis, axis))
+    a = np.cos(theta / 2.0)
+    b, c, d = -axis * np.sin(theta / 2.0)
+    aa, bb, cc, dd = a * a, b * b, c * c, d * d
+    bc, ad, ac, ab, bd, cd = b * c, a * d, a * c, a * b, b * d, c * d
+    return np.array(
+        [
+            [aa + bb - cc - dd, 2 * (bc + ad), 2 * (bd - ac)],
+            [2 * (bc - ad), aa + cc - bb - dd, 2 * (cd + ab)],
+            [2 * (bd + ac), 2 * (cd - ab), aa + dd - bb - cc],
+        ]
+    )
 
-def makeRotJitter( n=10, maxAngle=0.3 ):
+
+def makeRotJitter(n=10, maxAngle=0.3):
     rotJitter = []
     nrn = 50
-    rnjit = (np.random.rand(nrn,4) - 0.5) * 2
+    rnjit = (np.random.rand(nrn, 4) - 0.5) * 2
     for i in range(nrn):
-        axis = rnjit[i,:3] /np.sqrt( np.dot(rnjit[i,:3],rnjit[i,:3]) )
-        rotJitter.append( rotation_matrix(axis, rnjit[i,3]*maxAngle  ) )
+        axis = rnjit[i, :3] / np.sqrt(np.dot(rnjit[i, :3], rnjit[i, :3]))
+        rotJitter.append(rotation_matrix(axis, rnjit[i, 3] * maxAngle))
     return rotJitter
 
-def genRotations( axis, thetas ):
-    return np.array( [ rotation_matrix(axis, theta) for theta in thetas ] )
+
+def genRotations(axis, thetas):
+    return np.array([rotation_matrix(axis, theta) for theta in thetas])
+
 
 def sphereTangentSpace(n=100):
-    golden_angle = np.pi * ( 3.0 - np.sqrt(5.0) )
-    theta  = golden_angle * np.arange(n)
-    z      = np.linspace(1.0 - 1.0/n, 1.0/n - 1.0, n)
-    radius = np.sqrt( 1.0 - z*z )
-    cas  = np.cos(theta)
-    sas  = np.sin(theta)
-    rots = np.zeros( (n,3,3) )
-    rots[:,2,0] = radius * cas
-    rots[:,2,1] = radius * sas
-    rots[:,2,2] = z
-    rots[:,0,0] = -sas
-    rots[:,0,1] =  cas
-    rots[:,1,:] =  np.cross( rots[:,2,:], rots[:,0,:] )
+    golden_angle = np.pi * (3.0 - np.sqrt(5.0))
+    theta = golden_angle * np.arange(n)
+    z = np.linspace(1.0 - 1.0 / n, 1.0 / n - 1.0, n)
+    radius = np.sqrt(1.0 - z * z)
+    cas = np.cos(theta)
+    sas = np.sin(theta)
+    rots = np.zeros((n, 3, 3))
+    rots[:, 2, 0] = radius * cas
+    rots[:, 2, 1] = radius * sas
+    rots[:, 2, 2] = z
+    rots[:, 0, 0] = -sas
+    rots[:, 0, 1] = cas
+    rots[:, 1, :] = np.cross(rots[:, 2, :], rots[:, 0, :])
     return rots
 
+
 def maxAlongDir(atoms, hdir):
-    xdir = np.dot( atoms[:,:3], hdir[:,None] )
+    xdir = np.dot(atoms[:, :3], hdir[:, None])
     imin = np.argmax(xdir)
     return imin, xdir[imin][0]
 
-def maxAlongDirEntropy(atoms, hdir, beta=1.0 ):
-    xdir = np.dot( atoms[:,:3], hdir[:,None] )
+
+def maxAlongDirEntropy(atoms, hdir, beta=1.0):
+    xdir = np.dot(atoms[:, :3], hdir[:, None])
     imin = np.argmax(xdir)
-    entropy = np.sum( np.exp( beta*(xdir - xdir[imin]) ) )
+    entropy = np.sum(np.exp(beta * (xdir - xdir[imin])))
     return imin, xdir[imin][0], entropy
 
 
@@ -399,311 +441,413 @@ def maxAlongDirEntropy(atoms, hdir, beta=1.0 ):
 # ==============================  server interface file I/O
 # ==============================
 
+
 def autoGridN():
-    params["gridN"][0]=round(np.linalg.norm(params["gridA"])*10)
-    params["gridN"][1]=round(np.linalg.norm(params["gridB"])*10)
-    params["gridN"][2]=round(np.linalg.norm(params["gridC"])*10)
+    params["gridN"][0] = round(np.linalg.norm(params["gridA"]) * 10)
+    params["gridN"][1] = round(np.linalg.norm(params["gridB"]) * 10)
+    params["gridN"][2] = round(np.linalg.norm(params["gridC"]) * 10)
     return params["gridN"]
 
 
 # overide default parameters by parameters read from a file
-def loadParams( fname ):
-    if(verbose>0): print(" >> OVERWRITING SETTINGS by "+fname)
+def loadParams(fname):
+    if verbose > 0:
+        print(" >> OVERWRITING SETTINGS by " + fname)
     fin = open(fname)
     for line in fin:
-        words=line.split()
-        if len(words)>=2:
+        words = line.split()
+        if len(words) >= 2:
             key = words[0]
             if key in params:
                 val = params[key]
-                if key[0][0] == '#' : continue
-                if(verbose>0): print(key,' is class ', val.__class__)
-                if   isinstance( val, bool ):
-                    word=words[1].strip()
-                    if (word[0]=="T") or (word[0]=="t"):
+                if key[0][0] == "#":
+                    continue
+                if verbose > 0:
+                    print(key, " is class ", val.__class__)
+                if isinstance(val, bool):
+                    word = words[1].strip()
+                    if (word[0] == "T") or (word[0] == "t"):
                         params[key] = True
                     else:
                         params[key] = False
-                    if(verbose>0): print(key, params[key], ">>",word,"<<")
-                elif isinstance( val, float ):
-                    params[key] = float( words[1] )
-                    if(verbose>0): print(key, params[key], words[1])
-                elif   isinstance( val, int ):
-                    params[key] = int( words[1] )
-                    if(verbose>0): print(key, params[key], words[1])
-                elif isinstance( val, str ):
+                    if verbose > 0:
+                        print(key, params[key], ">>", word, "<<")
+                elif isinstance(val, float):
+                    params[key] = float(words[1])
+                    if verbose > 0:
+                        print(key, params[key], words[1])
+                elif isinstance(val, int):
+                    params[key] = int(words[1])
+                    if verbose > 0:
+                        print(key, params[key], words[1])
+                elif isinstance(val, str):
                     params[key] = words[1]
-                    if(verbose>0): print(key, params[key], words[1])
-                elif isinstance(val, np.ndarray ):
+                    if verbose > 0:
+                        print(key, params[key], words[1])
+                elif isinstance(val, np.ndarray):
                     if val.dtype == float:
-                        params[key] = np.array([ float(words[1]), float(words[2]), float(words[3]) ])
-                        if(verbose>0): print(key, params[key], words[1], words[2], words[3])
+                        params[key] = np.array(
+                            [float(words[1]), float(words[2]), float(words[3])]
+                        )
+                        if verbose > 0:
+                            print(key, params[key], words[1], words[2], words[3])
                     elif val.dtype == int:
-                        if(verbose>0): print(key)
-                        params[key] = np.array([ int(words[1]), int(words[2]), int(words[3]) ])
-                        if(verbose>0): print(key, params[key], words[1], words[2], words[3])
+                        if verbose > 0:
+                            print(key)
+                        params[key] = np.array(
+                            [int(words[1]), int(words[2]), int(words[3])]
+                        )
+                        if verbose > 0:
+                            print(key, params[key], words[1], words[2], words[3])
                     else:
-                        params[key] = np.array([ str(words[1]), float(words[2]) ])
-                        if(verbose>0): print(key, params[key], words[1], words[2])
-            else :
+                        params[key] = np.array([str(words[1]), float(words[2])])
+                        if verbose > 0:
+                            print(key, params[key], words[1], words[2])
+            else:
                 raise ValueError(f"Parameter {key} is not known")
     fin.close()
-    if (params["gridN"][0]<=0):
+    if params["gridN"][0] <= 0:
         autoGridN()
 
-    params["tip"] = params["tip"].replace('"', ''); params["tip"] = params["tip"].replace("'", ''); ### necessary for working even with quotemarks in params.ini
-    params["tip_base"][0] = params["tip_base"][0].replace('"', ''); params["tip_base"][0] = params["tip_base"][0].replace("'", ''); ### necessary for working even with quotemarks in params.ini
+    params["tip"] = params["tip"].replace('"', "")
+    params["tip"] = params["tip"].replace("'", "")
+    ### necessary for working even with quotemarks in params.ini
+    params["tip_base"][0] = params["tip_base"][0].replace('"', "")
+    params["tip_base"][0] = params["tip_base"][0].replace("'", "")
+    ### necessary for working even with quotemarks in params.ini
+
 
 def apply_options(opt):
-    if(verbose>0): print("!!!! OVERRIDE params !!!! in Apply options:")
-    if(verbose>0): print(opt)
+    if verbose > 0:
+        print("!!!! OVERRIDE params !!!! in Apply options:")
+    if verbose > 0:
+        print(opt)
     for key, value in opt.items():
         if value is None:
             continue
         if key in params:
             params[key] = value
-            if key == 'klat' and params['stiffness'][0] > 0.0:
-                print('Overriding stiffness parameter with klat')
-                params['stiffness'] = np.array( [ -1.0, -1.0, -1.0] ) # klat overrides stiffness
-            if(verbose>0): print(f'Applied: {key} = {value}')
+            if key == "klat" and params["stiffness"][0] > 0.0:
+                print("Overriding stiffness parameter with klat")
+                params["stiffness"] = np.array(
+                    [-1.0, -1.0, -1.0]
+                )  # klat overrides stiffness
+            if verbose > 0:
+                print(f"Applied: {key} = {value}")
+
 
 # load atoms species parameters form a file ( currently used to load Lenard-Jones parameters )
-def loadSpecies( fname=None ):
+def loadSpecies(fname=None):
     if fname is None or not os.path.exists(fname):
-        if(verbose>0): print("WARRNING: loadSpecies(None) => load default atomtypes.ini")
-        fname = cpp_utils.PACKAGE_PATH / 'defaults' / 'atomtypes.ini'
-    if(verbose>0): print(" loadSpecies from ", fname)
-    #FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('atom',int),('symbol', '|S10')],usecols=[0,1,2,3])
-    FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('alpha',np.float64),('atom',int),('symbol', '|S10')],usecols=(0,1,2,3,4))
+        if verbose > 0:
+            print("WARRNING: loadSpecies(None) => load default atomtypes.ini")
+        fname = cpp_utils.PACKAGE_PATH / "defaults" / "atomtypes.ini"
+    if verbose > 0:
+        print(" loadSpecies from ", fname)
+    # FFparams=np.genfromtxt(fname,dtype=[('rmin',np.float64),('epsilon',np.float64),('atom',int),('symbol', '|S10')],usecols=[0,1,2,3])
+    FFparams = np.genfromtxt(
+        fname,
+        dtype=[
+            ("rmin", np.float64),
+            ("epsilon", np.float64),
+            ("alpha", np.float64),
+            ("atom", int),
+            ("symbol", "|S10"),
+        ],
+        usecols=(0, 1, 2, 3, 4),
+    )
     return FFparams
 
+
 # load atoms species parameters form a file ( currently used to load Lenard-Jones parameters )
-def loadSpeciesLines( lines ):
+def loadSpeciesLines(lines):
     params = []
     for l in lines:
         l = l.split()
         if len(l) >= 5:
             # print l
-            params.append( ( float(l[0]), float(l[1]), float(l[2]), int(l[3]), l[4] ) )
-    return np.array( params, dtype=[('rmin',np.float64),('epsilon',np.float64),('alpha',np.float64),('atom',int),('symbol', '|S10')])
+            params.append((float(l[0]), float(l[1]), float(l[2]), int(l[3]), l[4]))
+    return np.array(
+        params,
+        dtype=[
+            ("rmin", np.float64),
+            ("epsilon", np.float64),
+            ("alpha", np.float64),
+            ("atom", int),
+            ("symbol", "|S10"),
+        ],
+    )
 
-def autoGeom( Rs, shiftXY=False, fitCell=False, border=3.0 ):
-    '''
+
+def autoGeom(Rs, shiftXY=False, fitCell=False, border=3.0):
+    """
     set Force-Filed and Scanning supercell to fit optimally given geometry
     then shifts the geometry in the center of the supercell
-    '''
-    zmax=max(Rs[2]); 	Rs[2] -= zmax
-    if(verbose>0): print(" autoGeom subtracted zmax = ",zmax)
-    xmin=min(Rs[0]); xmax=max(Rs[0])
-    ymin=min(Rs[1]); ymax=max(Rs[1])
+    """
+    zmax = max(Rs[2])
+    Rs[2] -= zmax
+    if verbose > 0:
+        print(" autoGeom subtracted zmax = ", zmax)
+    xmin = min(Rs[0])
+    xmax = max(Rs[0])
+    ymin = min(Rs[1])
+    ymax = max(Rs[1])
     if fitCell:
-        params[ 'gridA'   ][0] = (xmax-xmin) + 2*border
-        params[ 'gridA'   ][1] = 0
-        params[ 'gridB'   ][0] = 0
-        params[ 'gridB'   ][1] = (ymax-ymin) + 2*border
-        params[ 'scanMin' ][0] = 0
-        params[ 'scanMin' ][1] = 0
-        params[ 'scanMax' ][0] = params[ 'gridA' ][0]
-        params[ 'scanMax' ][1] = params[ 'gridB' ][1]
-        if(verbose>0): print(" autoGeom changed cell to = ", params[ 'scanMax' ])
+        params["gridA"][0] = (xmax - xmin) + 2 * border
+        params["gridA"][1] = 0
+        params["gridB"][0] = 0
+        params["gridB"][1] = (ymax - ymin) + 2 * border
+        params["scanMin"][0] = 0
+        params["scanMin"][1] = 0
+        params["scanMax"][0] = params["gridA"][0]
+        params["scanMax"][1] = params["gridB"][1]
+        if verbose > 0:
+            print(" autoGeom changed cell to = ", params["scanMax"])
     if shiftXY:
-        dx = -0.5*(xmin+xmax) + 0.5*( params[ 'gridA' ][0] + params[ 'gridB' ][0] ); Rs[0] += dx
-        dy = -0.5*(ymin+ymax) + 0.5*( params[ 'gridA' ][1] + params[ 'gridB' ][1] ); Rs[1] += dy;
-        if(verbose>0): print(" autoGeom moved geometry by ",dx,dy)
+        dx = -0.5 * (xmin + xmax) + 0.5 * (params["gridA"][0] + params["gridB"][0])
+        Rs[0] += dx
+        dy = -0.5 * (ymin + ymax) + 0.5 * (params["gridA"][1] + params["gridB"][1])
+        Rs[1] += dy
+        if verbose > 0:
+            print(" autoGeom moved geometry by ", dx, dy)
 
-def wrapAtomsCell( Rs, da, db, avec, bvec ):
-    M    = np.array( (avec[:2],bvec[:2]) )
+
+def wrapAtomsCell(Rs, da, db, avec, bvec):
+    M = np.array((avec[:2], bvec[:2]))
     invM = np.linalg.inv(M)
-    if(verbose>0): print(M)
-    if(verbose>0): print(invM)
-    ABs = np.dot( Rs[:,:2], invM )
-    if(verbose>0): print("ABs.shape", ABs.shape)
-    ABs[:,0] = (ABs[:,0] +10+da)%1.0
-    ABs[:,1] = (ABs[:,1] +10+db)%1.0
-    Rs[:,:2] = np.dot( ABs, M )
+    if verbose > 0:
+        print(M)
+    if verbose > 0:
+        print(invM)
+    ABs = np.dot(Rs[:, :2], invM)
+    if verbose > 0:
+        print("ABs.shape", ABs.shape)
+    ABs[:, 0] = (ABs[:, 0] + 10 + da) % 1.0
+    ABs[:, 1] = (ABs[:, 1] + 10 + db) % 1.0
+    Rs[:, :2] = np.dot(ABs, M)
 
-def PBCAtoms( Zs, Rs, Qs, avec, bvec, na=None, nb=None ):
-    '''
+
+def PBCAtoms(Zs, Rs, Qs, avec, bvec, na=None, nb=None):
+    """
     multiply atoms of sample along supercell vectors
     the multiplied sample geometry is used for evaluation of forcefield in Periodic-boundary-Conditions ( PBC )
-    '''
+    """
     Zs_ = []
     Rs_ = []
     Qs_ = []
-    if na is None: na=params['nPBC'][0]
-    if nb is None: nb=params['nPBC'][1]
-    for i in range(-na,na+1):
-        for j in range(-nb,nb+1):
+    if na is None:
+        na = params["nPBC"][0]
+    if nb is None:
+        nb = params["nPBC"][1]
+    for i in range(-na, na + 1):
+        for j in range(-nb, nb + 1):
             for iatom in range(len(Zs)):
-                x = Rs[iatom][0] + i*avec[0] + j*bvec[0]
-                y = Rs[iatom][1] + i*avec[1] + j*bvec[1]
-                Zs_.append( Zs[iatom]          )
-                Rs_.append( (x,y,Rs[iatom][2]) )
-                Qs_.append( Qs[iatom]          )
+                x = Rs[iatom][0] + i * avec[0] + j * bvec[0]
+                y = Rs[iatom][1] + i * avec[1] + j * bvec[1]
+                Zs_.append(Zs[iatom])
+                Rs_.append((x, y, Rs[iatom][2]))
+                Qs_.append(Qs[iatom])
     return np.array(Zs_).copy(), np.array(Rs_).copy(), np.array(Qs_).copy()
 
-def PBCAtoms3D( Zs, Rs, Qs, cLJs, lvec, npbc=[1,1,1] ):
-    '''
+
+def PBCAtoms3D(Zs, Rs, Qs, cLJs, lvec, npbc=[1, 1, 1]):
+    """
     multiply atoms of sample along supercell vectors
     the multiplied sample geometry is used for evaluation of forcefield in Periodic-boundary-Conditions ( PBC )
-    '''
-    Zs_   = []
-    Rs_   = []
-    Qs_   = []
+    """
+    Zs_ = []
+    Rs_ = []
+    Qs_ = []
     cLJs_ = []
     for iatom in range(len(Zs)):
-        Zs_.append( Zs[iatom] )
-        Rs_.append( Rs[iatom] )
-        Qs_.append( Qs[iatom] )
-    for ia in range(-npbc[0],npbc[0]+1):
-        for ib in range(-npbc[1],npbc[1]+1):
-            for ic in range(-npbc[2],npbc[2]+1):
-                if (ia==0) and (ib==0) and (ic==0) :
+        Zs_.append(Zs[iatom])
+        Rs_.append(Rs[iatom])
+        Qs_.append(Qs[iatom])
+    for ia in range(-npbc[0], npbc[0] + 1):
+        for ib in range(-npbc[1], npbc[1] + 1):
+            for ic in range(-npbc[2], npbc[2] + 1):
+                if (ia == 0) and (ib == 0) and (ic == 0):
                     continue
                 for iatom in range(len(Zs)):
-                    x = Rs[iatom][0] + ia*lvec[0][0] + ib*lvec[1][0] + ic*lvec[2][0]
-                    y = Rs[iatom][1] + ia*lvec[0][1] + ib*lvec[1][1] + ic*lvec[2][1]
-                    z = Rs[iatom][2] + ia*lvec[0][2] + ib*lvec[1][2] + ic*lvec[2][2]
-                    Zs_.append( Zs[iatom] )
-                    Rs_.append( (x,y,z)   )
-                    Qs_.append( Qs[iatom] )
-                    cLJs_.append( cLJs[iatom,:] )
-    return np.array(Zs_).copy(), np.array(Rs_).copy(), np.array(Qs_).copy(), np.array(cLJs_).copy()
+                    x = (
+                        Rs[iatom][0]
+                        + ia * lvec[0][0]
+                        + ib * lvec[1][0]
+                        + ic * lvec[2][0]
+                    )
+                    y = (
+                        Rs[iatom][1]
+                        + ia * lvec[0][1]
+                        + ib * lvec[1][1]
+                        + ic * lvec[2][1]
+                    )
+                    z = (
+                        Rs[iatom][2]
+                        + ia * lvec[0][2]
+                        + ib * lvec[1][2]
+                        + ic * lvec[2][2]
+                    )
+                    Zs_.append(Zs[iatom])
+                    Rs_.append((x, y, z))
+                    Qs_.append(Qs[iatom])
+                    cLJs_.append(cLJs[iatom, :])
+    return (
+        np.array(Zs_).copy(),
+        np.array(Rs_).copy(),
+        np.array(Qs_).copy(),
+        np.array(cLJs_).copy(),
+    )
 
-def findPBCAtoms3D_cutoff( Rs, lvec, Rcut=1.0, corners=None ):
-    '''
+
+def findPBCAtoms3D_cutoff(Rs, lvec, Rcut=1.0, corners=None):
+    """
     find which atoms with positions 'Rs' and radius 'Rcut' thouch rhombic cell defined by 3x3 matrix 'lvec';
        or more precisely which points 'Rs' belong to a rhombic cell enlarged by margin Rcut on each side
     all assuming that 'Rcut' is smaller than the rhombic cell (in all directions)
-    '''
+    """
     invLvec = np.linalg.inv(lvec)
-    abc = np.dot( invLvec, Rs )  # atoms in grid coordinates
+    abc = np.dot(invLvec, Rs)  # atoms in grid coordinates
     # calculate margin on each side in grid coordinates
-    ra  = np.sqrt(np.dot(invLvec[0],invLvec[0]));   mA = ra*Rcut
-    rb  = np.sqrt(np.dot(invLvec[1],invLvec[1]));   mB = rb*Rcut
-    rc  = np.sqrt(np.dot(invLvec[2],invLvec[2]));   mC = rc*Rcut
-    cells = [-1,0,1]
-    inds  = []
-    Rs_   = []
-    a = abc[0];
-    b = abc[1];
-    c = abc[2];
+    ra = np.sqrt(np.dot(invLvec[0], invLvec[0]))
+    mA = ra * Rcut
+    rb = np.sqrt(np.dot(invLvec[1], invLvec[1]))
+    mB = rb * Rcut
+    rc = np.sqrt(np.dot(invLvec[2], invLvec[2]))
+    mC = rc * Rcut
+    cells = [-1, 0, 1]
+    inds = []
+    Rs_ = []
+    a = abc[0]
+    b = abc[1]
+    c = abc[2]
     i = 0
     for ia in cells:
-        mask_a  = (a>(-mA-ia)) & (a<(mA+1-ia))
-        shift_a = ia*lvec[0,:]
+        mask_a = (a > (-mA - ia)) & (a < (mA + 1 - ia))
+        shift_a = ia * lvec[0, :]
         for ib in cells:
-            mask_ab  = (b>(-mB-ib)) & (b<(mB+1-ib)) & mask_a
-            shift_ab = ib*lvec[1,:] + shift_a
+            mask_ab = (b > (-mB - ib)) & (b < (mB + 1 - ib)) & mask_a
+            shift_ab = ib * lvec[1, :] + shift_a
             for ic in cells:
-                v_shift  = ic*lvec[2,:] + shift_ab
-                mask = mask_ab & (c>(-mC-ic)) & (c<(mC+1-ic))
-                inds_abc = np.nonzero( mask )[0]
-                if len(inds_abc)==0: continue
-                Rs_abc   = Rs[:,inds_abc]
-                Rs_abc  += v_shift[:,None]
-                inds.append( inds_abc )
-                Rs_ .append( Rs_abc   )
-                i+=1
-    inds = np.concatenate( inds )
-    Rs_  = np.hstack( Rs_  )
+                v_shift = ic * lvec[2, :] + shift_ab
+                mask = mask_ab & (c > (-mC - ic)) & (c < (mC + 1 - ic))
+                inds_abc = np.nonzero(mask)[0]
+                if len(inds_abc) == 0:
+                    continue
+                Rs_abc = Rs[:, inds_abc]
+                Rs_abc += v_shift[:, None]
+                inds.append(inds_abc)
+                Rs_.append(Rs_abc)
+                i += 1
+    inds = np.concatenate(inds)
+    Rs_ = np.hstack(Rs_)
 
     if corners is not None:
-        corns = np.array([
-            [ -mA, -mB, -mC],
-            [ -mA, -mB,1+mC],
-            [ -mA,1+mB, -mC],
-            [ -mA,1+mB,1+mC],
-            [1+mA, -mB, -mC],
-            [1+mA, -mB,1+mC],
-            [1+mA,1+mB, -mC],
-            [1+mA,1+mB,1+mC],
-        ]).transpose()
-        corners.append( np.dot(lvec,corns) )
+        corns = np.array(
+            [
+                [-mA, -mB, -mC],
+                [-mA, -mB, 1 + mC],
+                [-mA, 1 + mB, -mC],
+                [-mA, 1 + mB, 1 + mC],
+                [1 + mA, -mB, -mC],
+                [1 + mA, -mB, 1 + mC],
+                [1 + mA, 1 + mB, -mC],
+                [1 + mA, 1 + mB, 1 + mC],
+            ]
+        ).transpose()
+        corners.append(np.dot(lvec, corns))
 
     return inds, Rs_
 
 
-def PBCAtoms3D_np( Zs, Rs, Qs, cLJs, REAs, lvec, npbc=[1,1,1] ):
-    '''
+def PBCAtoms3D_np(Zs, Rs, Qs, cLJs, REAs, lvec, npbc=[1, 1, 1]):
+    """
     multiply atoms of sample along supercell vectors
     the multiplied sample geometry is used for evaluation of forcefield in Periodic-boundary-Conditions ( PBC )
-    '''
-    #print( "PBCAtoms3D_np lvec", lvec )
-    mx = npbc[0]*2 + 1
-    my = npbc[1]*2 + 1
-    mz = npbc[2]*2 + 1
-    mtot = mx*my*mz
+    """
+    # print( "PBCAtoms3D_np lvec", lvec )
+    mx = npbc[0] * 2 + 1
+    my = npbc[1] * 2 + 1
+    mz = npbc[2] * 2 + 1
+    mtot = mx * my * mz
     natom = len(Zs)
     matom = mtot * natom
-    Zs_    = np.empty(  matom   , np.int32  )
-    xyzs_ = np.empty( (matom,3), np.float32)
-    qs_ = np.empty( (matom,), np.float32)
+    Zs_ = np.empty(matom, np.int32)
+    xyzs_ = np.empty((matom, 3), np.float32)
+    qs_ = np.empty((matom,), np.float32)
     if cLJs is not None:
-        cLJs_  = np.empty( (matom,2), np.float32)
+        cLJs_ = np.empty((matom, 2), np.float32)
     else:
-        cLJs_=None
+        cLJs_ = None
     if REAs is not None:
-        REAs_ = np.empty( (matom,4), np.float32)
+        REAs_ = np.empty((matom, 4), np.float32)
     else:
         REAs_ = None
     i0 = 0
     i1 = i0 + natom
     # we want to have cell=(0,0,0) first
-    Zs_   [i0:i1] = Zs[:  ]
-    xyzs_ [i0:i1] = Rs[:,:]
-    qs_   [i0:i1] = Qs[:  ]
+    Zs_[i0:i1] = Zs[:]
+    xyzs_[i0:i1] = Rs[:, :]
+    qs_[i0:i1] = Qs[:]
     if cLJs is not None:
-        cLJs_ [i0:i1,: ] = cLJs[:,:]
+        cLJs_[i0:i1, :] = cLJs[:, :]
     if REAs is not None:
-        REAs_ [i0:i1,: ] = REAs[:,:]
+        REAs_[i0:i1, :] = REAs[:, :]
     i0 += natom
-    for ia in range(-npbc[0],npbc[0]+1):
-        for ib in range(-npbc[1],npbc[1]+1):
-            for ic in range(-npbc[2],npbc[2]+1):
-                if (ia==0) and (ib==0) and (ic==0) : continue
-                v_shift = ia*lvec[0,:] + ib*lvec[1,:] + ic*lvec[2,:]
+    for ia in range(-npbc[0], npbc[0] + 1):
+        for ib in range(-npbc[1], npbc[1] + 1):
+            for ic in range(-npbc[2], npbc[2] + 1):
+                if (ia == 0) and (ib == 0) and (ic == 0):
+                    continue
+                v_shift = ia * lvec[0, :] + ib * lvec[1, :] + ic * lvec[2, :]
                 i1 = i0 + natom
-                Zs_  [i0:i1] = Zs[:  ]
-                xyzs_[i0:i1] = Rs[:,:] + v_shift[None,:]
-                qs_  [i0:i1] = Qs[:  ]
+                Zs_[i0:i1] = Zs[:]
+                xyzs_[i0:i1] = Rs[:, :] + v_shift[None, :]
+                qs_[i0:i1] = Qs[:]
                 if cLJs is not None:
-                    cLJs_ [i0:i1,: ] = cLJs[:,:]
+                    cLJs_[i0:i1, :] = cLJs[:, :]
                 if REAs is not None:
-                    REAs_ [i0:i1,: ] = REAs[:,:]
+                    REAs_[i0:i1, :] = REAs[:, :]
                 i0 += natom
     return Zs_, xyzs_, qs_, cLJs_, REAs_
 
-def multRot( Zs, Rs, Qs, cLJs, rots, cog = (0,0,0) ):
-    '''
+
+def multRot(Zs, Rs, Qs, cLJs, rots, cog=(0, 0, 0)):
+    """
     multiply atoms of sample along supercell vectors
     the multiplied sample geometry is used for evaluation of forcefield in Periodic-boundary-Conditions ( PBC )
-    '''
-    Zs_   = []
-    Rs_   = []
-    Qs_   = []
+    """
+    Zs_ = []
+    Rs_ = []
+    Qs_ = []
     cLJs_ = []
     for rot in rots:
         for iatom in range(len(Zs)):
-            xyz = ( Rs[iatom][0] -cog[0],  Rs[iatom][1] -cog[1], Rs[iatom][2] -cog[2] )
-            x = xyz[0]*rot[0][0] + xyz[1]*rot[0][1] + xyz[2]*rot[0][2]    + cog[0]
-            y = xyz[0]*rot[1][0] + xyz[1]*rot[1][1] + xyz[2]*rot[1][2]    + cog[1]
-            z = xyz[0]*rot[2][0] + xyz[1]*rot[2][1] + xyz[2]*rot[2][2]    + cog[2]
-            Zs_.append( Zs[iatom] )
-            Rs_.append( (x,y,z)   )
-            Qs_.append( Qs[iatom] )
-            cLJs_.append( cLJs[iatom,:] )
-    return np.array(Zs_).copy(), np.array(Rs_).copy(), np.array(Qs_).copy(), np.array(cLJs_).copy()
+            xyz = (Rs[iatom][0] - cog[0], Rs[iatom][1] - cog[1], Rs[iatom][2] - cog[2])
+            x = xyz[0] * rot[0][0] + xyz[1] * rot[0][1] + xyz[2] * rot[0][2] + cog[0]
+            y = xyz[0] * rot[1][0] + xyz[1] * rot[1][1] + xyz[2] * rot[1][2] + cog[1]
+            z = xyz[0] * rot[2][0] + xyz[1] * rot[2][1] + xyz[2] * rot[2][2] + cog[2]
+            Zs_.append(Zs[iatom])
+            Rs_.append((x, y, z))
+            Qs_.append(Qs[iatom])
+            cLJs_.append(cLJs[iatom, :])
+    return (
+        np.array(Zs_).copy(),
+        np.array(Rs_).copy(),
+        np.array(Qs_).copy(),
+        np.array(cLJs_).copy(),
+    )
 
 
-def getFFdict( FFparams ):
-    elem_dict={}
-    for i,ff in enumerate(FFparams):
-        if(verbose>0): print(i,ff)
-        elem_dict[ff[4]] = i+1
+def getFFdict(FFparams):
+    elem_dict = {}
+    for i, ff in enumerate(FFparams):
+        if verbose > 0:
+            print(i, ff)
+        elem_dict[ff[4]] = i + 1
     return elem_dict
 
-def atom2iZ( atm, elem_dict ):
+
+def atom2iZ(atm, elem_dict):
     try:
         return int(atm)
     except:
@@ -712,149 +856,192 @@ def atom2iZ( atm, elem_dict ):
         except:
             raise ValueError(f"Did not find atomkind: {atm}")
 
-def atoms2iZs( names, elem_dict ):
-    return np.array( [atom2iZ(name,elem_dict) for name in names], dtype=np.int32 )
 
-def parseAtoms( atoms, elem_dict, PBC=True, autogeom=False, lvec=None ):
-    Rs = np.array([atoms[1],atoms[2],atoms[3]]);
+def atoms2iZs(names, elem_dict):
+    return np.array([atom2iZ(name, elem_dict) for name in names], dtype=np.int32)
+
+
+def parseAtoms(atoms, elem_dict, PBC=True, autogeom=False, lvec=None):
+    Rs = np.array([atoms[1], atoms[2], atoms[3]])
     if elem_dict is None:
-        if(verbose>0): print("WARRNING: elem_dict is None => iZs are zero")
-        iZs=np.zeros( len(atoms[0]) )
+        if verbose > 0:
+            print("WARRNING: elem_dict is None => iZs are zero")
+        iZs = np.zeros(len(atoms[0]))
     else:
-        iZs = atoms2iZs( atoms[0], elem_dict )
+        iZs = atoms2iZs(atoms[0], elem_dict)
     if autogeom:
-        if(verbose>0): print("WARRNING: autoGeom shifts atoms")
-        autoGeom( Rs, shiftXY=True,  fitCell=True,  border=3.0 )
-    Rs = np.transpose( Rs, (1,0) ).copy()
-    Qs = np.array( atoms[4] )
+        if verbose > 0:
+            print("WARRNING: autoGeom shifts atoms")
+        autoGeom(Rs, shiftXY=True, fitCell=True, border=3.0)
+    Rs = np.transpose(Rs, (1, 0)).copy()
+    Qs = np.array(atoms[4])
     if PBC:
-        if lvec is not None: avec=lvec[1];         bvec=lvec[2]
-        else:                avec=params['gridA']; bvec=params['gridB']
-        iZs,Rs,Qs = PBCAtoms( iZs, Rs, Qs, avec=avec, bvec=bvec )
-    return iZs,Rs,Qs
+        if lvec is not None:
+            avec = lvec[1]
+            bvec = lvec[2]
+        else:
+            avec = params["gridA"]
+            bvec = params["gridB"]
+        iZs, Rs, Qs = PBCAtoms(iZs, Rs, Qs, avec=avec, bvec=bvec)
+    return iZs, Rs, Qs
 
-def get_C612( i, j, FFparams ):
-    '''
+
+def get_C612(i, j, FFparams):
+    """
     compute Lenard-Jones coefitioens C6 and C12 pair of atoms i,j
-    '''
+    """
     Rij = FFparams[i][0] + FFparams[j][0]
-    Eij = np.sqrt( FFparams[i][1] * FFparams[j][1] )
-    return 2*Eij*(Rij**6), Eij*(Rij**12)
+    Eij = np.sqrt(FFparams[i][1] * FFparams[j][1])
+    return 2 * Eij * (Rij**6), Eij * (Rij**12)
 
-def getAtomsLJ( iZprobe, iZs,  FFparams ):
-    '''
+
+def getAtomsLJ(iZprobe, iZs, FFparams):
+    """
     compute Lenard-Jones coefitioens C6 and C12 for interaction between atoms in list "iZs" and probe-particle "iZprobe"
-    '''
-    n   = len(iZs)
-    cLJs  = np.zeros((n,2))
+    """
+    n = len(iZs)
+    cLJs = np.zeros((n, 2))
     for i in range(n):
-        cLJs[i,0],cLJs[i,1] = get_C612( iZprobe-1, iZs[i]-1, FFparams )
+        cLJs[i, 0], cLJs[i, 1] = get_C612(iZprobe - 1, iZs[i] - 1, FFparams)
     return cLJs
 
-def REA2LJ( cREAs, cLJs=None ):
+
+def REA2LJ(cREAs, cLJs=None):
     if cLJs is None:
-        cLJs = np.zeros((len(cREAs),2))
-    R6   = cREAs[:,0]**6
-    cLJs[:,0] = 2*cREAs[:,1] *  R6
-    cLJs[:,1] =   cREAs[:,1] * (R6**2)
+        cLJs = np.zeros((len(cREAs), 2))
+    R6 = cREAs[:, 0] ** 6
+    cLJs[:, 0] = 2 * cREAs[:, 1] * R6
+    cLJs[:, 1] = cREAs[:, 1] * (R6**2)
     return cLJs
 
-def getAtomsREA(  iZprobe, iZs,  FFparams, alphaFac=-1.0 ):
-    '''
+
+def getAtomsREA(iZprobe, iZs, FFparams, alphaFac=-1.0):
+    """
     compute Lenard-Jones coefitioens C6 and C12 for interaction between atoms in list "iZs" and probe-particle "iZprobe"
-    '''
-    n   = len(iZs)
-    REAs  = np.zeros( (n,4) )
-    i = iZprobe-1
+    """
+    n = len(iZs)
+    REAs = np.zeros((n, 4))
+    i = iZprobe - 1
     for ii in range(n):
-        j = iZs[ii]-1
-        REAs[ii,0] = FFparams[i][0] + FFparams[j][0]
-        REAs[ii,1] = np.sqrt( FFparams[i][1] * FFparams[j][1] )
-        REAs[ii,2] = FFparams[j][2] * alphaFac
+        j = iZs[ii] - 1
+        REAs[ii, 0] = FFparams[i][0] + FFparams[j][0]
+        REAs[ii, 1] = np.sqrt(FFparams[i][1] * FFparams[j][1])
+        REAs[ii, 2] = FFparams[j][2] * alphaFac
     return REAs
 
-def getSampleAtomsREA( iZs, FFparams ):
-    return np.array( [ ( FFparams[i-1][0],FFparams[i-1][1],FFparams[i-1][2] ) for i in iZs ] )
 
-def getAtomsRE(  iZprobe, iZs,  FFparams ):
-    n   = len(iZs)
-    Rpp = FFparams[iZprobe-1][0]
-    Epp = FFparams[iZprobe-1][1]
-    REs = np.array( [ ( Rpp+ FFparams[iZs[i]-1][0],  Epp * FFparams[iZs[i]-1][1] )  for i in range(n) ] )
-    REs[:,1] = np.sqrt(REs[:,1])
+def getSampleAtomsREA(iZs, FFparams):
+    return np.array(
+        [(FFparams[i - 1][0], FFparams[i - 1][1], FFparams[i - 1][2]) for i in iZs]
+    )
+
+
+def getAtomsRE(iZprobe, iZs, FFparams):
+    n = len(iZs)
+    Rpp = FFparams[iZprobe - 1][0]
+    Epp = FFparams[iZprobe - 1][1]
+    REs = np.array(
+        [
+            (Rpp + FFparams[iZs[i] - 1][0], Epp * FFparams[iZs[i] - 1][1])
+            for i in range(n)
+        ]
+    )
+    REs[:, 1] = np.sqrt(REs[:, 1])
     return REs
 
-def getAtomsLJ_fast( iZprobe, iZs,  FFparams ):
-    R = np.array( [ FFparams[i-1][0] for i in iZs ] )
-    E = np.array( [ FFparams[i-1][1] for i in iZs ] )
-    R+=FFparams[iZprobe-1][0]
-    E=np.sqrt(E*FFparams[iZprobe-1][1]);
-    cLJs = np.zeros((len(E),2))
-    cLJs[:,0] = E         * 2  *R6    # C6  = 2*Eij*(Rij**6 )
-    cLJs[:,1] = cLJs[:,0] * 0.5*R6    # C12 =   Eij*(Rij**12)
+
+def getAtomsLJ_fast(iZprobe, iZs, FFparams):
+    R = np.array([FFparams[i - 1][0] for i in iZs])
+    E = np.array([FFparams[i - 1][1] for i in iZs])
+    R += FFparams[iZprobe - 1][0]
+    E = np.sqrt(E * FFparams[iZprobe - 1][1])
+    cLJs = np.zeros((len(E), 2))
+    cLJs[:, 0] = E * 2 * R6  # C6  = 2*Eij*(Rij**6 )
+    cLJs[:, 1] = cLJs[:, 0] * 0.5 * R6  # C12 =   Eij*(Rij**12)
     return cLJs
+
 
 # ============= Hi-Level Macros
 
-def prepareScanGrids( ):
-    '''
+
+def prepareScanGrids():
+    """
     Defines the grid over which the tip will scan, according to scanMin, scanMax, and scanStep.
     The origin of the grid is going to be shifted (from scanMin) by the bond length between the "Probe Particle"
     and the "Apex", so that while the point of reference on the tip used to interpret scanMin  was the Apex,
     the new point of reference used in the XSF output will be the Probe Particle.
-    '''
-    zTips  = np.arange( params['scanMin'][2], params['scanMax'][2]+0.00001, params['scanStep'][2] )
-    xTips  = np.arange( params['scanMin'][0], params['scanMax'][0]+0.00001, params['scanStep'][0] )
-    yTips  = np.arange( params['scanMin'][1], params['scanMax'][1]+0.00001, params['scanStep'][1] )
-    ( xTips[0], xTips[-1], yTips[0], yTips[-1] )
-    lvecScan =np.array([
-        [(params['scanMin'] + params['r0Probe'])[0],
-         (params['scanMin'] + params['r0Probe'])[1],
-         (params['scanMin'] - params['r0Probe'])[2] ] ,
-        [        (params['scanMax']-params['scanMin'])[0],0.0,0.0],
-        [0.0,    (params['scanMax']-params['scanMin'])[1],0.0    ],
-        [0.0,0.0,(params['scanMax']-params['scanMin'])[2]        ]
-    ]).copy()
-    return xTips,yTips,zTips,lvecScan
+    """
+    zTips = np.arange(
+        params["scanMin"][2], params["scanMax"][2] + 0.00001, params["scanStep"][2]
+    )
+    xTips = np.arange(
+        params["scanMin"][0], params["scanMax"][0] + 0.00001, params["scanStep"][0]
+    )
+    yTips = np.arange(
+        params["scanMin"][1], params["scanMax"][1] + 0.00001, params["scanStep"][1]
+    )
+    (xTips[0], xTips[-1], yTips[0], yTips[-1])
+    lvecScan = np.array(
+        [
+            [
+                (params["scanMin"] + params["r0Probe"])[0],
+                (params["scanMin"] + params["r0Probe"])[1],
+                (params["scanMin"] - params["r0Probe"])[2],
+            ],
+            [(params["scanMax"] - params["scanMin"])[0], 0.0, 0.0],
+            [0.0, (params["scanMax"] - params["scanMin"])[1], 0.0],
+            [0.0, 0.0, (params["scanMax"] - params["scanMin"])[2]],
+        ]
+    ).copy()
+    return xTips, yTips, zTips, lvecScan
 
-def lvec2params( lvec ):
-    params['gridA'] = lvec[ 1,: ].copy()
-    params['gridB'] = lvec[ 2,: ].copy()
-    params['gridC'] = lvec[ 3,: ].copy()
 
-def params2lvec( ):
-    lvec = np.array([
-        [ 0.0, 0.0, 0.0 ],
-        params['gridA'],
-        params['gridB'],
-        params['gridC'],
-    ]).copy
+def lvec2params(lvec):
+    params["gridA"] = lvec[1, :].copy()
+    params["gridB"] = lvec[2, :].copy()
+    params["gridC"] = lvec[3, :].copy()
+
+
+def params2lvec():
+    lvec = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            params["gridA"],
+            params["gridB"],
+            params["gridC"],
+        ]
+    ).copy
     return lvec
 
 
-def genFFSampling( lvec, pixPerAngstrome=10 ):
-    nDim = np.array([
-        int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[1],lvec[1])) )),
-        int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[2],lvec[2])) )),
-        int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[3],lvec[3])) )),
-        4,
-    ], np.int32 )
+def genFFSampling(lvec, pixPerAngstrome=10):
+    nDim = np.array(
+        [
+            int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[1], lvec[1])))),
+            int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[2], lvec[2])))),
+            int(round(pixPerAngstrome * np.sqrt(np.dot(lvec[3], lvec[3])))),
+            4,
+        ],
+        np.int32,
+    )
     return nDim
 
-def getPos( lvec, nDim=None, pixPerAngstrome=10 ):
+
+def getPos(lvec, nDim=None, pixPerAngstrome=10):
     if nDim is None:
-        nDim =  genFFSampling( lvec, pixPerAngstrome=pixPerAngstrome )
-    dCell = np.array( ( lvec[1,:]/nDim[2], lvec[2,:]/nDim[1], lvec[3,:]/nDim[0] ) )
-    ABC   = np.mgrid[0:nDim[0],0:nDim[1],0:nDim[2]]
-    X = lvec[0,0] + ABC[2]*dCell[0,0] + ABC[1]*dCell[1,0] + ABC[0]*dCell[2,0]
-    Y = lvec[0,1] + ABC[2]*dCell[0,1] + ABC[1]*dCell[1,1] + ABC[0]*dCell[2,1]
-    Z = lvec[0,2] + ABC[2]*dCell[0,2] + ABC[1]*dCell[1,2] + ABC[0]*dCell[2,2]
+        nDim = genFFSampling(lvec, pixPerAngstrome=pixPerAngstrome)
+    dCell = np.array((lvec[1, :] / nDim[2], lvec[2, :] / nDim[1], lvec[3, :] / nDim[0]))
+    ABC = np.mgrid[0 : nDim[0], 0 : nDim[1], 0 : nDim[2]]
+    X = lvec[0, 0] + ABC[2] * dCell[0, 0] + ABC[1] * dCell[1, 0] + ABC[0] * dCell[2, 0]
+    Y = lvec[0, 1] + ABC[2] * dCell[0, 1] + ABC[1] * dCell[1, 1] + ABC[0] * dCell[2, 1]
+    Z = lvec[0, 2] + ABC[2] * dCell[0, 2] + ABC[1] * dCell[1, 2] + ABC[0] * dCell[2, 2]
     return X, Y, Z
 
-def getPos_Vec3d( lvec, nDim=None, pixPerAngstrome=10 ):
-    X,Y,Z = getPos( lvec, nDim=nDim, pixPerAngstrome=pixPerAngstrome )
-    XYZ = np.empty( X.shape + (3,) )
-    XYZ[:,:,:,0] = X
-    XYZ[:,:,:,1] = Y
-    XYZ[:,:,:,2] = Z
+
+def getPos_Vec3d(lvec, nDim=None, pixPerAngstrome=10):
+    X, Y, Z = getPos(lvec, nDim=nDim, pixPerAngstrome=pixPerAngstrome)
+    XYZ = np.empty(X.shape + (3,))
+    XYZ[:, :, :, 0] = X
+    XYZ[:, :, :, 1] = Y
+    XYZ[:, :, :, 2] = Z
     return XYZ

--- a/ppafm/common.py
+++ b/ppafm/common.py
@@ -230,40 +230,72 @@ class CLIParser(ArgumentParser):
 # ============================== Pure python functions
 # ==============================
 
-def getDfWeight( n, dz=0.1 ):
+def getDfWeight( A, dz = 0.1):
     '''
-    conversion of vertical force Fz to frequency shift
-    according to:
-    Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
-    oscialltion amplitude of cantilever is A = n * dz
-    '''
-    x  = np.linspace(-1,1,n+1)
-    y  = np.sqrt(1-x*x)
-    dy =  ( y[1:] - y[:-1] )/(dz*n)
-    fpi    = (n-2)**2
-    prefactor = -1 * ( 1 + fpi*(2/np.pi) ) / (fpi+1) # correction for small n
-    return dy*prefactor, (x[1:]+x[:-1])*0.5
+    Conversion of vertical force Fz to frequency shift
+    Returns the discretized version of the required convolution kernel
 
-def Fz2df( F, dz=0.1, k0 = params['kCantilever'], f0=params['f0Cantilever'], n=4, units=16.0217656 ):
+    The integrand for calculating the frequency shift from force is taken from:
+    Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
+
+    The continuous weight function needed for the conversion is w(t) = t/sqrt(1-t**2).
+    We want to find an array w_i (of n+1 elements) - the discrete convolution kernel - such that
+    (F*w)[j] = Sum_over(i) F[i+j] w[n+1-i] = -2/(A*pi) Integral_from(t=-1)_to(t=+1)_of F(t) w(t) dt
+    where the normalized coordinate t = z*2/A.
+    Linear interpolation will be used to define the force field F(t) from its discretized version F[i]:
+    F(t) = ( F[i] * (t[i+1] - t) + F[i+1] * (t - t[i]) ) / dt for t[i] < t < t[i+1] =
+    where dt = dz*2/A = t[i+1] - t[i].
+    For each i, the interval from t[i] up to t[i+1] contribues to w[n+1-i] the weight
+    (omitting the coefficient of 1/(pi*dz) but including the minus sign in front of the original integrtal)
+    Integral_from(t=t[i])_to(t=t[i+1])_of dt*w(t)*( -t[i+1] + t ) = t[i+1]*(f[i+1] - f[i]) + (f2[i+1] - f2[i])
+    corresponding to the coefficient multiplying F[i],
+    and, additionally, to w[n+1-(i+1)] = w[n-i] the weight
+    Integral_from(t=t[i]_to(t=t[i+1])_of dt*w(t)*( t[i] - t ) = -t[i]*(f[i+1] - f[i]) - (f2[i+1] - f2[i])
+    corresponding to the coefficient multiplying F[i+1].
+    In the above, two auxiliary functions were introduced to express the desired integrals,
+    f(t) = Integral_of -w(t)*dt = sqrt(1-t**2)
+    f2(t) = Integral_of w(t)*t*dt = (arccos(-t) - sqrt(1-t**2)) / 2
+    and their discrete versions f[i] = f(t[i]); f2[i] = f2(t[i]).
+    Note: we set f(t) = 0 and f2(t) = pi for t > +1.
+    '''
+
+    n = int(np.ceil(A/dz))
+    w = np.zeros(n+1)
+    f = np.zeros(n+1)
+    f2 = np.zeros(n+1)
+    #Note that, because of how the convolution is defined, the weight array w needs to be reversed:
+    #The largest index of w corresponds to the smallest index i of force F[j+i].
+    #In contrast to the theoretical description above, we already reverse all the auxiliary arrays (t,f,f2,df,df2) in the code,
+    #starting from t[n+1-i] -> t[i], so that we do not need to reverse w explicitely in the end.
+    t = np.linspace(-1 + 2*n*dz/A, -1, n+1)
+    if(n>1):
+        f[1:-1] = np.sqrt(1 - t[1:-1]*t[1:-1])
+        f2[1:-1] = (np.arccos(-t[1:-1]) - t[1:-1]*f[1:-1]) / 2.0
+    f2[0] = np.pi #end point for t>=1 must be as if t=1 even if t>1
+    df = f[:-1] - f[1:] #numerical derivative (first derivative integrated over one-step-long intervals) of function f(t)
+    df2 = f2[:-1] - f2[1:] #numerical derivative (first derivative integrated over one-step-long intervals) of f2(t)
+    w[1:] = t[:-1]*df + df2 #coefficients to multiply F[i]
+    w[:-1] -= t[1:]*df + df2 #coefficients to multiply F[i+1]
+    return w/(np.pi*dz)
+
+def Fz2df( F, dz=0.1, k0 = params['kCantilever'], f0=params['f0Cantilever'], A = 0.1, units=16.0217656 ):
     '''
     conversion of vertical force Fz to frequency shift
     according to:
     Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
-    oscialltion amplitude of cantilever is A = n * dz
     '''
-    W,xs = getDfWeight( n, dz=dz )
+    W = getDfWeight( A, dz=dz )
     dFconv = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F )
     return dFconv*units*f0/k0
 
-def Fz2df_tilt( F,  d=params['scanTilt'], k0 = params['kCantilever'], f0=params['f0Cantilever'], n=4, units=16.0217656 ):
+def Fz2df_tilt( F,  d=params['scanTilt'], k0 = params['kCantilever'], f0=params['f0Cantilever'], A = 0.1, units=16.0217656 ):
     '''
     conversion of vertical force Fz to frequency shift
     according to:
     Giessibl, F. J. A direct method to calculate tip-sample forces from frequency shifts in frequency-modulation atomic force microscopy Appl. Phys. Lett. 78, 123 (2001)
-    oscialltion amplitude of cantilever is A = n * dz
     '''
     dr = np.sqrt( d[0]**2 + d[1]**2 + d[2]**2 )
-    W,xs = getDfWeight( n, dz=dr )
+    W = getDfWeight( A, dz=dr )
     dFconv_x = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F[:,:,:,0] )
     dFconv_y = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F[:,:,:,1] )
     dFconv_z = np.apply_along_axis( lambda m: np.convolve(m, W, mode='valid'), axis=0, arr=F[:,:,:,2] )

--- a/ppafm/cpp_utils.py
+++ b/ppafm/cpp_utils.py
@@ -21,7 +21,7 @@ else:
 _vars_path = None
 
 PACKAGE_PATH = Path(__file__).resolve().parent
-CPP_PATH     = PACKAGE_PATH / 'cpp'
+CPP_PATH     = PACKAGE_PATH.joinpath('cpp')
 
 print(" PACKAGE_PATH = ", PACKAGE_PATH)
 print(" CPP_PATH     = ", CPP_PATH)

--- a/ppafm/ocl/AFMulator.py
+++ b/ppafm/ocl/AFMulator.py
@@ -207,7 +207,7 @@ class AFMulator():
 
         # Set df convolution weights
         self.dz = (self.scan_window[1][2] - self.scan_window[0][2]) / self.scan_dim[2]
-        self.dfWeight = PPU.getDfWeight(self.df_steps, dz=self.dz)[0].astype(np.float32)
+        self.dfWeight = PPU.get_simple_df_weight(self.df_steps, dz=self.dz)[0].astype(np.float32)
         self.dfWeight *= PPU.eVA_Nm * self.f0Cantilever / self.kCantilever
         self.amplitude = self.dz * len(self.dfWeight)
         self.scanner.zstep = self.dz

--- a/ppafm/ocl/AFMulator.py
+++ b/ppafm/ocl/AFMulator.py
@@ -16,8 +16,9 @@ from .field import ElectronDensity, HartreePotential, MultipoleTipDensity, TipDe
 
 VALID_SIZES = np.array([16, 32, 64, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048])
 
-class AFMulator():
-    '''
+
+class AFMulator:
+    """
     Simulate Atomic force microscope images of molecules.
 
     Arguments:
@@ -61,50 +62,55 @@ class AFMulator():
             potential defined on a grid is always considered to be periodic.
         f0Cantilever: float. Resonance frequency of the cantilever in Hz.
         kCantilever: float. Harmonic spring constant of the cantilever in N/m.
-    '''
+    """
 
-    bMergeConv = False   # Should we use merged kernel relaxStrokesTilted_convZ or two separated kernells  ( relaxStrokesTilted, convolveZ  )
+    bMergeConv = False  # Should we use merged kernel relaxStrokesTilted_convZ or two separated kernells  ( relaxStrokesTilted, convolveZ  )
 
     # --- Relaxation
-    relaxParams  = [ 0.5, 0.1, 0.1*0.2,0.1*5.0 ]    # (dt,damp, .., .. ) parameters of relaxation, in the moment just dt and damp are used
+    relaxParams = [
+        0.5,
+        0.1,
+        0.1 * 0.2,
+        0.1 * 5.0,
+    ]  # (dt,damp, .., .. ) parameters of relaxation, in the moment just dt and damp are used
 
     # --- Output
-    bSaveFF  = False    # Save debug ForceField as .xsf
-    verbose  = 0        # Print information during excecution
+    bSaveFF = False  # Save debug ForceField as .xsf
+    verbose = 0  # Print information during excecution
 
     # ==================== Methods =====================
 
-    def __init__( self,
-        pixPerAngstrome = 10,
-        lvec            = None,
-        scan_dim        = (128, 128, 30),
-        scan_window     = ((2.0, 2.0, 7.0), ( 18.0, 18.0, 10.0)),
-        iZPP            = 8,
-        QZs             = [ 0.1,  0, -0.1, 0 ],
-        Qs              = [ -10, 20,  -10, 0 ],
-        rho             = None,
-        sigma           = 0.71,
-        rho_delta       = None,
-        A_pauli         = 18.0,
-        B_pauli         = 1.0,
-        fdbm_vdw_type   = 'D3',
-        d3_params       = 'PBE',
-        lj_vdw_damp     = 2,
-        df_steps        = 10,
-        tipR0           = [0.0, 0.0, 3.0],
-        tipStiffness    = [0.25, 0.25, 0.0, 30.0],
-        npbc            = (1, 1, 0),
-        f0Cantilever    = 30300,
-        kCantilever     = 1800
+    def __init__(
+        self,
+        pixPerAngstrome=10,
+        lvec=None,
+        scan_dim=(128, 128, 30),
+        scan_window=((2.0, 2.0, 7.0), (18.0, 18.0, 10.0)),
+        iZPP=8,
+        QZs=[0.1, 0, -0.1, 0],
+        Qs=[-10, 20, -10, 0],
+        rho=None,
+        sigma=0.71,
+        rho_delta=None,
+        A_pauli=18.0,
+        B_pauli=1.0,
+        fdbm_vdw_type="D3",
+        d3_params="PBE",
+        lj_vdw_damp=2,
+        df_steps=10,
+        tipR0=[0.0, 0.0, 3.0],
+        tipStiffness=[0.25, 0.25, 0.0, 30.0],
+        npbc=(1, 1, 0),
+        f0Cantilever=30300,
+        kCantilever=1800,
     ):
-
         if not FFcl.oclu or not oclr.oclu:
             oclu.init_env()
 
         self.forcefield = FFcl.ForceField_LJC()
 
         self.scanner = oclr.RelaxedScanner()
-        self.scanner.relax_params = np.array( self.relaxParams, dtype=np.float32 )
+        self.scanner.relax_params = np.array(self.relaxParams, dtype=np.float32)
         self.scanner.stiffness = np.array(tipStiffness, dtype=np.float32) / -PPU.eVA_Nm
 
         self.iZPP = iZPP
@@ -126,12 +132,23 @@ class AFMulator():
         self.setRhoDelta(rho_delta)
         self.setQs(Qs, QZs)
 
-        self.typeParams = PPU.loadSpecies('atomtypes.ini')
+        self.typeParams = PPU.loadSpecies("atomtypes.ini")
         self.saveFFpre = ""
 
-    def eval(self, xyzs, Zs, qs, rho_sample=None, sample_lvec=None, rot=np.eye(3), rot_center=None,
-        REAs=None, X=None, plot_to_dir=None):
-        '''
+    def eval(
+        self,
+        xyzs,
+        Zs,
+        qs,
+        rho_sample=None,
+        sample_lvec=None,
+        rot=np.eye(3),
+        rot_center=None,
+        REAs=None,
+        X=None,
+        plot_to_dir=None,
+    ):
+        """
         Prepare and evaluate AFM image.
 
         Arguments:
@@ -153,48 +170,54 @@ class AFMulator():
 
         Returns:
             X: np.ndarray. Output AFM images. If input X is not None, this is the same array object as X with values overwritten.
-        '''
+        """
         self.prepareFF(xyzs, Zs, qs, rho_sample, sample_lvec, rot, rot_center, REAs)
         self.prepareScanner()
         X = self.evalAFM(X)
-        if plot_to_dir: self.plot_images(X, outdir=plot_to_dir)
+        if plot_to_dir:
+            self.plot_images(X, outdir=plot_to_dir)
         return X
 
     def __call__(self, *args, **kwargs):
-        '''
+        """
         Makes object callable. See :meth:`eval` for input arguments.
-        '''
+        """
         return self.eval(*args, **kwargs)
 
-    def eval_( self, mol ):
-        return self.eval( mol.xyzs, mol.Zs, mol.qs )
+    def eval_(self, mol):
+        return self.eval(mol.xyzs, mol.Zs, mol.qs)
 
     # ========= Setup =========
 
     def setLvec(self, lvec=None, pixPerAngstrome=None):
-        ''' Set forcefield lattice vectors. If lvec is not given it is inferred from the scan window.'''
+        """Set forcefield lattice vectors. If lvec is not given it is inferred from the scan window."""
 
         if pixPerAngstrome is not None:
             self.pixPerAngstrome = pixPerAngstrome
         if lvec is not None:
             self.lvec = lvec
         else:
-            self.lvec = get_lvec(self.scan_window, tipR0=self.tipR0,
-                pixPerAngstrome=self.pixPerAngstrome)
+            self.lvec = get_lvec(
+                self.scan_window, tipR0=self.tipR0, pixPerAngstrome=self.pixPerAngstrome
+            )
 
         # Remember old grid size
-        if hasattr(self.forcefield, 'nDim'):
+        if hasattr(self.forcefield, "nDim"):
             self._old_nDim = self.forcefield.nDim.copy()
         else:
             self._old_nDim = np.zeros(4)
 
         # Set lvec in force field and scanner
         self.forcefield.initSampling(self.lvec, pixPerAngstrome=self.pixPerAngstrome)
-        FEin_shape = self.forcefield.nDim if (self._old_nDim != self.forcefield.nDim).any() else None
+        FEin_shape = (
+            self.forcefield.nDim
+            if (self._old_nDim != self.forcefield.nDim).any()
+            else None
+        )
         self.scanner.prepareBuffers(lvec=self.lvec, FEin_shape=FEin_shape)
 
     def setScanWindow(self, scan_window=None, scan_dim=None, df_steps=None):
-        '''Set scanner scan window.'''
+        """Set scanner scan window."""
 
         if scan_window is not None:
             self.scan_window = scan_window
@@ -202,86 +225,118 @@ class AFMulator():
             self.scan_dim = scan_dim
         if df_steps is not None:
             if df_steps <= 0 or df_steps > self.scan_dim[2]:
-                raise ValueError(f'df_steps should be between 1 and scan_dim[2]({scan_dim[2]}), but got {df_steps}.')
+                raise ValueError(
+                    f"df_steps should be between 1 and scan_dim[2]({scan_dim[2]}), but got {df_steps}."
+                )
             self.df_steps = df_steps
 
         # Set df convolution weights
         self.dz = (self.scan_window[1][2] - self.scan_window[0][2]) / self.scan_dim[2]
-        self.dfWeight = PPU.get_simple_df_weight(self.df_steps, dz=self.dz)[0].astype(np.float32)
+        self.dfWeight = PPU.get_simple_df_weight(self.df_steps, dz=self.dz).astype(
+            np.float32
+        )
         self.dfWeight *= PPU.eVA_Nm * self.f0Cantilever / self.kCantilever
         self.amplitude = self.dz * len(self.dfWeight)
         self.scanner.zstep = self.dz
 
         # Prepare buffers
-        self.scanner.prepareBuffers(scan_dim=self.scan_dim, nDimConv=len(self.dfWeight),
-            nDimConvOut=(self.scan_dim[2] - len(self.dfWeight) + 1))
+        self.scanner.prepareBuffers(
+            scan_dim=self.scan_dim,
+            nDimConv=len(self.dfWeight),
+            nDimConvOut=(self.scan_dim[2] - len(self.dfWeight) + 1),
+        )
         self.scanner.updateBuffers(WZconv=self.dfWeight)
-        self.scanner.preparePosBasis(start=self.scan_window[0][:2], end=self.scan_window[1][:2] )
+        self.scanner.preparePosBasis(
+            start=self.scan_window[0][:2], end=self.scan_window[1][:2]
+        )
 
     def setRho(self, rho=None, sigma=0.71, B_pauli=1.0):
-        '''Set tip charge distribution.
+        """Set tip charge distribution.
 
         Arguments:
             rho: Dict, :class:`.TipDensity`, or None. Tip charge density. If None, the existing density is deleted.
             sigma: float. Tip charge density distribution when rho is a dict.
             B_pauli: float. Pauli repulsion exponent for tip density when using FDBM.
-        '''
+        """
         if rho is not None:
             self.sigma = sigma
             self.B_pauli = B_pauli
-            self._rho = rho # Remember argument value so that we can recompute the power from grid or the grid from a dict later if needed
+            self._rho = rho  # Remember argument value so that we can recompute the power from grid or the grid from a dict later if needed
             if isinstance(rho, dict):
-                self.rho = MultipoleTipDensity(self.forcefield.lvec[:, :3], self.forcefield.nDim[:3], sigma=self.sigma,
-                    multipole=rho, ctx=self.forcefield.ctx)
+                self.rho = MultipoleTipDensity(
+                    self.forcefield.lvec[:, :3],
+                    self.forcefield.nDim[:3],
+                    sigma=self.sigma,
+                    multipole=rho,
+                    ctx=self.forcefield.ctx,
+                )
             else:
                 if not isinstance(rho, TipDensity):
-                    raise ValueError(f'rho should of type `TipDensity`, but got `{type(rho)}`')
+                    raise ValueError(
+                        f"rho should of type `TipDensity`, but got `{type(rho)}`"
+                    )
                 self.rho = rho
-            if self.verbose > 0: print('AFMulator.setRho: Preparing buffers')
+            if self.verbose > 0:
+                print("AFMulator.setRho: Preparing buffers")
             if not np.allclose(B_pauli, 1.0):
                 rho_power = self.rho.power_positive(p=self.B_pauli, in_place=False)
-                self.rho.release() # Let's not keep the original array in device memory to minimize memory foot print
+                self.rho.release()  # Let's not keep the original array in device memory to minimize memory foot print
                 self.rho = rho_power
             self.forcefield.prepareBuffers(rho=self.rho, bDirect=True)
         else:
             self._rho = None
             self.rho = None
             if self.forcefield.rho is not None:
-                if self.verbose > 0: print('AFMulator.setRho: Releasing buffers')
+                if self.verbose > 0:
+                    print("AFMulator.setRho: Releasing buffers")
                 self.forcefield.rho.release()
                 self.forcefield.rho = None
 
     def setBPauli(self, B_pauli=1.0):
-        '''Set Pauli repulsion exponent used in FDBM.'''
+        """Set Pauli repulsion exponent used in FDBM."""
         self.setRho(self._rho, sigma=self.sigma, B_pauli=B_pauli)
 
     def setRhoDelta(self, rho_delta=None):
-        '''Set tip electron delta-density that is used for electrostatic interaction in FDBM.
+        """Set tip electron delta-density that is used for electrostatic interaction in FDBM.
 
         Arguments:
             rho_delta: :class:`.TipDensity` or None. Tip electron delta-density. If None, the existing density is deleted.
-        '''
+        """
         self.rho_delta = rho_delta
         if self.rho_delta is not None:
             if not isinstance(rho_delta, TipDensity):
-                raise ValueError(f'rho_delta should of type `TipDensity`, but got `{type(rho_delta)}`')
-            if self.verbose > 0: print('AFMulator.setRhoDelta: Preparing buffers')
+                raise ValueError(
+                    f"rho_delta should of type `TipDensity`, but got `{type(rho_delta)}`"
+                )
+            if self.verbose > 0:
+                print("AFMulator.setRhoDelta: Preparing buffers")
             self.forcefield.prepareBuffers(rho_delta=self.rho_delta, bDirect=True)
         elif self.forcefield.rho_delta is not None:
-            if self.verbose > 0: print('AFMulator.setRhoDelta: Releasing buffers')
+            if self.verbose > 0:
+                print("AFMulator.setRhoDelta: Releasing buffers")
             self.forcefield.rho_delta.release()
             self.forcefield.rho_delta = None
 
     def setQs(self, Qs, QZs):
-        '''Set tip point charges.'''
+        """Set tip point charges."""
         self.Qs = Qs
         self.QZs = QZs
         self.forcefield.setQs(Qs=Qs, QZs=QZs)
 
     # ========= Imaging =========
 
-    def prepareFF(self, xyzs, Zs, qs, rho_sample=None, sample_lvec=None, rot=np.eye(3), rot_center=None, REAs=None):
-        '''
+    def prepareFF(
+        self,
+        xyzs,
+        Zs,
+        qs,
+        rho_sample=None,
+        sample_lvec=None,
+        rot=np.eye(3),
+        rot_center=None,
+        REAs=None,
+    ):
+        """
         Prepare molecule parameters and calculate force field.
 
         Arguments:
@@ -298,31 +353,41 @@ class AFMulator():
             rot: np.ndarray of shape (3, 3). Rotation matrix to apply to atom positions.
             rot_center: np.ndarray of shape (3,). Center for rotation. Defaults to center of atom coordinates.
             REAs: np.ndarray of shape (num_atoms, 4). Lennard Jones interaction parameters. Calculated automatically if None.
-        '''
+        """
 
         # Check if the scan window extends over any non-periodic boundaries and issue a warning if it does
         self.check_scan_window()
 
         # (Re)initialize force field if the size of the grid changed since last run.
         if (self._old_nDim != self.forcefield.nDim).any():
-            if self.verbose > 0: print('(Re)initializing force field buffers.')
-            if self.verbose > 1: print(f'old nDim: {self._old_nDim}, new nDim: {self.forcefield.nDim}')
+            if self.verbose > 0:
+                print("(Re)initializing force field buffers.")
+            if self.verbose > 1:
+                print(f"old nDim: {self._old_nDim}, new nDim: {self.forcefield.nDim}")
             self.forcefield.tryReleaseBuffers()
             if self._rho is not None:
                 # The grid size changed so we need to recompute/reinterpolate the tip density grid
                 self.setRho(self._rho, self.sigma, self.B_pauli)
-                self.setRhoDelta(self.rho_delta) # self.rho_delta could be None, but then this does nothing
+                self.setRhoDelta(
+                    self.rho_delta
+                )  # self.rho_delta could be None, but then this does nothing
             self.forcefield.prepareBuffers()
             self._old_nDim = self.forcefield.nDim
 
         # If rho_sample is specified, then we use FDBM. Check that other requirements are satisfied.
         if rho_sample is not None:
             if not isinstance(rho_sample, ElectronDensity):
-                raise ValueError(f'rho_sample should of type `ElectronDensity`, but got `{type(rho_sample)}`')
+                raise ValueError(
+                    f"rho_sample should of type `ElectronDensity`, but got `{type(rho_sample)}`"
+                )
             if not isinstance(qs, HartreePotential):
-                raise ValueError(f'qs should be HartreePotential when rho_sample is not None, but got type `{type(qs)}`.')
+                raise ValueError(
+                    f"qs should be HartreePotential when rho_sample is not None, but got type `{type(qs)}`."
+                )
             if self.rho_delta is None:
-                raise ValueError(f'rho_delta should be set when rho_sample is not None.')
+                raise ValueError(
+                    f"rho_delta should be set when rho_sample is not None."
+                )
 
         # Check if using point charges or precomputed Hartee potential
         if qs is None:
@@ -332,21 +397,26 @@ class AFMulator():
             pot = qs
             qs = np.zeros(len(Zs))
             self.sample_lvec = sample_lvec if sample_lvec is not None else pot.lvec[1:]
-            assert self.sample_lvec.shape == (3, 3), f'sample_lvec has shape {self.sample_lvec.shape}, but should have shape (3, 3)'
+            assert self.sample_lvec.shape == (
+                3,
+                3,
+            ), f"sample_lvec has shape {self.sample_lvec.shape}, but should have shape (3, 3)"
         else:
             pot = None
 
         # Determine method
         if rho_sample is not None:
-            method = 'fdbm'
+            method = "fdbm"
             self.forcefield.setPP(self.iZPP)
         elif pot is not None:
-            method = 'hartree'
+            method = "hartree"
         else:
-            method = 'point-charge'
+            method = "point-charge"
 
-        if (method != 'fdbm') and (not np.allclose(self.B_pauli, 1.0)):
-            warnings.warn(f'Not using FDBM, but tip density exponent is {self.B_pauli}! This is probably not what you want to do!')
+        if (method != "fdbm") and (not np.allclose(self.B_pauli, 1.0)):
+            warnings.warn(
+                f"Not using FDBM, but tip density exponent is {self.B_pauli}! This is probably not what you want to do!"
+            )
 
         npbc = self.npbc if self.sample_lvec is not None else (0, 0, 0)
 
@@ -358,17 +428,37 @@ class AFMulator():
             REAs = PPU.getAtomsREA(self.iZPP, Zs, self.typeParams, alphaFac=-1.0)
         cLJs = PPU.REA2LJ(REAs)
         if sum(npbc) > 0:
-            Zs, xyzs, qs, cLJs, REAs = PPU.PBCAtoms3D_np(Zs, xyzs, qs, cLJs, REAs, self.sample_lvec, npbc=npbc)
+            Zs, xyzs, qs, cLJs, REAs = PPU.PBCAtoms3D_np(
+                Zs, xyzs, qs, cLJs, REAs, self.sample_lvec, npbc=npbc
+            )
 
         # Compute force field
-        self.forcefield.makeFF(xyzs, cLJs, REAs=REAs, Zs=Zs, method=method, qs=qs, pot=pot, rho_sample=rho_sample,
-            rho_delta=None, A=self.A_pauli, B=self.B_pauli, rot=rot, rot_center=rot_center,
-            fdbm_vdw_type=self.fdbm_vdw_type, d3_params=self.d3_params, lj_vdw_damp=self.lj_vdw_damp,
-            bRelease=False, bCopy=False, bFinish=False)
-        if self.bSaveFF: self.saveFF()
+        self.forcefield.makeFF(
+            xyzs,
+            cLJs,
+            REAs=REAs,
+            Zs=Zs,
+            method=method,
+            qs=qs,
+            pot=pot,
+            rho_sample=rho_sample,
+            rho_delta=None,
+            A=self.A_pauli,
+            B=self.B_pauli,
+            rot=rot,
+            rot_center=rot_center,
+            fdbm_vdw_type=self.fdbm_vdw_type,
+            d3_params=self.d3_params,
+            lj_vdw_damp=self.lj_vdw_damp,
+            bRelease=False,
+            bCopy=False,
+            bFinish=False,
+        )
+        if self.bSaveFF:
+            self.saveFF()
 
     def prepareScanner(self):
-        '''Prepare scanner. Run after preparing force field.'''
+        """Prepare scanner. Run after preparing force field."""
 
         # Copy forcefield array to scanner buffer
         self.scanner.updateFEin(self.forcefield.cl_FE)
@@ -380,7 +470,7 @@ class AFMulator():
         self.scanner.setScanRot(self.pos0, rot=np.eye(3), tipR0=self.tipR0)
 
     def evalAFM(self, X=None):
-        '''
+        """
         Evaluate AFM image. Run after preparing force field and scanner.
 
         Arguments:
@@ -389,7 +479,7 @@ class AFMulator():
 
         Returns:
             X: np.ndarray. Output AFM images. If input X is not None, this is the same array object as X with values overwritten.
-        '''
+        """
 
         if self.bMergeConv:
             FEout = self.scanner.run_relaxStrokesTilted_convZ()
@@ -398,219 +488,275 @@ class AFMulator():
             FEout = self.scanner.run_convolveZ()
 
         if X is None:
-            X = FEout[:,:,:,2].copy()
+            X = FEout[:, :, :, 2].copy()
         else:
-            if X.shape != self.scan_dim[:2] + (self.scan_dim[2] - len(self.dfWeight) + 1,):
+            if X.shape != self.scan_dim[:2] + (
+                self.scan_dim[2] - len(self.dfWeight) + 1,
+            ):
                 raise ValueError(
                     f"Expected an array of shape {self.scan_dim[:2] + (self.scan_dim[2] - len(self.dfWeight) + 1,)} "
                     + f"for storing AFM image, but got an array of shape {X.shape} instead."
                 )
-            X[:,:,:] = FEout[:,:,:,2]
+            X[:, :, :] = FEout[:, :, :, 2]
 
         return X
 
     # ========= Save/Load state =========
 
     @classmethod
-    def from_params(cls, file_path='./params.ini'):
-        '''
+    def from_params(cls, file_path="./params.ini"):
+        """
         Construct an AFMulator instance from a params.ini file.
 
         Arguments:
             file_path: str. Path to the params.ini file to load.
-        '''
+        """
         params, sample_lvec = _get_params(file_path)
         afmulator = cls(**params)
         afmulator.sample_lvec = sample_lvec
         return afmulator
 
-    def load_params(self, file_path='./params.ini'):
-        '''
+    def load_params(self, file_path="./params.ini"):
+        """
         Update the parameters of this AFMulator instance from a params.ini file.
 
         Arguments:
             file_path: str. Path to the params.ini file to load.
-        '''
+        """
         params, sample_lvec = _get_params(file_path)
-        if params['tipStiffness'] is not None:
-            self.scanner.stiffness = np.array(params['tipStiffness'], dtype=np.float32) / -PPU.eVA_Nm
-        self.iZPP = params['iZPP']
-        self.tipR0 = params['tipR0']
-        self.f0Cantilever = params['f0Cantilever']
-        self.kCantilever = params['kCantilever']
-        self.npbc = params['npbc']
-        self.A_pauli = params['A_pauli']
-        self.setScanWindow(params['scan_window'], params['scan_dim'], params['df_steps'])
-        self.setLvec(params['lvec'], params['pixPerAngstrome'])
+        if params["tipStiffness"] is not None:
+            self.scanner.stiffness = (
+                np.array(params["tipStiffness"], dtype=np.float32) / -PPU.eVA_Nm
+            )
+        self.iZPP = params["iZPP"]
+        self.tipR0 = params["tipR0"]
+        self.f0Cantilever = params["f0Cantilever"]
+        self.kCantilever = params["kCantilever"]
+        self.npbc = params["npbc"]
+        self.A_pauli = params["A_pauli"]
+        self.setScanWindow(
+            params["scan_window"], params["scan_dim"], params["df_steps"]
+        )
+        self.setLvec(params["lvec"], params["pixPerAngstrome"])
         if (self._rho is None) or isinstance(self._rho, dict):
-            self.setRho(params['rho'], params['sigma'])
+            self.setRho(params["rho"], params["sigma"])
         else:
-            warnings.warn(f'Using existing tip density with exponent {params["B_pauli"]}, instead of parameters from params.ini file.')
-            self.setRho(self._rho, sigma=params['sigma'], B_pauli=params['B_pauli'])
+            warnings.warn(
+                f'Using existing tip density with exponent {params["B_pauli"]}, instead of parameters from params.ini file.'
+            )
+            self.setRho(self._rho, sigma=params["sigma"], B_pauli=params["B_pauli"])
         self.sample_lvec = sample_lvec
 
-    def save_params(self, file_path='./params.ini'):
-        '''
+    def save_params(self, file_path="./params.ini"):
+        """
         Save the parameters of this AFMulator instance to a params.ini file.
 
         Arguments:
             file_path: str. Path to the file where parameters are saved.
-        '''
+        """
         k = self.scanner.stiffness * -PPU.eVA_Nm
         nDim = self.forcefield.nDim
         scan_step = (
             (self.scan_window[1][0] - self.scan_window[0][0]) / (self.scan_dim[0] - 1),
             (self.scan_window[1][1] - self.scan_window[0][1]) / (self.scan_dim[1] - 1),
-            (self.scan_window[1][2] - self.scan_window[0][2]) / self.scan_dim[2]
+            (self.scan_window[1][2] - self.scan_window[0][2]) / self.scan_dim[2],
         )
-        with open(file_path, 'w') as f:
-            f.write(f'probeType {self.iZPP}\n')
+        with open(file_path, "w") as f:
+            f.write(f"probeType {self.iZPP}\n")
             if isinstance(self._rho, dict):
                 if len(self._rho) > 1:
-                    warnings.warn('More than one tip multipole type specified. Only writing the first one into params.ini.')
+                    warnings.warn(
+                        "More than one tip multipole type specified. Only writing the first one into params.ini."
+                    )
                 tip = list(self._rho)[0]
-                f.write(f'tip {tip}\n')
-                f.write(f'charge {self._rho[tip]}\n')
-                f.write(f'sigma {self.sigma}\n')
-            f.write(f'stiffness {k[0]} {k[1]} {k[3]}\n')
-            f.write(f'r0Probe {self.tipR0[0]} {self.tipR0[1]} {self.tipR0[2]}\n')
-            f.write(f'PBC {(np.array(self.npbc) > 0).any()}\n')
-            f.write(f'nPBC {self.npbc[0]} {self.npbc[1]} {self.npbc[2]}\n')
+                f.write(f"tip {tip}\n")
+                f.write(f"charge {self._rho[tip]}\n")
+                f.write(f"sigma {self.sigma}\n")
+            f.write(f"stiffness {k[0]} {k[1]} {k[3]}\n")
+            f.write(f"r0Probe {self.tipR0[0]} {self.tipR0[1]} {self.tipR0[2]}\n")
+            f.write(f"PBC {(np.array(self.npbc) > 0).any()}\n")
+            f.write(f"nPBC {self.npbc[0]} {self.npbc[1]} {self.npbc[2]}\n")
             if self.sample_lvec is not None:
-                f.write(f'gridA {self.sample_lvec[0, 0]} {self.sample_lvec[0, 1]} {self.sample_lvec[0, 2]}\n')
-                f.write(f'gridB {self.sample_lvec[1, 0]} {self.sample_lvec[1, 1]} {self.sample_lvec[1, 2]}\n')
-                f.write(f'gridC {self.sample_lvec[2, 0]} {self.sample_lvec[2, 1]} {self.sample_lvec[2, 2]}\n')
-            f.write(f'FFgrid0 {self.lvec[0, 0]} {self.lvec[0, 1]} {self.lvec[0, 2]}\n')
-            f.write(f'FFgridA {self.lvec[1, 0]} {self.lvec[1, 1]} {self.lvec[1, 2]}\n')
-            f.write(f'FFgridB {self.lvec[2, 0]} {self.lvec[2, 1]} {self.lvec[2, 2]}\n')
-            f.write(f'FFgridC {self.lvec[3, 0]} {self.lvec[3, 1]} {self.lvec[3, 2]}\n')
-            f.write(f'gridN {nDim[0]} {nDim[1]} {nDim[2]}\n')
-            f.write(f'scanMin {self.scan_window[0][0]} {self.scan_window[0][1]} {self.scan_window[0][2]}\n')
-            f.write(f'scanMax {self.scan_window[1][0]} {self.scan_window[1][1]} {self.scan_window[1][2]}\n')
-            f.write(f'scanStep {scan_step[0]} {scan_step[1]} {scan_step[2]}\n')
-            f.write(f'kCantilever {self.kCantilever}\n')
-            f.write(f'f0Cantilever {self.f0Cantilever}\n')
-            f.write(f'Amplitude {self.amplitude}\n')
-            f.write(f'Apauli {self.A_pauli}\n')
-            f.write(f'Bpauli {self.B_pauli}\n')
+                f.write(
+                    f"gridA {self.sample_lvec[0, 0]} {self.sample_lvec[0, 1]} {self.sample_lvec[0, 2]}\n"
+                )
+                f.write(
+                    f"gridB {self.sample_lvec[1, 0]} {self.sample_lvec[1, 1]} {self.sample_lvec[1, 2]}\n"
+                )
+                f.write(
+                    f"gridC {self.sample_lvec[2, 0]} {self.sample_lvec[2, 1]} {self.sample_lvec[2, 2]}\n"
+                )
+            f.write(f"FFgrid0 {self.lvec[0, 0]} {self.lvec[0, 1]} {self.lvec[0, 2]}\n")
+            f.write(f"FFgridA {self.lvec[1, 0]} {self.lvec[1, 1]} {self.lvec[1, 2]}\n")
+            f.write(f"FFgridB {self.lvec[2, 0]} {self.lvec[2, 1]} {self.lvec[2, 2]}\n")
+            f.write(f"FFgridC {self.lvec[3, 0]} {self.lvec[3, 1]} {self.lvec[3, 2]}\n")
+            f.write(f"gridN {nDim[0]} {nDim[1]} {nDim[2]}\n")
+            f.write(
+                f"scanMin {self.scan_window[0][0]} {self.scan_window[0][1]} {self.scan_window[0][2]}\n"
+            )
+            f.write(
+                f"scanMax {self.scan_window[1][0]} {self.scan_window[1][1]} {self.scan_window[1][2]}\n"
+            )
+            f.write(f"scanStep {scan_step[0]} {scan_step[1]} {scan_step[2]}\n")
+            f.write(f"kCantilever {self.kCantilever}\n")
+            f.write(f"f0Cantilever {self.f0Cantilever}\n")
+            f.write(f"Amplitude {self.amplitude}\n")
+            f.write(f"Apauli {self.A_pauli}\n")
+            f.write(f"Bpauli {self.B_pauli}\n")
 
     # ========= Debug/Plot Misc. =========
 
     def saveFF(self):
         FF = self.forcefield.downloadFF()
-        FFx=FF[:,:,:,0]
-        FFy=FF[:,:,:,1]
-        FFz=FF[:,:,:,2]
-        Fr = np.sqrt( FFx**2 + FFy**2 + FFz**2 )
+        FFx = FF[:, :, :, 0]
+        FFy = FF[:, :, :, 1]
+        FFz = FF[:, :, :, 2]
+        Fr = np.sqrt(FFx**2 + FFy**2 + FFz**2)
         Fbound = 10.0
         mask = Fr.flat > Fbound
-        FFx.flat[mask] *= (Fbound/Fr).flat[mask]
-        FFy.flat[mask] *= (Fbound/Fr).flat[mask]
-        FFz.flat[mask] *= (Fbound/Fr).flat[mask]
-        if self.verbose > 0: print("FF.shape ", FF.shape)
-        self.saveDebugXSF_FF( self.saveFFpre+"FF_x.xsf", FFx )
-        self.saveDebugXSF_FF( self.saveFFpre+"FF_y.xsf", FFy )
-        self.saveDebugXSF_FF( self.saveFFpre+"FF_z.xsf", FFz )
+        FFx.flat[mask] *= (Fbound / Fr).flat[mask]
+        FFy.flat[mask] *= (Fbound / Fr).flat[mask]
+        FFz.flat[mask] *= (Fbound / Fr).flat[mask]
+        if self.verbose > 0:
+            print("FF.shape ", FF.shape)
+        self.saveDebugXSF_FF(self.saveFFpre + "FF_x.xsf", FFx)
+        self.saveDebugXSF_FF(self.saveFFpre + "FF_y.xsf", FFy)
+        self.saveDebugXSF_FF(self.saveFFpre + "FF_z.xsf", FFz)
 
-    def saveDebugXSF_FF( self, fname, F ):
-        if(self.verbose>0): print("saveDebugXSF : ", fname)
-        io.saveXSF( fname, F, self.lvec )
+    def saveDebugXSF_FF(self, fname, F):
+        if self.verbose > 0:
+            print("saveDebugXSF : ", fname)
+        io.saveXSF(fname, F, self.lvec)
 
     def check_scan_window(self):
-        '''Check that scan window does not extend beyond any non-periodic boundaries.'''
-        for i, dim in enumerate('xyz'):
-            if self.npbc[i]: continue
+        """Check that scan window does not extend beyond any non-periodic boundaries."""
+        for i, dim in enumerate("xyz"):
+            if self.npbc[i]:
+                continue
             lvec_start = self.lvec[0, i]
-            lvec_end = lvec_start + self.lvec[i+1, i]
-            scan_start = self.scan_window[0][i] - 0.3   # Small offsets because being close to the boundary
-            scan_end = self.scan_window[1][i] + 0.3     # is problematic as well because of PP bending.
+            lvec_end = lvec_start + self.lvec[i + 1, i]
+            scan_start = (
+                self.scan_window[0][i] - 0.3
+            )  # Small offsets because being close to the boundary
+            scan_end = (
+                self.scan_window[1][i] + 0.3
+            )  # is problematic as well because of PP bending.
             if i == 2:
                 scan_start -= self.tipR0[2]
                 scan_end -= self.tipR0[2]
             if (scan_start < lvec_start) or (scan_end > lvec_end):
-                print(f'Warning: The edge of the scan window in {dim} dimension is very close or extends over '
-                    f'the boundary of the force-field grid which is not periodic in {dim} dimension. '
-                    'If you get artifacts in the images, please check the boundary conditions and '
-                    'the size of the scan window and the force field grid.')
+                print(
+                    f"Warning: The edge of the scan window in {dim} dimension is very close or extends over "
+                    f"the boundary of the force-field grid which is not periodic in {dim} dimension. "
+                    "If you get artifacts in the images, please check the boundary conditions and "
+                    "the size of the scan window and the force field grid."
+                )
 
-    def plot_images(self, X, outdir='afm_images', prefix='df'):
-        '''
+    def plot_images(self, X, outdir="afm_images", prefix="df"):
+        """
         Plot simulated AFM images and save them to a directory.
 
         Arguments:
             X: np.ndarray. AFM images to plot.
             outdir: str. Path to directory where files are saved.
             prefix: str. Prefix string for saved files.
-        '''
+        """
         if not os.path.exists(outdir):
             os.makedirs(outdir)
         X = X.transpose(2, 1, 0)[::-1]
-        zTips = np.linspace(self.scan_window[0][2], self.scan_window[1][2] - self.df_steps * self.dz,
-            self.scan_dim[2] - self.df_steps + 1)
+        zTips = np.linspace(
+            self.scan_window[0][2],
+            self.scan_window[1][2] - self.df_steps * self.dz,
+            self.scan_dim[2] - self.df_steps + 1,
+        )
         zTips += self.amplitude / 2
-        extent = [self.scan_window[0][0], self.scan_window[1][0], self.scan_window[0][1], self.scan_window[1][1]]
-        plotImages(os.path.join(outdir, prefix), X, slices = list(range(0, len(X))),
-            zs=zTips, extent=extent, cmap=PPU.params['colorscale'])
+        extent = [
+            self.scan_window[0][0],
+            self.scan_window[1][0],
+            self.scan_window[0][1],
+            self.scan_window[1][1],
+        ]
+        plotImages(
+            os.path.join(outdir, prefix),
+            X,
+            slices=list(range(0, len(X))),
+            zs=zTips,
+            extent=extent,
+            cmap=PPU.params["colorscale"],
+        )
+
 
 def _get_params(file_path):
-    '''Get AFMulator arguments from a params.ini file.'''
+    """Get AFMulator arguments from a params.ini file."""
     PPU.loadParams(file_path)
-    lvec = np.array([
-        PPU.params['FFgrid0'],
-        PPU.params['FFgridA'],
-        PPU.params['FFgridB'],
-        PPU.params['FFgridC']
-    ])
+    lvec = np.array(
+        [
+            PPU.params["FFgrid0"],
+            PPU.params["FFgridA"],
+            PPU.params["FFgridB"],
+            PPU.params["FFgridC"],
+        ]
+    )
     if (lvec < 0).any():
         lvec = None
-    sample_lvec = np.array([
-        PPU.params['gridA'],
-        PPU.params['gridB'],
-        PPU.params['gridC']
-    ])
-    if (PPU.params['gridN'] == 0).any() or lvec is None:
+    sample_lvec = np.array(
+        [PPU.params["gridA"], PPU.params["gridB"], PPU.params["gridC"]]
+    )
+    if (PPU.params["gridN"] == 0).any() or lvec is None:
         pixPerAngstrome = 10
     else:
-        rx, ry, rz = (round(PPU.params['gridN'][i] / np.linalg.norm(lvec[i+1])) for i in range(3))
+        rx, ry, rz = (
+            round(PPU.params["gridN"][i] / np.linalg.norm(lvec[i + 1]))
+            for i in range(3)
+        )
         if np.allclose([rx, ry], rz):
             pixPerAngstrome = rx
         else:
             pixPerAngstrome = np.max([rx, ry, rz])
-            warnings.warn("Unequal grid densities in x, y, z directions is not supported in the OpenCL version of ppafm. "
-                f"Using the maximum of x, y, z directions, {pixPerAngstrome}, for grid point density.")
-    scan_window = (PPU.params['scanMin'], PPU.params['scanMax'])
+            warnings.warn(
+                "Unequal grid densities in x, y, z directions is not supported in the OpenCL version of ppafm. "
+                f"Using the maximum of x, y, z directions, {pixPerAngstrome}, for grid point density."
+            )
+    scan_window = (PPU.params["scanMin"], PPU.params["scanMax"])
     scan_dim = (
-        round((scan_window[1][0] - scan_window[0][0]) / PPU.params['scanStep'][0]) + 1,
-        round((scan_window[1][1] - scan_window[0][1]) / PPU.params['scanStep'][1]) + 1,
-        round((scan_window[1][2] - scan_window[0][2]) / PPU.params['scanStep'][2])
+        round((scan_window[1][0] - scan_window[0][0]) / PPU.params["scanStep"][0]) + 1,
+        round((scan_window[1][1] - scan_window[0][1]) / PPU.params["scanStep"][1]) + 1,
+        round((scan_window[1][2] - scan_window[0][2]) / PPU.params["scanStep"][2]),
     )
-    iZPP = PPU.params['probeType']
-    iZPP = elements.ELEMENT_DICT[iZPP][0] if iZPP in elements.ELEMENT_DICT else int(iZPP)
-    tipStiffness = PPU.params['stiffness']
+    iZPP = PPU.params["probeType"]
+    iZPP = (
+        elements.ELEMENT_DICT[iZPP][0] if iZPP in elements.ELEMENT_DICT else int(iZPP)
+    )
+    tipStiffness = PPU.params["stiffness"]
     if (tipStiffness < 0).any():
         tipStiffness = [0.25, 0.25, 0.0, 30.0]
     else:
-        tipStiffness = np.insert(tipStiffness, 2, 0.0) # AFMulator additionally has a z-component in the third place
+        tipStiffness = np.insert(
+            tipStiffness, 2, 0.0
+        )  # AFMulator additionally has a z-component in the third place
     afmulator_params = {
-        'lvec': lvec,
-        'pixPerAngstrome': pixPerAngstrome,
-        'scan_dim': scan_dim,
-        'scan_window': scan_window,
-        'iZPP': iZPP,
-        'rho': {PPU.params['tip']: PPU.params['charge']},
-        'sigma': PPU.params['sigma'],
-        'A_pauli': PPU.params['Apauli'],
-        'B_pauli': PPU.params['Bpauli'],
-        'df_steps': round(PPU.params['Amplitude'] / PPU.params['scanStep'][2]),
-        'tipR0': PPU.params['r0Probe'],
-        'tipStiffness': tipStiffness,
-        'npbc': PPU.params['nPBC'] * PPU.params['PBC'],
-        'f0Cantilever': PPU.params['f0Cantilever'],
-        'kCantilever': PPU.params['kCantilever']
+        "lvec": lvec,
+        "pixPerAngstrome": pixPerAngstrome,
+        "scan_dim": scan_dim,
+        "scan_window": scan_window,
+        "iZPP": iZPP,
+        "rho": {PPU.params["tip"]: PPU.params["charge"]},
+        "sigma": PPU.params["sigma"],
+        "A_pauli": PPU.params["Apauli"],
+        "B_pauli": PPU.params["Bpauli"],
+        "df_steps": round(PPU.params["Amplitude"] / PPU.params["scanStep"][2]),
+        "tipR0": PPU.params["r0Probe"],
+        "tipStiffness": tipStiffness,
+        "npbc": PPU.params["nPBC"] * PPU.params["PBC"],
+        "f0Cantilever": PPU.params["f0Cantilever"],
+        "kCantilever": PPU.params["kCantilever"],
     }
     return afmulator_params, sample_lvec
 
-def get_lvec(scan_window, pad=(2.0, 2.0, 3.0), tipR0=(0.0, 0.0, 3.0), pixPerAngstrome=10):
+
+def get_lvec(
+    scan_window, pad=(2.0, 2.0, 3.0), tipR0=(0.0, 0.0, 3.0), pixPerAngstrome=10
+):
     pad = np.array(pad)
     tipR0 = np.array(tipR0)
     center = (np.array(scan_window[0]) + np.array(scan_window[1])) / 2
@@ -619,17 +765,27 @@ def get_lvec(scan_window, pad=(2.0, 2.0, 3.0), tipR0=(0.0, 0.0, 3.0), pixPerAngs
     nDim = np.array([VALID_SIZES[VALID_SIZES >= d][0] for d in nDim])
     box_size = nDim / pixPerAngstrome
     origin = center - box_size / 2 - tipR0
-    lvec = np.array([
-        origin,
-        [box_size[0], 0, 0],
-        [0, box_size[1], 0],
-        [0, 0, box_size[2]]
-    ])
+    lvec = np.array(
+        [origin, [box_size[0], 0, 0], [0, box_size[1], 0], [0, 0, box_size[2]]]
+    )
     return lvec
 
-def quick_afm(file_path, scan_size=(16, 16), offset=(0, 0), distance=8.0, scan_step=(0.1, 0.1, 0.1),
-        probe_type=8, charge=-0.1, tip='dz2', sigma=0.71, num_heights=10, amplitude=1.0, out_dir=None):
-    r'''
+
+def quick_afm(
+    file_path,
+    scan_size=(16, 16),
+    offset=(0, 0),
+    distance=8.0,
+    scan_step=(0.1, 0.1, 0.1),
+    probe_type=8,
+    charge=-0.1,
+    tip="dz2",
+    sigma=0.71,
+    num_heights=10,
+    amplitude=1.0,
+    out_dir=None,
+):
+    r"""
     Make an AFM simulation from a .cube, .xsf, or .xyz file, and print images to a folder.
 
     Arguments:
@@ -645,7 +801,7 @@ def quick_afm(file_path, scan_size=(16, 16), offset=(0, 0), distance=8.0, scan_s
         num_heights: int. Number of different heights to scan.
         amplitude: float. Oscillation amplitude in angstroms.
         out_dir: str or None. Output folder path. If None, defaults to "./afm\_" + input_file_name.
-    '''
+    """
 
     if not FFcl.oclu or not oclr.oclu:
         oclu.init_env()
@@ -653,44 +809,54 @@ def quick_afm(file_path, scan_size=(16, 16), offset=(0, 0), distance=8.0, scan_s
     if not out_dir:
         file_name = os.path.split(file_path)[1]
         file_name = os.path.splitext(file_name)[0]
-        out_dir = f'afm_{file_name}'.replace(' ', '_')
+        out_dir = f"afm_{file_name}".replace(" ", "_")
 
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
     # Load input file
-    if file_path.endswith('.xsf') or file_path.endswith('.cube'):
+    if file_path.endswith(".xsf") or file_path.endswith(".cube"):
         qs, xyzs, Zs = FFcl.HartreePotential.from_file(file_path, scale=-1.0)
         multipole = {tip: charge}
         Qs = [0, 0, 0, 0]
         QZs = [0, 0, 0, 0]
-    elif file_path.endswith('.xyz'):
+    elif file_path.endswith(".xyz"):
         xyzs, Zs, qs, _ = io.loadXYZ(file_path)
         multipole = {}
-        if tip == 's':
+        if tip == "s":
             Qs = [charge, 0, 0, 0]
             QZs = [0, 0, 0, 0]
-        elif tip == 'pz':
-            Qs = [10*charge, -10*charge, 0, 0]
+        elif tip == "pz":
+            Qs = [10 * charge, -10 * charge, 0, 0]
             QZs = [0.1, -0.1, 0, 0]
-        elif tip == 'dz2':
-            Qs = [100*charge, -200*charge, 100*charge, 0]
+        elif tip == "dz2":
+            Qs = [100 * charge, -200 * charge, 100 * charge, 0]
             QZs = [0.1, 0, -0.1, 0]
         else:
-            raise ValueError(f'Unsupported tip type `{tip}` for point charges.')
+            raise ValueError(f"Unsupported tip type `{tip}` for point charges.")
     else:
-        raise ValueError(f'Unsupported file format in file `{file_path}`.')
+        raise ValueError(f"Unsupported file format in file `{file_path}`.")
 
     # Figure out scan parameters
     z_max = xyzs[:, 2].max() + distance
-    xy_center = (xyzs[:, :2].min(axis=0) + xyzs[:, :2].max(axis=0)) / 2 + np.array(offset)
+    xy_center = (xyzs[:, :2].min(axis=0) + xyzs[:, :2].max(axis=0)) / 2 + np.array(
+        offset
+    )
     df_steps = int(amplitude / scan_step[2])
     z_size = (num_heights + df_steps - 1) * scan_step[2]
     scan_window = (
-        (xy_center[0] - scan_size[0] / 2, xy_center[1] - scan_size[1] / 2, z_max - z_size),
-        (xy_center[0] + scan_size[0] / 2, xy_center[1] + scan_size[1] / 2, z_max)
+        (
+            xy_center[0] - scan_size[0] / 2,
+            xy_center[1] - scan_size[1] / 2,
+            z_max - z_size,
+        ),
+        (xy_center[0] + scan_size[0] / 2, xy_center[1] + scan_size[1] / 2, z_max),
     )
-    scan_dim = (int(scan_size[0] / scan_step[0]), int(scan_size[1] / scan_step[1]), int(z_size / scan_step[2]))
+    scan_dim = (
+        int(scan_size[0] / scan_step[0]),
+        int(scan_size[1] / scan_step[1]),
+        int(z_size / scan_step[2]),
+    )
 
     # Do scan
     afmulator = AFMulator(
@@ -700,12 +866,19 @@ def quick_afm(file_path, scan_size=(16, 16), offset=(0, 0), distance=8.0, scan_s
         iZPP=probe_type,
         Qs=Qs,
         QZs=QZs,
-        df_steps=df_steps
+        df_steps=df_steps,
     )
     X = afmulator(xyzs, Zs, qs)
 
     # Plot
     X = X[:, :, ::-1].T
-    extent = [scan_window[0][0], scan_window[1][0], scan_window[0][1], scan_window[1][1]]
-    zs = np.linspace(scan_window[0][2], scan_window[1][2], scan_dim[2]+1)[:num_heights]
-    plotImages(os.path.join(out_dir, 'df'), X, range(len(X)), extent=extent, zs=zs)
+    extent = [
+        scan_window[0][0],
+        scan_window[1][0],
+        scan_window[0][1],
+        scan_window[1][1],
+    ]
+    zs = np.linspace(scan_window[0][2], scan_window[1][2], scan_dim[2] + 1)[
+        :num_heights
+    ]
+    plotImages(os.path.join(out_dir, "df"), X, range(len(X)), extent=extent, zs=zs)

--- a/ppafm/ocl/relax.py
+++ b/ppafm/ocl/relax.py
@@ -396,7 +396,7 @@ class RelaxedScanner:
         self.queue.finish()
         return FEout
 
-    def prepareFEConv( ):
+    def prepareFEConv(self):
         return np.empty( self.scan_dim[:2]+(self.nDimConvOut,4,), dtype=np.float32 )
 
     def run_convolveZ(self, FEconv=None, nz=None ):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,27 +4,15 @@ from ppafm import common
 
 
 def test_get_df_weight():
-    #amplitude = dz = 0.1
+    # amplitude = dz = 0.1
     assert np.allclose(common.get_df_weight(0.1), np.array([-5.0, 5.0]))
-    
-    #amplitude=1.0, dz=0.2
+
+    # amplitude=1.0, dz=0.2
     w = common.get_df_weight(1.0, dz=0.2)
     assert np.allclose(
         w,
         np.array(
-            [
-                -2.60220097e-01,
-                -1.91452256e-01,
-                -9.80141360e-02,
-                -5.63847676e-02,
-                -2.62785481e-02,
-                3.69960354e-16,
-                2.62785481e-02,
-                5.63847676e-02,
-                9.80141360e-02,
-                1.91452256e-01,
-                2.60220097e-01,
-            ]
+            [-0.35594622, -0.22193265, -0.05447093, 0.05447093, 0.22193265, 0.35594622]
         ),
     )
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,19 +4,35 @@ from ppafm import common
 
 
 def test_get_df_weight():
-    x, y = common.getDfWeight(n=5, dz=0.2)
-    assert np.allclose(x, np.array([-0.53836624, -0.12099505, -0.0, 0.12099505, 0.53836624]))
+    #amplitude = dz = 0.1
+    assert np.allclose(common.get_df_weight(0.1), np.array([-5.0, 5.0]))
+    
+    #amplitude=1.0, dz=0.2
+    w = common.get_df_weight(1.0, dz=0.2)
     assert np.allclose(
-        y,
+        w,
         np.array(
             [
-                -8.00000000e-01,
-                -4.00000000e-01,
-                1.11022302e-16,
-                4.00000000e-01,
-                8.00000000e-01,
+                -2.60220097e-01,
+                -1.91452256e-01,
+                -9.80141360e-02,
+                -5.63847676e-02,
+                -2.62785481e-02,
+                3.69960354e-16,
+                2.62785481e-02,
+                5.63847676e-02,
+                9.80141360e-02,
+                1.91452256e-01,
+                2.60220097e-01,
             ]
         ),
+    )
+
+
+def test_get_simple_df_weight():
+    w = common.get_simple_df_weight(n=5, dz=0.2)
+    assert np.allclose(
+        w, np.array([-0.62725683, -0.74548635, -0.0, 0.74548635, 0.62725683])
     )
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,7 +20,7 @@ def test_get_df_weight():
 def test_get_simple_df_weight():
     w = common.get_simple_df_weight(n=5, dz=0.2)
     assert np.allclose(
-        w, np.array([-0.62725683, -0.74548635, -0.0, 0.74548635, 0.62725683])
+        w, np.array([-0.31362841, -0.37274317, 0, 0.37274317, 0.31362841])
     )
 
 


### PR DESCRIPTION
I have defined `lvec_df` in `ppafm/cli/plot_results.py` so that it contains a modified copy of `lvec`. The modification consists basically in subtracting the amplitude from the height (defined by the third vector) and adding half of the amplitude to the origin (the "zeroth" vector). This `lvec_df` is then used when saving `df.xsf` (requested by the `--save_df` option). This will close #199.
Besides that, I have improved the numerical conversion from force to frequency shift itself, as implemented by the functions `Fz2df` and `Fz2df_tilt` in `ppafm/common.py`. Well, changed at least, I hope that it is an improvement, although I made the numerical procedure more complicated. In particular, I have totally rewritten the function `getDfWeight`. My intention was to make it work for very small amplitudes. The former solution could become imprecise if the amplitude was comparable to the grid step, thus extending over only very few grid points. If the amplitude equaled the grid step or if it was even smaller, the algorithm failed completely. My proposed solution should return a frequency shift proportional to the gradient of the force (estimated from forces on two consecutive grid points) for amplitudes smaller than or equal to the grid step. Moreover, while the former solution always rounded the amplitude to some integer multiple of grid step, now the conversion result is a continuous function of the (real-typed) amplitude, even though, of course, a discrete convolution will still be done.
Not sure I would have implemented the new way of `Fz2df` if I had realized from the beginning how complicated the formulae were going to be. Nevertheless, here it is. Please decide if you like the change. It is going to impact all AFM images, though I have checked using the `Graphene/` example that the changes are very small, usually not visible by eye at all except for extremely small amplitudes. I should probably write up a description of the algorithm in LaTEX and put it up somewhere, or perhaps put it to the Wiki. So far, however, I just described it by comments in the code of the `getDfWeight` function. Unfortunately, the math rendered in the plain text format is very hard to read, I am afraid.
If you do not like the new force to `df` conversion, I will put back the old solution or push some alternative less radically different from the old one, keeping just the height correction for `df.xsf` in this branch.