### PR TITLE
Add Python 3.13 to the CI test matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+                python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
         steps:
             - name: Check out repository


### PR DESCRIPTION
[Python 3.13 was released in October](https://www.python.org/downloads/release/python-3130/). The tests seem to pass without any problems.