### PR TITLE
Correct sign of densities and potentials in KPFM

### DIFF
--- a/ppafm/HighLevel.py
+++ b/ppafm/HighLevel.py
@@ -157,7 +157,7 @@ def perform_relaxation(lvec, FFLJ, FFel=None, FFpauli=None, FFboltz=None, FFkpfm
         if verbose > 0:
             print("adding charge:", PPU.params["charge"])
     if FFkpfm_t0sV is not None and FFkpfm_tVs0 is not None:
-        FF += (np.sign(PPU.params["charge"]) * FFkpfm_t0sV - FFkpfm_tVs0) * abs(PPU.params["charge"]) * PPU.params["Vbias"]
+        FF += (PPU.params["charge"] * FFkpfm_t0sV - FFkpfm_tVs0) * PPU.params["Vbias"]
         if verbose > 0:
             print("adding charge:", PPU.params["charge"], "and bias:", PPU.params["Vbias"], "V")
     if FFpauli is not None:
@@ -366,7 +366,7 @@ def computeELFF_pointCharge(geomFile, geometry_format=None, tip="s", save_format
     return FF, V, nDim, lvec
 
 
-def computeElFF(V, lvec, nDim, tip, computeVpot=False, tilt=0.0, sigma=None):
+def computeElFF(V, lvec, nDim, tip, computeVpot=False, tilt=0.0, sigma=None, deleteV=True):
     if verbose > 0:
         print(" ========= get electrostatic forcefiled from hartree ")
     rho = None
@@ -385,9 +385,10 @@ def computeElFF(V, lvec, nDim, tip, computeVpot=False, tilt=0.0, sigma=None):
             rho, lvec_tip, nDim_tip, tiphead = io.loadXSF(tip)
             if any(nDim_tip != nDim):
                 sys.exit("Error: Input file for tip charge density has been specified, but the dimensions are incompatible with the Hartree potential file!")
+            rho *= -1  # Negative charge density from positive electron density
     if verbose > 0:
         print(" computing convolution with tip by FFT ")
-    Fel_x, Fel_y, Fel_z, Vout = fFFT.potential2forces_mem(V, lvec, nDim, rho=rho, sigma=sigma, multipole=multipole, doPot=computeVpot, tilt=tilt)
+    Fel_x, Fel_y, Fel_z, Vout = fFFT.potential2forces_mem(V, lvec, nDim, rho=rho, sigma=sigma, multipole=multipole, doPot=computeVpot, tilt=tilt, deleteV=deleteV)
     FFel = io.packVecGrid(Fel_x, Fel_y, Fel_z)
     del Fel_x, Fel_y, Fel_z
     return FFel, Vout

--- a/ppafm/PPPlot.py
+++ b/ppafm/PPPlot.py
@@ -95,7 +95,7 @@ def plotImages(
         plt.imshow(F[i], origin="lower", interpolation=interpolation, cmap=cmap, extent=extent, vmin=vmin, vmax=vmax)
 
         if cbar:
-            plt.colorbar(shrink=0.5)
+            plt.colorbar(shrink=float(F[i].shape[0]) / float(F[i].shape[1]))
         plotGeom(atoms, bonds, atomSize=atomSize)
         plt.xlabel(r" Tip_x $\AA$")
         plt.ylabel(r" Tip_y $\AA$")

--- a/ppafm/PPPlot.py
+++ b/ppafm/PPPlot.py
@@ -95,7 +95,7 @@ def plotImages(
         plt.imshow(F[i], origin="lower", interpolation=interpolation, cmap=cmap, extent=extent, vmin=vmin, vmax=vmax)
 
         if cbar:
-            plt.colorbar(shrink=float(F[i].shape[0]) / float(F[i].shape[1]))
+            plt.colorbar(shrink=min(1.0, F[i].shape[0] / F[i].shape[1]))
         plotGeom(atoms, bonds, atomSize=atomSize)
         plt.xlabel(r" Tip_x $\AA$")
         plt.ylabel(r" Tip_y $\AA$")

--- a/ppafm/PPPlot.py
+++ b/ppafm/PPPlot.py
@@ -95,7 +95,7 @@ def plotImages(
         plt.imshow(F[i], origin="lower", interpolation=interpolation, cmap=cmap, extent=extent, vmin=vmin, vmax=vmax)
 
         if cbar:
-            plt.colorbar()
+            plt.colorbar(shrink=0.5)
         plotGeom(atoms, bonds, atomSize=atomSize)
         plt.xlabel(r" Tip_x $\AA$")
         plt.ylabel(r" Tip_y $\AA$")

--- a/ppafm/fieldFFT.py
+++ b/ppafm/fieldFFT.py
@@ -81,7 +81,7 @@ def getSphericalHarmonic(X, Y, Z, kind="dz2", tilt=0.0):
             print("Spherical harmonic: dz2")
         return 0.25 * (
             2 * Z**2 - X**2 - Y**2
-        )  # quadrupole normalized to get 3 times the quadrpole in the standard (cartesian) tensor normalization of Qzz. Also, 3D integral of rho_dz2(x,y,z)*(z/sigma)**2 gives 1 in the normalization use here.
+        )  # quadrupole normalized to get 3 times the quadrpole in the standard (cartesian) tensor normalization of Qzz. Also, 3D integral of rho_dz2(x,y,z)*(z/sigma)**2 gives 1 in the normalization used here.
     elif kind == "dx2":
         if verbose > 0:
             print("Spherical harmonic: dx2")


### PR DESCRIPTION
Fixes #250. What I have done to address the sign issue itself can be best understood from the code changes I think. Besides that

1. The `main` of `ppafm/cli/generateElFF.py` was creating two copies of the electrostatic potential before calculating LCPD: ```v_v0_aux = electrostatic_potential.copy()``` and ```v_v0_aux2 = electrostatic_potential.copy()```. Having the same field written in three places made the code look rather messy to me and I found it difficult to keep track of the required sign changes in such a mess so I did away with those copies. As I understood it, they were needed because the `potential2forces_mem` function in `ppafm/fieldFFT.py` would remove the array with the potential after the potential had been used, unless the function had been called with the `deleteV=False` argument. In order to address this, I have therefore introduced the `deleteV` argument to the function `computeElFF` from `ppafm/HighLevel.py` so that the `deleteV=False` option could be passed from `generateElFF.py` to `potential2forces_mem` through `computeElFF`.
2. The `FFkpfm_tVs0` term was scaled by the tip charge `abs(PPU.params.["charge"])` here https://github.com/Probe-Particle/ppafm/blob/18a5d8a68158e5ffc76d7988bb3e9a6a3b86ff2d/ppafm/HighLevel.py#L160 I did not think this made any sense so I removed this scaling: https://github.com/Probe-Particle/ppafm/blob/aaeedbcbabab2c82453ff283379b4a4e21720071/ppafm/HighLevel.py#L160 @aureliojgc, can you comment on what idea was behind it? Anyway, as I removed it, I changed the meaning of the numerical tip polarizabilities defined here: https://github.com/Probe-Particle/ppafm/blob/aaeedbcbabab2c82453ff283379b4a4e21720071/ppafm/cli/generateElFF.py#L126-L137 I did not change the numbers (only the signs) as it seemed to me that before I removed the scaling, the `FFkpfm_tVs0` contribution was always negligible with respect to the `FFkpfm_t0sV` contribution for default tip polarizability and typical tip charge, which did not seem right. Now this relative contributions of  `FFkpfm_tVs0` and `FFkpfm_tVs0` somewhat improved as to become more equalized.