### PR TITLE
Fix OpenCL compilation not working during CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Install package and its dependencies
               run: |
                   pip install .[dev,opencl]
-                  sudo apt install pocl-opencl-icd
+                  pip install pocl-binary-distribution
 
             - name: Run pytest
               run: pytest tests -v --cov


### PR DESCRIPTION
Fixes #226 

Something was not working with the version of PoCL from the Ubuntu repositories. Switched to using a version from pip, which made the tests work again.