### PR TITLE
Fix spline interpolation segfaults.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.7', '3.9', '3.10', '3.11', '3.12']
+                python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
         steps:
             - name: Check out repository
@@ -24,8 +24,7 @@ jobs:
                   pip install pocl-binary-distribution
 
             - name: Run pytest
-              # run: PPAFM_RECOMPILE=1 pytest tests examples -v --cov --cov-report json # Re-enable this when #232 is resolved
-              run: PPAFM_RECOMPILE=1 pytest tests examples/PTCDA_Hartree_dz2 -v --cov --cov-report json
+              run: PPAFM_RECOMPILE=1 pytest tests examples -v --cov --cov-report json
 
             - name: Upload coverage report
               uses: codecov/codecov-action@v3

--- a/examples/PTCDA_Hartree_dz2/example_ptcda_hartree.py
+++ b/examples/PTCDA_Hartree_dz2/example_ptcda_hartree.py
@@ -14,8 +14,9 @@ def example_ptcda_hartree():
     # Change directory to the location of this script
     os.chdir(script_location)
 
-    subprocess.run(["wget", "--no-check-certificate", "https://www.dropbox.com/s/18eg89l89npll8x/LOCPOT.xsf.zip"])
-    subprocess.run(["unzip", "LOCPOT.xsf.zip"])
+    if not Path("LOCPOT.xsf").exists():
+        subprocess.run(["wget", "--no-check-certificate", "https://www.dropbox.com/s/18eg89l89npll8x/LOCPOT.xsf.zip"])
+        subprocess.run(["unzip", "LOCPOT.xsf.zip"])
 
     generate_ljff(["--input", "LOCPOT.xsf"])
     generate_elff(["--input", "LOCPOT.xsf", "--tip", "dz2"])

--- a/ppafm/HighLevel.py
+++ b/ppafm/HighLevel.py
@@ -103,7 +103,7 @@ def relaxedScan3D(xTips, yTips, zTips, trj=None, bF3d=False):
     return fzs, PPpos
 
 
-def relaxedScan3D_omp(xTips, yTips, zTips, trj=None, bF3d=False):
+def relaxedScan3D_omp(xTips, yTips, zTips, trj=None, bF3d=False, spline_parameters=None):
     if verbose > 0:
         print(">>BEGIN: relaxedScan3D_omp()")
     if verbose > 0:
@@ -117,7 +117,7 @@ def relaxedScan3D_omp(xTips, yTips, zTips, trj=None, bF3d=False):
     rTips[:, :, :, 0] = xTips[:, None, None]
     rTips[:, :, :, 1] = yTips[None, :, None]
     rTips[:, :, :, 2] = zTips[::-1][None, None, :]
-    core.relaxTipStrokes_omp(rTips, rs, fs)
+    core.relaxTipStrokes_omp(rTips, rs, fs, spline_parameters=spline_parameters)
     # rs[:,:,:,:] = rs[:,:,::-1,:].transpose(2,1,0,3).copy()
     # fs[:,:,:,:] = fs[:,:,::-1,:]
     # fzs = fs[:,:,::-1,2].transpose(2,1,0).copy()
@@ -131,26 +131,22 @@ def relaxedScan3D_omp(xTips, yTips, zTips, trj=None, bF3d=False):
     return fzs, rs
 
 
-def perform_relaxation(lvec, FFLJ, FFel=None, FFpauli=None, FFboltz=None, FFkpfm_t0sV=None, FFkpfm_tVs0=None, tipspline=None, bPPdisp=False, bFFtotDebug=False, parameters=None):
+def perform_relaxation(
+    lvec,
+    FFLJ,
+    FFel=None,
+    FFpauli=None,
+    FFboltz=None,
+    FFkpfm_t0sV=None,
+    FFkpfm_tVs0=None,
+    spline_parameters=None,
+    bPPdisp=False,
+    bFFtotDebug=False,
+    parameters=None,
+):
     global FF  # We need FF global otherwise it is garbage collected and program crashes inside C++ e.g. in stiffnessMatrix()
     if verbose > 0:
         print(">>>BEGIN: perform_relaxation()")
-    if tipspline is not None:
-        try:
-            if verbose > 0:
-                print(" loading tip spline from " + tipspline)
-            S = np.genfromtxt(tipspline)
-            xs = S[:, 0].copy()
-            if verbose > 0:
-                print("xs: ", xs)
-            ydys = S[:, 1:].copy()
-            if verbose > 0:
-                print("ydys: ", ydys)
-            core.setTipSpline(xs, ydys)
-        except:
-            if verbose > 0:
-                print("cannot load tip spline from " + tipspline)
-            sys.exit()
     xTips, yTips, zTips, lvecScan = PPU.prepareScanGrids(parameters=parameters)
     FF = FFLJ.copy()
     if FFel is not None:
