### PR TITLE
Consider non-zero origin of the grid cell

### DIFF
--- a/ppafm/HighLevel.py
+++ b/ppafm/HighLevel.py
@@ -40,6 +40,24 @@ def trjByDir(n, d=[0.0, 0.0, PPU.params["scanStep"][2]], p0=[0, 0, PPU.params["s
     return trj
 
 
+def shift_positions(R, s):
+    """
+    Shifts positions in R by s; returns the result. Needed especially to shift atoms according to the grid origin.
+
+    Arguments:
+    R = list of positional vectors or a 2D array. The first index donoting the item (typically an atom)
+      the second index determines the coordinate
+    s = vector that determines the required shift
+
+    Returns Rs: Rs[ia,i] = R[ia,i] - s[i]
+    """
+    Rs = np.array(R).copy()
+    Rs[:,0] += s[0]
+    Rs[:,1] += s[1]
+    Rs[:,2] += s[2]
+    return Rs
+
+
 def relaxedScan3D(xTips, yTips, zTips, trj=None, bF3d=False):
     if verbose > 0:
         print(">>BEGIN: relaxedScan3D()")
@@ -126,10 +144,18 @@ def perform_relaxation(lvec, FFLJ, FFel=None, FFpauli=None, FFboltz=None, FFkpfm
     if verbose > 0:
         print("stiffness:", PPU.params["stiffness"])
     core.setTip(kSpring=np.array((PPU.params["stiffness"][0], PPU.params["stiffness"][1], 0.0)) / -PPU.eVA_Nm, kRadial=PPU.params["stiffness"][2] / -PPU.eVA_Nm)
+
+    #grid origin has to be moved to zero, hence the subtraction of lvec[0,:] from trj and xTip, yTips, zTips
     trj = None
-    if PPU.params["tiltedScan"]:
-        trj = trjByDir(len(zTips), d=PPU.params["scanTilt"], p0=PPU.params["scanMin"])
-    fzs, PPpos = relaxedScan3D(xTips, yTips, zTips, trj=trj, bF3d=PPU.params["tiltedScan"])
+    if PPU.params['tiltedScan']:
+        trj = trjByDir(len(zTips), d=PPU.params['scanTilt'], p0=PPU.params['scanMin'] - lvec[0,:])
+    fzs,PPpos = relaxedScan3D( xTips - lvec[0,0], yTips - lvec[0,1], zTips - lvec[0,2], trj=trj, bF3d=PPU.params['tiltedScan'] )
+
+    #transform probe-particle positions back to the original coordinates
+    PPpos[:,:,:,0] += lvec[0,0]
+    PPpos[:,:,:,1] += lvec[0,1]
+    PPpos[:,:,:,2] += lvec[0,2]
+
     if bPPdisp:
         PPdisp = PPpos.copy()
         init_pos = np.array(np.meshgrid(xTips, yTips, zTips)).transpose(3, 1, 2, 0) + np.array([PPU.params["r0Probe"][0], PPU.params["r0Probe"][1], -PPU.params["r0Probe"][2]])
@@ -171,13 +197,9 @@ def computeLJ(geomFile, speciesFile, geometry_format=None, save_format=None, com
     # --- load atomic geometry
     atoms, nDim, lvec = io.loadGeometry(geomFile, format=geometry_format, params=PPU.params)
     atomstring = io.primcoords2Xsf(PPU.atoms2iZs(atoms[0], elem_dict), [atoms[1], atoms[2], atoms[3]], lvec)
-    PPU.params["gridN"] = nDim
-    PPU.params["gridA"] = lvec[1]
-    PPU.params["gridB"] = lvec[2]
-    PPU.params["gridC"] = lvec[3]  # must be before parseAtoms
     if verbose > 0:
-        print(PPU.params["gridN"], PPU.params["gridA"], PPU.params["gridB"], PPU.params["gridC"])
-    iZs, Rs, Qs = PPU.parseAtoms(atoms, elem_dict, autogeom=False, PBC=PPU.params["PBC"])
+        print(PPU.params['gridN'], PPU.params['gridO'], PPU.params['gridA'], PPU.params['gridB'], PPU.params['gridC'])
+    iZs, Rs, Qs = PPU.parseAtoms(atoms, elem_dict, autogeom=False, PBC=PPU.params["PBC"], lvec=lvec)
     # --- prepare LJ parameters
     iPP = PPU.atom2iZ(PPU.params["probeType"], elem_dict)
     # --- prepare arrays and compute
@@ -185,20 +207,24 @@ def computeLJ(geomFile, speciesFile, geometry_format=None, save_format=None, com
     if verbose > 0:
         print("FFLJ.shape", FF.shape)
     core.setFF_shape(np.shape(FF), lvec)
+
+    #shift atoms to the coordinate system in which the grid origin is zero
+    Rs0 = shift_positions(Rs, -lvec[0])
+
     if ffModel == "Morse":
         REs = PPU.getAtomsRE(iPP, iZs, FFparams)
-        core.getMorseFF(Rs, REs)  # THE MAIN STUFF HERE
+        core.getMorseFF(Rs0, REs)  # THE MAIN STUFF HERE
     elif ffModel == "vdW":
         vdWDampKind = PPU.params["vdWDampKind"]
         if vdWDampKind == 0:
             cLJs = PPU.getAtomsLJ(iPP, iZs, FFparams)
-            core.getVdWFF(Rs, cLJs)  # THE MAIN STUFF HERE
+            core.getVdWFF(Rs0, cLJs)  # THE MAIN STUFF HERE
         else:
             REs = PPU.getAtomsRE(iPP, iZs, FFparams)
-            core.getVdWFF_RE(Rs, REs, kind=vdWDampKind)  # THE MAIN STUFF HERE
+            core.getVdWFF_RE(Rs0, REs, kind=vdWDampKind)  # THE MAIN STUFF HERE
     else:
         cLJs = PPU.getAtomsLJ(iPP, iZs, FFparams)
-        core.getLennardJonesFF(Rs, cLJs)  # THE MAIN STUFF HERE
+        core.getLennardJonesFF(Rs0, cLJs)  # THE MAIN STUFF HERE
     # --- post porces FFs
     if Fmax is not None:
         if verbose > 0:
@@ -241,12 +267,8 @@ def computeDFTD3(input_file, df_params="PBE", geometry_format=None, save_format=
 
     # Load atomic geometry
     atoms, nDim, lvec = io.loadGeometry(input_file, format=geometry_format, params=PPU.params)
-    PPU.params["gridN"] = nDim
-    PPU.params["gridA"] = lvec[1]
-    PPU.params["gridB"] = lvec[2]
-    PPU.params["gridC"] = lvec[3]
     elem_dict = PPU.getFFdict(PPU.loadSpecies())
-    iZs, Rs, _ = PPU.parseAtoms(atoms, elem_dict, autogeom=False, PBC=PPU.params["PBC"])
+    iZs, Rs, _ = PPU.parseAtoms(atoms, elem_dict, autogeom=False, PBC=PPU.params["PBC"], lvec=lvec)
     iPP = PPU.atom2iZ(PPU.params["probeType"], elem_dict)
 
     # Compute coefficients for each atom
@@ -256,7 +278,7 @@ def computeDFTD3(input_file, df_params="PBE", geometry_format=None, save_format=
     # Compute the force field
     FF, V = prepareArrays(None, compute_energy)
     core.setFF_shape(np.shape(FF), lvec)
-    core.getDFTD3FF(Rs, coeffs)
+    core.getDFTD3FF(shift_positions(Rs, -lvec[0]), coeffs)
 
     # Save to file
     if save_format is not None:
@@ -283,16 +305,16 @@ def computeELFF_pointCharge(geomFile, geometry_format=None, tip="s", save_format
     atoms, nDim, lvec = io.loadGeometry(geomFile, format=geometry_format, params=PPU.params)
     atomstring = io.primcoords2Xsf(PPU.atoms2iZs(atoms[0], elem_dict), [atoms[1], atoms[2], atoms[3]], lvec)
     # --- prepare arrays and compute
-    PPU.params["gridN"] = nDim
-    PPU.params["gridA"] = lvec[1]
-    PPU.params["gridB"] = lvec[2]
-    PPU.params["gridC"] = lvec[3]
     if verbose > 0:
         print(PPU.params["gridN"], PPU.params["gridA"], PPU.params["gridB"], PPU.params["gridC"])
-    iZs, Rs, Qs = PPU.parseAtoms(atoms, elem_dict=elem_dict, autogeom=False, PBC=PPU.params["PBC"])
+    iZs, Rs, Qs = PPU.parseAtoms(atoms, elem_dict=elem_dict, autogeom=False, PBC=PPU.params["PBC"], lvec=lvec)
     FF, V = prepareArrays(None, computeVpot)
     core.setFF_shape(np.shape(FF), lvec)
-    core.getCoulombFF(Rs, Qs * PPU.CoulombConst, kind=tipKind)  # THE MAIN STUFF HERE
+
+    #shift atoms to the coordinate system in which the grid origin is zero
+    Rs0 = shift_positions(Rs, -lvec[0])
+
+    core.getCoulombFF(Rs0, Qs * PPU.CoulombConst, kind=tipKind)  # THE MAIN STUFF HERE
     # --- post porces FFs
     if Fmax is not None:
         if verbose > 0:
@@ -381,8 +403,7 @@ def getAtomsWhichTouchPBCcell(fname, Rcut=1.0, bSaveDebug=True, geometry_format=
     return Rs, elems
 
 
-def subtractCoreDensities(rho, lvec_, elems=None, Rs=None, fname=None, valElDict=None, Rcore=0.7, bSaveDebugDens=False, bSaveDebugGeom=True, head=io.XSF_HEAD_DEFAULT):
-    lvec = lvec_[1:]
+def subtractCoreDensities(rho, lvec, elems=None, Rs=None, fname=None, valElDict=None, Rcore=0.7, bSaveDebugDens=False, bSaveDebugGeom=True, head=io.XSF_HEAD_DEFAULT):
     nDim = rho.shape
     if fname is not None:
         elems, Rs = getAtomsWhichTouchPBCcell(fname, Rcut=Rcore, bSaveDebug=bSaveDebugDens)
@@ -391,7 +412,7 @@ def subtractCoreDensities(rho, lvec_, elems=None, Rs=None, fname=None, valElDict
     print("subtractCoreDensities valElDict ", valElDict)
     print("subtractCoreDensities elems ", elems)
     cRAs = np.array([(-valElDict[elem], Rcore) for elem in elems])
-    V = np.linalg.det(lvec)  # volume of triclinic cell
+    V = np.linalg.det(lvec[1:])  # volume of triclinic cell
     N = nDim[0] * nDim[1] * nDim[2]
     dV = V / N  # volume of one voxel
     if verbose > 0:
@@ -403,8 +424,8 @@ def subtractCoreDensities(rho, lvec_, elems=None, Rs=None, fname=None, valElDict
     if verbose > 0:
         print(">>> Projecting Core Densities ... ")
 
-    core.getDensityR4spline(Rs, cRAs.copy())  # Do the job ( the Projection of atoms onto grid )
+    core.getDensityR4spline(shift_positions(Rs, -lvec[0]), cRAs.copy())  # Do the job ( the Projection of atoms onto grid )
     if verbose > 0:
         print("sum(RHO), Nelec: ", rho.sum(), rho.sum() * dV)  # check sum
     if bSaveDebugDens:
-        io.saveXSF("rho_subCoreChg.xsf", rho, lvec_, head=head)
+        io.saveXSF("rho_subCoreChg.xsf", rho, lvec, head=head)

--- a/ppafm/HighLevel.py
+++ b/ppafm/HighLevel.py
@@ -148,7 +148,7 @@ def perform_relaxation(lvec, FFLJ, FFel=None, FFpauli=None, FFboltz=None, FFkpfm
     #grid origin has to be moved to zero, hence the subtraction of lvec[0,:] from trj and xTip, yTips, zTips
     trj = None
     if PPU.params['tiltedScan']:
-        trj = trjByDir(len(zTips), d=PPU.params['scanTilt'], p0=PPU.params['scanMin'] - lvec[0,:])
+        trj = trjByDir(len(zTips), d=PPU.params['scanTilt'], p0=[0.0, 0.0, PPU.params['scanMin'][2] - lvec[0,2]])
     fzs,PPpos = relaxedScan3D( xTips - lvec[0,0], yTips - lvec[0,1], zTips - lvec[0,2], trj=trj, bF3d=PPU.params['tiltedScan'] )
 
     #transform probe-particle positions back to the original coordinates

--- a/ppafm/HighLevel.py
+++ b/ppafm/HighLevel.py
@@ -52,9 +52,9 @@ def shift_positions(R, s):
     Returns Rs: Rs[ia,i] = R[ia,i] - s[i]
     """
     Rs = np.array(R).copy()
-    Rs[:,0] += s[0]
-    Rs[:,1] += s[1]
-    Rs[:,2] += s[2]
+    Rs[:, 0] += s[0]
+    Rs[:, 1] += s[1]
+    Rs[:, 2] += s[2]
     return Rs
 
 
@@ -145,16 +145,16 @@ def perform_relaxation(lvec, FFLJ, FFel=None, FFpauli=None, FFboltz=None, FFkpfm
         print("stiffness:", PPU.params["stiffness"])
     core.setTip(kSpring=np.array((PPU.params["stiffness"][0], PPU.params["stiffness"][1], 0.0)) / -PPU.eVA_Nm, kRadial=PPU.params["stiffness"][2] / -PPU.eVA_Nm)
 
-    #grid origin has to be moved to zero, hence the subtraction of lvec[0,:] from trj and xTip, yTips, zTips
+    # grid origin has to be moved to zero, hence the subtraction of lvec[0,:] from trj and xTip, yTips, zTips
     trj = None
-    if PPU.params['tiltedScan']:
-        trj = trjByDir(len(zTips), d=PPU.params['scanTilt'], p0=[0.0, 0.0, PPU.params['scanMin'][2] - lvec[0,2]])
-    fzs,PPpos = relaxedScan3D( xTips - lvec[0,0], yTips - lvec[0,1], zTips - lvec[0,2], trj=trj, bF3d=PPU.params['tiltedScan'] )
+    if PPU.params["tiltedScan"]:
+        trj = trjByDir(len(zTips), d=PPU.params["scanTilt"], p0=[0.0, 0.0, PPU.params["scanMin"][2] - lvec[0, 2]])
+    fzs, PPpos = relaxedScan3D(xTips - lvec[0, 0], yTips - lvec[0, 1], zTips - lvec[0, 2], trj=trj, bF3d=PPU.params["tiltedScan"])
 
-    #transform probe-particle positions back to the original coordinates
-    PPpos[:,:,:,0] += lvec[0,0]
-    PPpos[:,:,:,1] += lvec[0,1]
-    PPpos[:,:,:,2] += lvec[0,2]
+    # transform probe-particle positions back to the original coordinates
+    PPpos[:, :, :, 0] += lvec[0, 0]
+    PPpos[:, :, :, 1] += lvec[0, 1]
+    PPpos[:, :, :, 2] += lvec[0, 2]
 
     if bPPdisp:
         PPdisp = PPpos.copy()
@@ -198,7 +198,7 @@ def computeLJ(geomFile, speciesFile, geometry_format=None, save_format=None, com
     atoms, nDim, lvec = io.loadGeometry(geomFile, format=geometry_format, params=PPU.params)
     atomstring = io.primcoords2Xsf(PPU.atoms2iZs(atoms[0], elem_dict), [atoms[1], atoms[2], atoms[3]], lvec)
     if verbose > 0:
-        print(PPU.params['gridN'], PPU.params['gridO'], PPU.params['gridA'], PPU.params['gridB'], PPU.params['gridC'])
+        print(PPU.params["gridN"], PPU.params["gridO"], PPU.params["gridA"], PPU.params["gridB"], PPU.params["gridC"])
     iZs, Rs, Qs = PPU.parseAtoms(atoms, elem_dict, autogeom=False, PBC=PPU.params["PBC"], lvec=lvec)
     # --- prepare LJ parameters
     iPP = PPU.atom2iZ(PPU.params["probeType"], elem_dict)
@@ -208,7 +208,7 @@ def computeLJ(geomFile, speciesFile, geometry_format=None, save_format=None, com
         print("FFLJ.shape", FF.shape)
     core.setFF_shape(np.shape(FF), lvec)
 
-    #shift atoms to the coordinate system in which the grid origin is zero
+    # shift atoms to the coordinate system in which the grid origin is zero
     Rs0 = shift_positions(Rs, -lvec[0])
 
     if ffModel == "Morse":
@@ -311,7 +311,7 @@ def computeELFF_pointCharge(geomFile, geometry_format=None, tip="s", save_format
     FF, V = prepareArrays(None, computeVpot)
     core.setFF_shape(np.shape(FF), lvec)
 
-    #shift atoms to the coordinate system in which the grid origin is zero
+    # shift atoms to the coordinate system in which the grid origin is zero
     Rs0 = shift_positions(Rs, -lvec[0])
 
     core.getCoulombFF(Rs0, Qs * PPU.CoulombConst, kind=tipKind)  # THE MAIN STUFF HERE

--- a/ppafm/common.py
+++ b/ppafm/common.py
@@ -23,6 +23,7 @@ params = {
     "PBC": True,
     "nPBC": np.array([1, 1, 1]),
     "gridN": np.array([-1, -1, -1]).astype(int),
+    "gridO": np.array([0.0, 0.0, 0.0]),
     "gridA": np.array([0.0, 0.0, 0.0]),
     "gridB": np.array([0.0, 0.0, 0.0]),
     "gridC": np.array([0.0, 0.0, 0.0]),
@@ -938,9 +939,9 @@ def prepareScanGrids():
     and the "Apex", so that while the point of reference on the tip used to interpret scanMin  was the Apex,
     the new point of reference used in the XSF output will be the Probe Particle.
     """
-    zTips = np.arange(params["scanMin"][2], params["scanMax"][2] + 0.00001, params["scanStep"][2])
-    xTips = np.arange(params["scanMin"][0], params["scanMax"][0] + 0.00001, params["scanStep"][0])
-    yTips = np.arange(params["scanMin"][1], params["scanMax"][1] + 0.00001, params["scanStep"][1])
+    xTips = np.arange(params["scanMin"][0], params["scanMax"][0] + 0.5*params["scanStep"][0], params["scanStep"][0])
+    yTips = np.arange(params["scanMin"][1], params["scanMax"][1] + 0.5*params["scanStep"][1], params["scanStep"][1])
+    zTips = np.arange(params["scanMin"][2], params["scanMax"][2] + 0.5*params["scanStep"][2], params["scanStep"][2])
     (xTips[0], xTips[-1], yTips[0], yTips[-1])
     lvecScan = np.array(
         [

--- a/ppafm/common.py
+++ b/ppafm/common.py
@@ -939,9 +939,9 @@ def prepareScanGrids():
     and the "Apex", so that while the point of reference on the tip used to interpret scanMin  was the Apex,
     the new point of reference used in the XSF output will be the Probe Particle.
     """
-    xTips = np.arange(params["scanMin"][0], params["scanMax"][0] + 0.5*params["scanStep"][0], params["scanStep"][0])
-    yTips = np.arange(params["scanMin"][1], params["scanMax"][1] + 0.5*params["scanStep"][1], params["scanStep"][1])
-    zTips = np.arange(params["scanMin"][2], params["scanMax"][2] + 0.5*params["scanStep"][2], params["scanStep"][2])
+    xTips = np.arange(params["scanMin"][0], params["scanMax"][0] + 0.5 * params["scanStep"][0], params["scanStep"][0])
+    yTips = np.arange(params["scanMin"][1], params["scanMax"][1] + 0.5 * params["scanStep"][1], params["scanStep"][1])
+    zTips = np.arange(params["scanMin"][2], params["scanMax"][2] + 0.5 * params["scanStep"][2], params["scanStep"][2])
     (xTips[0], xTips[-1], yTips[0], yTips[-1])
     lvecScan = np.array(
         [

--- a/ppafm/io.py
+++ b/ppafm/io.py
@@ -313,7 +313,7 @@ def loadAtomsCUBE(fname):
     f.readline().split()
     f.readline().split()
 
-    #origin = [float(sth0[1]), float(sth0[2]), float(sth0[3])]
+    # origin = [float(sth0[1]), float(sth0[2]), float(sth0[3])]
     nlines = int(sth0[0])
     for i in range(nlines):
         l = f.readline().split()

--- a/ppafm/io.py
+++ b/ppafm/io.py
@@ -313,15 +313,14 @@ def loadAtomsCUBE(fname):
     f.readline().split()
     f.readline().split()
 
-    shift = [float(sth0[1]), float(sth0[2]), float(sth0[3])]
+    #origin = [float(sth0[1]), float(sth0[2]), float(sth0[3])]
     nlines = int(sth0[0])
     for i in range(nlines):
         l = f.readline().split()
         r = [float(l[2]), float(l[3]), float(l[4])]
-        x.append((r[0] - shift[0]) * bohrRadius2angstroem)
-        y.append((r[1] - shift[1]) * bohrRadius2angstroem)
-        z.append((r[2] - shift[2]) * bohrRadius2angstroem)
-        # print float(l[2])*bohrRadius2angstroem, float(l[3])*bohrRadius2angstroem, float(l[4])*bohrRadius2angstroem
+        x.append(r[0] * bohrRadius2angstroem)
+        y.append(r[1] * bohrRadius2angstroem)
+        z.append(r[2] * bohrRadius2angstroem)
         e.append(int(l[0]))
         q.append(0.0)
     f.close()
@@ -381,8 +380,7 @@ def loadCellCUBE(fname):
     n3 = int(line[0])
     c3 = [float(s) for s in line[1:4]]
 
-    #    cell0 = [c0[0]*   bohrRadius2angstroem, c0[1]   *bohrRadius2angstroem, c0[2]   *bohrRadius2angstroem]
-    cell0 = [0.0, 0.0, 0.0]
+    cell0 = [c0[0] * bohrRadius2angstroem, c0[1] * bohrRadius2angstroem, c0[2] * bohrRadius2angstroem]
     cell1 = [c1[0] * n1 * bohrRadius2angstroem, c1[1] * n1 * bohrRadius2angstroem, c1[2] * n1 * bohrRadius2angstroem]
     cell2 = [c2[0] * n2 * bohrRadius2angstroem, c2[1] * n2 * bohrRadius2angstroem, c2[2] * n2 * bohrRadius2angstroem]
     cell3 = [c3[0] * n3 * bohrRadius2angstroem, c3[1] * n3 * bohrRadius2angstroem, c3[2] * n3 * bohrRadius2angstroem]
@@ -464,6 +462,7 @@ def loadGeometry(fname=None, format=None, params=None):
     # Make sure lvec is a 4x3 array. Use default grid parameters if needed
     if (lvec is None) or (len(lvec) == 0):
         lvec = np.zeros((4, 3))
+        lvec[0, :] = params["gridO"].copy()
         lvec[1, :] = params["gridA"].copy()
         lvec[2, :] = params["gridB"].copy()
         lvec[3, :] = params["gridC"].copy()
@@ -494,8 +493,8 @@ def loadGeometry(fname=None, format=None, params=None):
         # The automatically generated lattice vector should enclose the whole scanning area plus the default padding.
         if np.allclose(lvec[i + 1, :], 0):
             params["PBC"] = False
-            # lvec[i + 1, i] = probe_max[i] - probe_min[i] + 2*pad
-            lvec[i + 1, i] = probe_max[i] + pad
+            lvec[i + 1, i] = probe_max[i] - probe_min[i] + 2 * pad
+            lvec[0, i] = probe_min[i] - pad
 
         # Generate automatic grid using the default step if the grid dimension specified so far is not a positive number
         if not nDim[i] > 0:
@@ -504,6 +503,7 @@ def loadGeometry(fname=None, format=None, params=None):
     # Copy lattice vectors and grid dimensions to the global parameters
     # so as to guarantee compatibility between the local variables and global parameters
     for i in range(3):
+        params["gridO"][i] = lvec[0][i]
         params["gridA"][i] = lvec[1][i]
         params["gridB"][i] = lvec[2][i]
         params["gridC"][i] = lvec[3][i]


### PR DESCRIPTION
Fixes #223. Will help with #190 too.

I have introduced a **new parameter**, `gridO`, through which the user can specify the grid cell origin in `params.ini` if the geometry input file is not `*.xsf`, `*.cube` or `*.npz`, that is, if the geometry input file itself does not specify the grid.
- You are welcome to propose a different name for this `gridO` parameter.
- Moreover, we may want to merge it with `FFgrid0`. Now `gridO` is intended for the CPU(CLI) version while `FFgrid0` is for the GPU(OCL) version. However, merging those parameters into one may require more profound changes in the CPU version, in particular, maintaining a consistent distinction between the lattice vectors of the structural periodicity and the grid vectors, as discussed in #198.