### PR TITLE
Add Python 3.12 to CI tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ---
-# Run basic tests for this app on the latest aiidalab-docker image.
 name: continuous-integration
 on: [push, pull_request]
 
@@ -8,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
         steps:
             - name: Check out repository


### PR DESCRIPTION
Python 3.12 was release a couple of weeks ago. This adds it to the CI test matrix. Seems to work fine.