@@ -180,7 +176,7 @@ def perform_relaxation(lvec, FFLJ, FFel=None, FFpauli=None, FFboltz=None, FFkpfm
     if parameters.tiltedScan:
         trj = trjByDir(len(zTips), d=parameters.scanTilt, p0=[0.0, 0.0, parameters.scanMin[2] - lvec[0, 2]])
     # fzs, PPpos = relaxedScan3D(xTips - lvec[0, 0], yTips - lvec[0, 1], zTips - lvec[0, 2], trj=trj, bF3d=parameters.tiltedScan)
-    fzs, PPpos = relaxedScan3D_omp(xTips - lvec[0, 0], yTips - lvec[0, 1], zTips - lvec[0, 2], trj=trj, bF3d=parameters.tiltedScan)
+    fzs, PPpos = relaxedScan3D_omp(xTips - lvec[0, 0], yTips - lvec[0, 1], zTips - lvec[0, 2], trj=trj, bF3d=parameters.tiltedScan, spline_parameters=spline_parameters)
 
     # transform probe-particle positions back to the original coordinates
     PPpos[:, :, :, 0] += lvec[0, 0]

--- a/ppafm/HighLevel.py
+++ b/ppafm/HighLevel.py
@@ -103,7 +103,7 @@ def relaxedScan3D(xTips, yTips, zTips, trj=None, bF3d=False):
     return fzs, PPpos
 
 
-def relaxedScan3D_omp(xTips, yTips, zTips, trj=None, bF3d=False, spline_parameters=None):
+def relaxedScan3D_omp(xTips, yTips, zTips, trj=None, bF3d=False, tip_spline=None):
     if verbose > 0:
         print(">>BEGIN: relaxedScan3D_omp()")
     if verbose > 0:
@@ -117,7 +117,7 @@ def relaxedScan3D_omp(xTips, yTips, zTips, trj=None, bF3d=False, spline_paramete
     rTips[:, :, :, 0] = xTips[:, None, None]
     rTips[:, :, :, 1] = yTips[None, :, None]
     rTips[:, :, :, 2] = zTips[::-1][None, None, :]
-    core.relaxTipStrokes_omp(rTips, rs, fs, spline_parameters=spline_parameters)
+    core.relaxTipStrokes_omp(rTips, rs, fs, tip_spline=tip_spline)
     # rs[:,:,:,:] = rs[:,:,::-1,:].transpose(2,1,0,3).copy()
     # fs[:,:,:,:] = fs[:,:,::-1,:]
     # fzs = fs[:,:,::-1,2].transpose(2,1,0).copy()
@@ -139,7 +139,7 @@ def perform_relaxation(
     FFboltz=None,
     FFkpfm_t0sV=None,
     FFkpfm_tVs0=None,
-    spline_parameters=None,
+    tip_spline=None,
     bPPdisp=False,
     bFFtotDebug=False,
     parameters=None,
@@ -176,7 +176,7 @@ def perform_relaxation(
     if parameters.tiltedScan:
         trj = trjByDir(len(zTips), d=parameters.scanTilt, p0=[0.0, 0.0, parameters.scanMin[2] - lvec[0, 2]])
     # fzs, PPpos = relaxedScan3D(xTips - lvec[0, 0], yTips - lvec[0, 1], zTips - lvec[0, 2], trj=trj, bF3d=parameters.tiltedScan)
-    fzs, PPpos = relaxedScan3D_omp(xTips - lvec[0, 0], yTips - lvec[0, 1], zTips - lvec[0, 2], trj=trj, bF3d=parameters.tiltedScan, spline_parameters=spline_parameters)
+    fzs, PPpos = relaxedScan3D_omp(xTips - lvec[0, 0], yTips - lvec[0, 1], zTips - lvec[0, 2], trj=trj, bF3d=parameters.tiltedScan, tip_spline=tip_spline)
 
     # transform probe-particle positions back to the original coordinates
     PPpos[:, :, :, 0] += lvec[0, 0]

--- a/ppafm/cli/relaxed_scan.py
+++ b/ppafm/cli/relaxed_scan.py
@@ -2,6 +2,7 @@
 
 import itertools as it
 import os
+import sys
 
 import numpy as np
 
@@ -139,6 +140,18 @@ def main(argv=None):
     lvec[2, :] = rotate_vector(lvec[2, :], opt_dict["rotate"])
     common.lvec2params(parameters=parameters, lvec=lvec)
 
+    if args.tipspline is not None:
+        try:
+            spline_parameters = core.SplineParameters.from_file(args.tipspline)
+            print(f"Loaded tip spline from {args.tipspline}")
+            print("xs: ", spline_parameters.rff_xs)
+            print("ydys: ", spline_parameters.rff_ydys)
+        except:
+            print(f"Could not load tip spline from {args.tipspline}")
+            sys.exit(1)
+    else:
+        spline_parameters = None
+
     for charge, stiffness, voltage in it.product(charges, k_constants, voltages):
         parameters.charge = charge
         parameters.klat = stiffness
@@ -160,7 +173,7 @@ def main(argv=None):
             FFboltz=ff_boltzman,
             FFkpfm_t0sV=ff_kpfm_t0sv,
             FFkpfm_tVs0=ff_kpfm_tvs0,
-            tipspline=args.tipspline,
+            spline_parameters=spline_parameters,
             bFFtotDebug=args.bDebugFFtot,
             parameters=parameters,
         )
@@ -176,7 +189,13 @@ def main(argv=None):
             print(f" === Computing eigenvectors of dynamical matrix: which={which} ddisp={parameters.ddisp}")
             tip_positions_x, tip_positions_y, tip_positions_z, lvec_scan = common.prepareScanGrids()
             r_tips = np.array(np.meshgrid(tip_positions_x, tip_positions_y, tip_positions_z)).transpose(3, 1, 2, 0).copy()
-            evals, evecs = core.stiffnessMatrix(r_tips.reshape((-1, 3)), pp_positions.reshape((-1, 3)), which=which, ddisp=parameters.ddisp)
+            evals, evecs = core.stiffnessMatrix(
+                r_tips.reshape((-1, 3)),
+                pp_positions.reshape((-1, 3)),
+                which=which,
+                ddisp=parameters.ddisp,
+                spline_parameters=spline_parameters,
+            )
             print("vib eigenval 1 min..max : ", np.min(evals[:, 0]), np.max(evals[:, 0]))
             print("vib eigenval 2 min..max : ", np.min(evals[:, 1]), np.max(evals[:, 1]))
             print("vib eigenval 3 min..max : ", np.min(evals[:, 2]), np.max(evals[:, 2]))

--- a/ppafm/cli/relaxed_scan.py
+++ b/ppafm/cli/relaxed_scan.py
@@ -142,15 +142,15 @@ def main(argv=None):
 
     if args.tipspline is not None:
         try:
-            spline_parameters = core.SplineParameters.from_file(args.tipspline)
+            tip_spline = core.SplineParameters.from_file(args.tipspline)
             print(f"Loaded tip spline from {args.tipspline}")
-            print("xs: ", spline_parameters.rff_xs)
-            print("ydys: ", spline_parameters.rff_ydys)
+            print("xs: ", tip_spline.rff_xs)
+            print("ydys: ", tip_spline.rff_ydys)
         except:
             print(f"Could not load tip spline from {args.tipspline}")
             sys.exit(1)
     else:
-        spline_parameters = None
+        tip_spline = None
 
     for charge, stiffness, voltage in it.product(charges, k_constants, voltages):
         parameters.charge = charge
@@ -173,7 +173,7 @@ def main(argv=None):
             FFboltz=ff_boltzman,
             FFkpfm_t0sV=ff_kpfm_t0sv,
             FFkpfm_tVs0=ff_kpfm_tvs0,
-            spline_parameters=spline_parameters,
+            tip_spline=tip_spline,
             bFFtotDebug=args.bDebugFFtot,
             parameters=parameters,
         )
@@ -194,7 +194,7 @@ def main(argv=None):
                 pp_positions.reshape((-1, 3)),
                 which=which,
                 ddisp=parameters.ddisp,
-                spline_parameters=spline_parameters,
+                tip_spline=tip_spline,
             )
             print("vib eigenval 1 min..max : ", np.min(evals[:, 0]), np.max(evals[:, 0]))
             print("vib eigenval 2 min..max : ", np.min(evals[:, 1]), np.max(evals[:, 1]))

--- a/ppafm/core.py
+++ b/ppafm/core.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from ctypes import c_double, c_int
+from ctypes import POINTER, Structure, c_double, c_int
 
 import numpy as np
 
@@ -150,14 +150,28 @@ def setTip(lRadial=None, kRadial=None, rPP0=None, kSpring=None, parameters=None)
     lib.setTip(lRadial, kRadial, rPP0, kSpring)
 
 
-# void setTipSpline( int n, double * xs, double * ydys ){
-lib.setTipSpline.argtypes = [c_int, array1d, array2d]
-lib.setTipSpline.restype = None
+# struct SplineParameters {
+#     int      rff_n;
+#     double * rff_xs;
+#     double * rff_ydys;
+# }
+class SplineParameters(Structure):
+    _fields_ = [
+        ("rff_n", c_int),
+        ("rff_xs", POINTER(c_double)),
+        ("rff_ydys", POINTER(c_double)),
+    ]
 
+    def __init__(self, xs, ydys):
+        super().__init__()
+        self.rff_n = len(xs)
+        self.rff_xs = np.ctypeslib.as_ctypes(xs.astype(np.double))
+        self.rff_ydys = np.ctypeslib.as_ctypes(ydys.flatten().astype(np.double))
 
-def setTipSpline(xs, ydys):
-    n = len(xs)
-    lib.setTipSpline(n, xs, ydys)
+    @classmethod
+    def from_file(cls, file_path):
+        spline_data = np.genfromtxt(file_path)
+        return cls(spline_data[:, 0], spline_data[:, 1:])
 
 
 # void getInPoints_LJ( int npoints, double * points, double * FEs, int natoms_, double * Ratoms_, double * cLJs ){
@@ -309,32 +323,32 @@ def getDensityR4spline(Rs, cRAs, bNormalize=True):
     lib.getDensityR4spline(natom, Rs, cRAs)
 
 
-# int relaxTipStroke ( int probeStart, int nstep, double * rTips_, double * rs_, double * fs_ )
-lib.relaxTipStroke.argtypes = [c_int, c_int, c_int, array2d, array2d, array2d]
+# int relaxTipStroke( int probeStart, int relaxAlg, int nstep, double * rTips_, double * rs_, double * fs_, TIP::SplineParams *splineParams )
+lib.relaxTipStroke.argtypes = [c_int, c_int, c_int, array2d, array2d, array2d, POINTER(SplineParameters)]
 lib.relaxTipStroke.restype = c_int
 
 
-def relaxTipStroke(rTips, rs, fs, probeStart=1, relaxAlg=1):
+def relaxTipStroke(rTips, rs, fs, probeStart=1, relaxAlg=1, spline_parameters=None):
     n = len(rTips)
-    return lib.relaxTipStroke(probeStart, relaxAlg, n, rTips, rs, fs)
+    return lib.relaxTipStroke(probeStart, relaxAlg, n, rTips, rs, fs, spline_parameters)
 
 
-# int relaxTipStrokes ( int nx, int ny, int probeStart, int nstep, double * rTips_, double * rs_, double * fs_ )
-lib.relaxTipStrokes_omp.argtypes = [c_int, c_int, c_int, c_int, c_int, array4d, array4d, array4d]
+# int relaxTipStrokes_omp( int nx, int ny, int probeStart, int relaxAlg, int nstep, double * rTips_, double * rs_, double * fs_, TIP::SplineParams *splineParams )
+lib.relaxTipStrokes_omp.argtypes = [c_int, c_int, c_int, c_int, c_int, array4d, array4d, array4d, POINTER(SplineParameters)]
 lib.relaxTipStrokes_omp.restype = c_int
 
 
-def relaxTipStrokes_omp(rTips, rs, fs, probeStart=1, relaxAlg=1):
+def relaxTipStrokes_omp(rTips, rs, fs, probeStart=1, relaxAlg=1, spline_parameters=None):
     nx, ny, nz, _ = rTips.shape
-    return lib.relaxTipStrokes_omp(nx, ny, probeStart, relaxAlg, nz, rTips, rs, fs)
+    return lib.relaxTipStrokes_omp(nx, ny, probeStart, relaxAlg, nz, rTips, rs, fs, spline_parameters)
 
 
-# void stiffnessMatrix( double ddisp, int which, int n,  double * rTips_, double * rs_,    double * eigenvals_, double * evec1_, double * evec2_, double * evec3_ ){
-lib.stiffnessMatrix.argtypes = [c_double, c_int, c_int, array2d, array2d, array2d, array2d, array2d, array2d]
+# void stiffnessMatrix( double ddisp, int which, int n, double * rTips_, double * rPPs_, double * eigenvals_, double * evec1_, double * evec2_, double * evec3_, TIP::SplineParams *sp )
+lib.stiffnessMatrix.argtypes = [c_double, c_int, c_int, array2d, array2d, array2d, array2d, array2d, array2d, POINTER(SplineParameters)]
 lib.stiffnessMatrix.restype = None
 
 
-def stiffnessMatrix(rTips, rPPs, which=0, ddisp=0.05):
+def stiffnessMatrix(rTips, rPPs, which=0, ddisp=0.05, spline_parameters=None):
     print("py.core.stiffnessMatrix() ")
     n = len(rTips)
     eigenvals = np.zeros((n, 3))
@@ -346,7 +360,7 @@ def stiffnessMatrix(rTips, rPPs, which=0, ddisp=0.05):
         evecs[i] = np.zeros((n, 3))
     print("py.core.stiffnessMatrix() 1 ")
 
-    lib.stiffnessMatrix(ddisp, which, n, rTips, rPPs, eigenvals, evecs[0], evecs[1], evecs[2])
+    lib.stiffnessMatrix(ddisp, which, n, rTips, rPPs, eigenvals, evecs[0], evecs[1], evecs[2], spline_parameters)
     return eigenvals, evecs
 
 
@@ -378,14 +392,14 @@ def subsample_nonuniform_spline(xs, ydys, xs_, ys_=None):
     return ys_
 
 
-# void test_force( int type, int n, double * r0_, double * dr_, double * R_, double * fs_ ){
-lib.test_force.argtypes = [c_int, c_int, array1d, array1d, array1d, array2d]
+# void test_force( int type, int n, double * r0_, double * dr_, double * R_, double * fs_, TIP::SplineParams *splineParams )
+lib.test_force.argtypes = [c_int, c_int, array1d, array1d, array1d, array2d, POINTER(SplineParameters)]
 lib.test_force.restype = None
 
 
-def test_force(typ, r0, dr, R, fs):
+def test_force(typ, r0, dr, R, fs, spline_parameters=None):
     n = len(fs)
-    lib.test_force(typ, n, r0, dr, R, fs)
+    lib.test_force(typ, n, r0, dr, R, fs, spline_parameters)
     return fs
 
 

--- a/tests/human_eye/test_TipForce.py
+++ b/tests/human_eye/test_TipForce.py
@@ -7,46 +7,53 @@ import numpy as np
 
 from ppafm import common, core
 
-spline_ini = """
-0.0   0.4 -0.1
-2.0   0.2 -0.1
-4.0   0.0 -0.1
-5.0  -4.0 -4.0
-10.0 -24.0 -4.0
-"""
-# S = np.genfromtxt('TipRSpline.ini')
-S = np.genfromtxt(StringIO(spline_ini), skip_header=1)
 
-parameters = common.PpafmParameters()
+def test_tip_force():
 
-print("TipRSpline.ini overrides harmonic tip")
-xs = S[:, 0].copy()
-print("xs: ", xs)
-ydys = S[:, 1:].copy()
-print("ydys: ", ydys)
-plt.plot(xs, ydys[:, 0], "o")
-plt.plot(xs, ydys[:, 0] + ydys[:, 1], ".")
-core.setTipSpline(xs, ydys)
+    spline_ini = """
+    0.0   0.4 -0.1
+    2.0   0.2 -0.1
+    4.0   0.0 -0.1
+    5.0  -4.0 -4.0
+    10.0 -24.0 -4.0
+    """
+    # S = np.genfromtxt('TipRSpline.ini')
+    S = np.genfromtxt(StringIO(spline_ini), skip_header=1)
 
-core.setTip(parameters=parameters)
+    parameters = common.PpafmParameters()
 
-fs = np.zeros((60, 3))
-r0 = np.array([0.0, 0.0, 0.5])
-dr = np.array([0.0, 0.0, 0.1])
-R = np.array([0.0, 0.0, 0.0])
-xs = np.array(list(range(len(fs)))) * dr[2] + r0[2]
-# print "xs=",xs
+    print("TipRSpline.ini overrides harmonic tip")
+    xs = S[:, 0].copy()
+    print("xs: ", xs)
+    ydys = S[:, 1:].copy()
+    print("ydys: ", ydys)
+    plt.plot(xs, ydys[:, 0], "o")
+    plt.plot(xs, ydys[:, 0] + ydys[:, 1], ".")
+    core.setTipSpline(xs, ydys)
 
-print(">>>  core.test_force( 1, r0, dr, R, fs )")
-core.test_force(1, r0, dr, R, fs)
-plt.plot(xs, fs[:, 2])
+    core.setTip(parameters=parameters)
 
-print(">>>  core.test_force( 2, r0, dr, R, fs )")
-core.test_force(2, r0, dr, R, fs)
-plt.plot(xs, fs[:, 2])
+    fs = np.zeros((60, 3))
+    r0 = np.array([0.0, 0.0, 0.5])
+    dr = np.array([0.0, 0.0, 0.1])
+    R = np.array([0.0, 0.0, 0.0])
+    xs = np.array(list(range(len(fs)))) * dr[2] + r0[2]
+    # print "xs=",xs
 
-# print "fs:", fs
+    print(">>>  core.test_force( 1, r0, dr, R, fs )")
+    core.test_force(1, r0, dr, R, fs)
+    plt.plot(xs, fs[:, 2])
 
-plt.grid()
-plt.savefig("tip_force.png")
-plt.show()
+    print(">>>  core.test_force( 2, r0, dr, R, fs )")
+    core.test_force(2, r0, dr, R, fs)
+    plt.plot(xs, fs[:, 2])
+
+    # print "fs:", fs
+
+    plt.grid()
+    plt.savefig("tip_force.png")
+    plt.show()
+
+
+if __name__ == "__main__":
+    test_tip_force()

--- a/tests/human_eye/test_TipForce.py
+++ b/tests/human_eye/test_TipForce.py
@@ -29,7 +29,7 @@ def test_tip_force():
     print("ydys: ", ydys)
     plt.plot(xs, ydys[:, 0], "o")
     plt.plot(xs, ydys[:, 0] + ydys[:, 1], ".")
-    core.setTipSpline(xs, ydys)
+    spline_parameters = core.SplineParameters(xs, ydys)
 
     core.setTip(parameters=parameters)
 
@@ -41,11 +41,11 @@ def test_tip_force():
     # print "xs=",xs
 
     print(">>>  core.test_force( 1, r0, dr, R, fs )")
-    core.test_force(1, r0, dr, R, fs)
+    core.test_force(1, r0, dr, R, fs, spline_parameters)
     plt.plot(xs, fs[:, 2])
 
     print(">>>  core.test_force( 2, r0, dr, R, fs )")
-    core.test_force(2, r0, dr, R, fs)
+    core.test_force(2, r0, dr, R, fs, spline_parameters)
     plt.plot(xs, fs[:, 2])
 
     # print "fs:", fs

--- a/tests/human_eye/test_TipForce.py
+++ b/tests/human_eye/test_TipForce.py
@@ -17,21 +17,15 @@ def test_tip_force():
     5.0  -4.0 -4.0
     10.0 -24.0 -4.0
     """
-    # S = np.genfromtxt('TipRSpline.ini')
-    S = np.genfromtxt(StringIO(spline_ini), skip_header=1)
 
-    parameters = common.PpafmParameters()
+    tip_spline = core.SplineParameters.from_file(StringIO(spline_ini))
 
-    print("TipRSpline.ini overrides harmonic tip")
-    xs = S[:, 0].copy()
-    print("xs: ", xs)
-    ydys = S[:, 1:].copy()
-    print("ydys: ", ydys)
-    plt.plot(xs, ydys[:, 0], "o")
-    plt.plot(xs, ydys[:, 0] + ydys[:, 1], ".")
-    spline_parameters = core.SplineParameters(xs, ydys)
+    print("xs: ", tip_spline.np_rff_xs)
+    print("ydys: ", tip_spline.np_rff_ydys)
+    plt.plot(tip_spline.np_rff_xs, tip_spline.np_rff_ydys[:, 0], "o")
+    plt.plot(tip_spline.np_rff_xs, tip_spline.np_rff_ydys[:, 0] + tip_spline.np_rff_ydys[:, 1], ".")
 
-    core.setTip(parameters=parameters)
+    core.setTip(parameters=common.PpafmParameters())
 
     fs = np.zeros((60, 3))
     r0 = np.array([0.0, 0.0, 0.5])
@@ -41,11 +35,11 @@ def test_tip_force():
     # print "xs=",xs
 
     print(">>>  core.test_force( 1, r0, dr, R, fs )")
-    core.test_force(1, r0, dr, R, fs, spline_parameters)
+    core.test_force(1, r0, dr, R, fs, tip_spline)
     plt.plot(xs, fs[:, 2])
 
     print(">>>  core.test_force( 2, r0, dr, R, fs )")
-    core.test_force(2, r0, dr, R, fs, spline_parameters)
+    core.test_force(2, r0, dr, R, fs, tip_spline)
     plt.plot(xs, fs[:, 2])
 
     # print "fs:", fs

--- a/tests/human_eye/test_splines.py
+++ b/tests/human_eye/test_splines.py
@@ -6,46 +6,53 @@ import numpy as np
 
 import ppafm.core as PPC
 
-# =========== uniform spline
 
-ys = np.array([0.0, 0.2, -0.3, 0.0])
-dys = np.array([0.8, 0.8, -1.2, -1.2])
-xs_ = np.linspace(-0.89, 0.59, 100)
-ydys = np.transpose(np.array([ys, dys])).copy()
-# print "ydys" = ydys
+def test_splines():
 
-x0 = -0.9
-dx = 0.5
-ys_ = PPC.subsample_uniform_spline(x0, dx, ydys, xs_)
-xs = np.array(list(range(len(ys)))) * dx + x0
+    # =========== uniform spline
 
-plt.figure()
-plt.plot(xs, ys, "o")
-plt.plot(xs, ys + 0.1 * dys, ".")
-plt.plot(xs_, ys_, "-")
-plt.grid()
+    ys = np.array([0.0, 0.2, -0.3, 0.0])
+    dys = np.array([0.8, 0.8, -1.2, -1.2])
+    xs_ = np.linspace(-0.89, 0.59, 100)
+    ydys = np.transpose(np.array([ys, dys])).copy()
+    # print "ydys" = ydys
 
-plt.savefig("splines1.png")
+    x0 = -0.9
+    dx = 0.5
+    ys_ = PPC.subsample_uniform_spline(x0, dx, ydys, xs_)
+    xs = np.array(list(range(len(ys)))) * dx + x0
 
-# =========== non-uniform spline
+    plt.figure()
+    plt.plot(xs, ys, "o")
+    plt.plot(xs, ys + 0.1 * dys, ".")
+    plt.plot(xs_, ys_, "-")
+    plt.grid()
 
-xs = np.array([-0.9, -0.6, 0.4, 0.6])
-# ys  = np.array   ( [  0.0, 0.2, -0.3,  0.0 ] )
-# dys = np.array  ( [  0.8, 0.8, -1.2, -1.2 ] )
-# dys = np.array   ( [  0.0, 0.0, 0.0, 0.0   ] )
-# xs_ = np.linspace(   -0.89, 0.59, 20           )
+    plt.savefig("splines1.png")
 
-ys_ = PPC.subsample_nonuniform_spline(xs, ydys, xs_)
+    # =========== non-uniform spline
 
-plt.figure()
-plt.plot(xs, ys, "o")
-plt.plot(xs, ys + 0.1 * dys, ".")
-plt.plot(xs_, ys_, "-")
-plt.grid()
+    xs = np.array([-0.9, -0.6, 0.4, 0.6])
+    # ys  = np.array   ( [  0.0, 0.2, -0.3,  0.0 ] )
+    # dys = np.array  ( [  0.8, 0.8, -1.2, -1.2 ] )
+    # dys = np.array   ( [  0.0, 0.0, 0.0, 0.0   ] )
+    # xs_ = np.linspace(   -0.89, 0.59, 20           )
 
-# print "xs_", xs_
-# print "ys_", ys_
+    ys_ = PPC.subsample_nonuniform_spline(xs, ydys, xs_)
 
-plt.savefig("splines2.png")
+    plt.figure()
+    plt.plot(xs, ys, "o")
+    plt.plot(xs, ys + 0.1 * dys, ".")
+    plt.plot(xs_, ys_, "-")
+    plt.grid()
 
-plt.show()
+    # print "xs_", xs_
+    # print "ys_", ys_
+
+    plt.savefig("splines2.png")
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    test_splines()

--- a/tests/human_eye/test_vdwDamping.py
+++ b/tests/human_eye/test_vdwDamping.py
@@ -8,115 +8,116 @@ import numpy as np
 import ppafm.common as PPU
 import ppafm.core as PPC
 
-# ======== Setup
-iPP = 8
-iZs = [1, 6, 7, 8]
-# iZs   = [1]
-iAtom = 3
 
-iVdWModel = 3
-if len(sys.argv) > 1:
-    try:
-        iVdWModel = int(sys.argv[1])
-    except ValueError:
-        print(f"Invalid input argument {sys.argv[1]}")
+def test_vdw_damping():
 
-ADamps = [180.0, 0.5, 0.5, 0.03, 0.01]
+    # ======== Setup
+    iPP = 8
+    iZs = [1, 6, 7, 8]
+    # iZs   = [1]
+    iAtom = 3
 
-model_names = [
-    #   "LJ_RE",     # -3
-    #   "LJ   ",     # -2
-    #   "invR6",     # -1
-    "VdW_C6",  # 0
-    "VdW_R2",  # 1
-    "VdW_R4",  # 2
-    "VdW_invR4",  # 3
-    "VdW_invR8",  # 4
-]
+    iVdWModel = 3
+    if len(sys.argv) > 1:
+        try:
+            iVdWModel = int(sys.argv[1])
+        except ValueError:
+            print(f"Invalid input argument {sys.argv[1]}")
+
+    ADamps = [180.0, 0.5, 0.5, 0.03, 0.01]
+
+    model_names = [
+        #   "LJ_RE",     # -3
+        #   "LJ   ",     # -2
+        #   "invR6",     # -1
+        "VdW_C6",  # 0
+        "VdW_R2",  # 1
+        "VdW_R4",  # 2
+        "VdW_invR4",  # 3
+        "VdW_invR8",  # 4
+    ]
+
+    # ======== Functions
+
+    def plotDecor(x0, vmax):
+        plt.axvline(x0, ls=":", c="k")
+        plt.axhline(0, ls="-", c="k")
+        plt.ylim(vmax * -2, vmax)
+        plt.grid()
+
+    def deriv(xs, Es, d=None):
+        if d is None:
+            d = xs[1] - xs[0]  # ;print( "d ", d )
+        Fs = -(Es[2:] - Es[:-2]) / (2.0 * d)
+        xs = xs[1:-1]
+        return Fs, xs
+
+    # ======== Main
+
+    FFparams = PPU.loadSpecies()
+    PPU.getFFdict(FFparams)
+    # print elem_dict
+
+    REs = PPU.getAtomsRE(iPP, iZs, FFparams)
+    print("REs  ", REs)
+    cLJs = PPU.getAtomsLJ(iPP, iZs, FFparams)
+    print("cLJs ", cLJs)
+
+    xs = np.arange(0.0, 6.0, 0.1)  # ;print(xs)
+
+    """
+    Es_LJ,Fs_LJ = PPC.evalRadialFF( xs, REs[iAtom,:], kind=-3 ) #;print( "Es_LJ", Es_LJ )  # LJ  -C6/r^6 + C12/r^12
+    #Es_LJ,Fs_LJ = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=-2 ) ;print( "Es_LJ", Es_LJ )  # LJ  -C6/r^6 + C12/r^12
+    Es_r6,Fs_r6 = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=0 ) #;print( "Es_r6", Es_r6 )   # vdW -C6/r^6
+
+    Es,Fs       = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=0  )
+    #Es,Fs       = PPC.evalRadialFF( xs, REs [iAtom,:], kind=0  )
+
+    plt.figure(figsize=(8,16))
+    plt.subplot(2,1,1);    plt.plot(xs,Es_LJ   ,':k'); plt.plot(xs,Es_r6   ,'--k'); plt.plot(xs,Es   );       plotDecor( R0, E0*2 )
+    plt.subplot(2,1,2);    plt.plot(xs,Fs_LJ*-1,':k'); plt.plot(xs,Fs_r6*-1,'--k'); plt.plot(xs,Fs*-1);       plotDecor( R0, E0*5 )
+    """
+
+    coefs = REs
+    if iVdWModel in {-2, -1, 0}:
+        coefs = cLJs
+
+    name = model_names[iVdWModel]
+    nz = len(iZs)
+    plt.figure(figsize=(5 * nz, 5 * 2))
+    for i in range(nz):
+        iAtom = i
+
+        R0 = REs[iAtom, 0]
+        E0 = REs[iAtom, 1]
+        Es_LJ, Fs_LJ = PPC.evalRadialFF(-xs, REs[iAtom, :], kind=-3)  # ;print( "Es_LJ", Es_LJ )  # LJ  -C6/r^6 + C12/r^12
+        Es_r6, Fs_r6 = PPC.evalRadialFF(-xs, cLJs[iAtom, :], kind=-1)  # ;print( "Es_r6", Es_r6 )   # vdW -C6/r^6
+        ADamp = ADamps[iVdWModel]
+        Es, Fs = PPC.evalRadialFF(-xs, coefs[iAtom, :], kind=iVdWModel, ADamp=ADamp)
+
+        Fs_num, xs_ = deriv(xs, Es)
+
+        plt.subplot(2, nz, i + 1)
+        plt.plot(xs, Es_LJ, ":k")
+        plt.plot(xs, Es_r6, "--k")
+        plt.plot(xs, Es)
+        plotDecor(R0, E0 * 5)
+        plt.title(f"{name}(Adamp={ADamp:5.2f}) {(FFparams[iZs[i] - 1][4]).decode()}-{(FFparams[iPP - 1][4]).decode()}")  # ; plt.title("Interaction %i-%i" %(iZs[i], iPP) )
+        plt.subplot(2, nz, i + nz + 1)
+        plt.plot(xs, Fs_LJ, ":k")
+        plt.plot(xs, Fs_r6, "--k")
+        plt.plot(xs, Fs)
+        plt.plot(xs_, Fs_num, ":r")
+        plotDecor(R0, E0 * 7)
+
+    plt.subplot(2, nz, +1)
+    plt.ylabel("Energy [eV]")
+    plt.subplot(2, nz, nz + 1)
+    plt.ylabel("Force  [eV/A]")
+    plt.savefig(name + ".png", bbox_inches="tight")
+
+    plt.show()
 
 
-# ======== Functions
-
-
-def plotDecor(x0, vmax):
-    plt.axvline(x0, ls=":", c="k")
-    plt.axhline(0, ls="-", c="k")
-    plt.ylim(vmax * -2, vmax)
-    plt.grid()
-
-
-def deriv(xs, Es, d=None):
-    if d is None:
-        d = xs[1] - xs[0]  # ;print( "d ", d )
-    Fs = -(Es[2:] - Es[:-2]) / (2.0 * d)
-    xs = xs[1:-1]
-    return Fs, xs
-
-
-# ======== Main
-
-FFparams = PPU.loadSpecies()
-elem_dict = PPU.getFFdict(FFparams)
-# print elem_dict
-
-REs = PPU.getAtomsRE(iPP, iZs, FFparams)
-print("REs  ", REs)
-cLJs = PPU.getAtomsLJ(iPP, iZs, FFparams)
-print("cLJs ", cLJs)
-
-
-xs = np.arange(0.0, 6.0, 0.1)  # ;print(xs)
-
-"""
-Es_LJ,Fs_LJ = PPC.evalRadialFF( xs, REs[iAtom,:], kind=-3 ) #;print( "Es_LJ", Es_LJ )  # LJ  -C6/r^6 + C12/r^12
-#Es_LJ,Fs_LJ = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=-2 ) ;print( "Es_LJ", Es_LJ )  # LJ  -C6/r^6 + C12/r^12
-Es_r6,Fs_r6 = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=0 ) #;print( "Es_r6", Es_r6 )   # vdW -C6/r^6
-
-Es,Fs       = PPC.evalRadialFF( xs, cLJs[iAtom,:], kind=0  )
-#Es,Fs       = PPC.evalRadialFF( xs, REs [iAtom,:], kind=0  )
-
-plt.figure(figsize=(8,16))
-plt.subplot(2,1,1);    plt.plot(xs,Es_LJ   ,':k'); plt.plot(xs,Es_r6   ,'--k'); plt.plot(xs,Es   );       plotDecor( R0, E0*2 )
-plt.subplot(2,1,2);    plt.plot(xs,Fs_LJ*-1,':k'); plt.plot(xs,Fs_r6*-1,'--k'); plt.plot(xs,Fs*-1);       plotDecor( R0, E0*5 )
-"""
-
-coefs = REs
-if iVdWModel in {-2, -1, 0}:
-    coefs = cLJs
-
-
-name = model_names[iVdWModel]
-nz = len(iZs)
-plt.figure(figsize=(5 * nz, 5 * 2))
-for i in range(nz):
-    iAtom = i
-
-    R0 = REs[iAtom, 0]
-    E0 = REs[iAtom, 1]
-    Es_LJ, Fs_LJ = PPC.evalRadialFF(-xs, REs[iAtom, :], kind=-3)  # ;print( "Es_LJ", Es_LJ )  # LJ  -C6/r^6 + C12/r^12
-    Es_r6, Fs_r6 = PPC.evalRadialFF(-xs, cLJs[iAtom, :], kind=-1)  # ;print( "Es_r6", Es_r6 )   # vdW -C6/r^6
-    ADamp = ADamps[iVdWModel]
-    Es, Fs = PPC.evalRadialFF(-xs, coefs[iAtom, :], kind=iVdWModel, ADamp=ADamp)
-
-    Fs_num, xs_ = deriv(xs, Es)
-
-    plt.subplot(2, nz, i + 1)
-    plt.plot(xs, Es_LJ, ":k")
-    plt.plot(xs, Es_r6, "--k")
-    plt.plot(xs, Es)
-    plotDecor(R0, E0 * 5)
-    plt.title(f"{name}(Adamp={ADamp:5.2f}) {(FFparams[iZs[i] - 1][4]).decode()}-{(FFparams[iPP - 1][4]).decode()}")  # ; plt.title("Interaction %i-%i" %(iZs[i], iPP) )
-    plt.subplot(2, nz, i + nz + 1)
-    plt.plot(xs, Fs_LJ, ":k")
-    plt.plot(xs, Fs_r6, "--k")
-    plt.plot(xs, Fs)
-    plt.plot(xs_, Fs_num, ":r")
-    plotDecor(R0, E0 * 7)
-
-plt.subplot(2, nz, +1)
-plt.ylabel("Energy [eV]")
-plt.subplot(2, nz, nz + 1)
-plt.ylabel("Force  [eV/A]")
-plt.savefig(name + ".png", bbox_inches="tight")
-
-plt.show()
+if __name__ == "__main__":
+    test_vdw_damping()


### PR DESCRIPTION
Fixes #308
Fixes #279 

This PR moves the spline parameters in the `TIP` namespace into a struct in the C++ code and introduces a corresponding Python class for managing the parameter arrays. A pointer to the parameters are now explicitly passed into the relevant functions instead of being set on a global level. This gets rid of the problem where the parameter array pointer could still be set even after the arrays were freed.

Also fixes one uninitialized variable in the spline interpolation function that was sometimes segfaulting.

All tests are now enabled and seem to be passing without problems again.