### PR TITLE
Update upload-artifact v3->v4 in CI workflows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             - name: Save test images
               uses: actions/upload-artifact@v4
               with:
-                  name: test-images
+                  name: test-images-${{ matrix.python-version }}
                   path: ./*.png
 
     test-docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
                   flags: python-${{ matrix.python-version }}
 
             - name: Save test images
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: test-images
                   path: ./*.png

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
               uses: pypa/cibuildwheel@v2.16.5
 
             - name: Upload distribution artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: release
                   path: ./wheelhouse/*.whl
@@ -52,7 +52,7 @@ jobs:
               run: python -m build --sdist --outdir dist/
 
             - name: Upload distribution artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: release
                   path: dist/*.tar.gz


### PR DESCRIPTION
The CI workflow is broken as of yesterday, because [version v3 of `upload-artifact` is deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). 

This updates the version to v4. Additionally, the name of the uploaded artifact in v4 cannot overlap between different jobs, so each python version uploads a different file.