### PR TITLE
Fix API docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,7 @@ build:
 
 sphinx:
     configuration: doc/sphinx/source/conf.py
+    fail_on_warning: true
 
 python:
     install:

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -7,3 +7,4 @@ sphinx==7.2.6
 furo==2023.9.10
 myst-parser
 pydantic
+toml

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -6,3 +6,4 @@ ase
 sphinx==7.2.6
 furo==2023.9.10
 myst-parser
+pydantic

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -8,3 +8,4 @@ furo==2023.9.10
 myst-parser
 pydantic
 toml
+PyQt5

--- a/ppafm/fieldFFT.py
+++ b/ppafm/fieldFFT.py
@@ -350,9 +350,9 @@ def potential2forces_mem(V, lvec, nDim, sigma=0.7, rho=None, multipole=None, doF
 
 def Average_surf(Val_surf, W_surf, W_tip):
     """
-               Int_r Val_surf(r+R)  W_tip(r) W_sample(r+R)     W_tip) * (Val_surf W_sample)
-    <F>(R) = -----------------------------------------  = -----------------------------; where * means convolution
-               Int_r W_tip(r) W_sample(r+R)                     W_tip * W_sample
+    |            Int_r Val_surf(r+R)  W_tip(r) W_sample(r+R)     W_tip) * (Val_surf W_sample)
+    | <F>(R) = -----------------------------------------  = -----------------------------; where * means convolution
+    |            Int_r W_tip(r) W_sample(r+R)                     W_tip * W_sample
     """
     if verbose > 0:
         print("Forward FFT ")
@@ -384,9 +384,9 @@ def Average_surf(Val_surf, W_surf, W_tip):
 
 def Average_tip(Val_tip, W_surf, W_tip):
     """
-               Int_r Val_tip(r)  W_tip(r) W_sample(r+R)    (Val_tip W_tip) * W_sample
-    <F>(R) = -----------------------------------------  = -----------------------------; where * means convolution
-               Int_r W_surf(r) W_sample(r+R)                     W_tip * W_sample
+    |            Int_r Val_tip(r)  W_tip(r) W_sample(r+R)    (Val_tip W_tip) * W_sample
+    | <F>(R) = -----------------------------------------  = -----------------------------; where * means convolution
+    |            Int_r W_surf(r) W_sample(r+R)                     W_tip * W_sample
     """
     if verbose > 0:
         print("Forward FFT ")


### PR DESCRIPTION
Fixes #304 

The API docs are currently blank because the new dependencies from #275 were missing in the ReadTheDocs build.

The badge on the front page does not show the failure, however. This is because the failed imports are treated as warnings instead of errors. So I also added `fail_on_warning: true` to the config and fixed all of the remaining warnings so that there is at least some indication that the build is failing if this happens again in the future.