### PR TITLE
Temporarily disable one of the CI tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
                   pip install pocl-binary-distribution
 
             - name: Run pytest
-              run: PPAFM_RECOMPILE=1 pytest tests examples -v --cov --cov-report json
+              # run: PPAFM_RECOMPILE=1 pytest tests examples -v --cov --cov-report json # Re-enable this when #232 is resolved
+              run: PPAFM_RECOMPILE=1 pytest tests examples/PTCDA_Hartree_dz2 -v --cov --cov-report json
 
             - name: Upload coverage report
               uses: codecov/codecov-action@v3


### PR DESCRIPTION
A temporary fix for #279 by disabling the failing test. We should look into fixing this properly after #232 is resolved, because the issue is probably with the sharing of the parameters between simulation test runs.