### PR TITLE
Change ncell to nPBC in examples/FFPB_KPFM/params.ini

### DIFF
--- a/examples/FFPB_KPFM/params.ini
+++ b/examples/FFPB_KPFM/params.ini
@@ -4,12 +4,12 @@ klat     0.25
 krad    30.0
 r0Probe  0.0 0.0 3.00
 PBC True
+nPBC 2 2 1
 scanMin -15.0 -7.5  6.0
 scanMax  15.0  7.5 12.0
 scanStep  0.1  0.1  0.1
 gridA     40.00000000      0.00000000      0.00000000
 gridB      0.00000000     20.00000000      0.00000000
 gridC      0.00000000      0.00000000     20.00000000
-ncell=(2,2,1)
 Amplitude 0.5
 Rtip     40.0


### PR DESCRIPTION
The example in `examples/FFPB_KPFM` still has the `ncell` option in `params.ini`, although this option has been replaced (I think) with `nPBC`. I have updated `examples/FFPB_KPFM/params.ini` accordingly.