### PR TITLE
Some changes in handling the arrays that represent force fields, potentials and densities

### DIFF
--- a/ppafm/GUIWidgets.py
+++ b/ppafm/GUIWidgets.py
@@ -173,10 +173,10 @@ class FigImshow(FigCanvas):
         if margins:
             self.axes.add_patch(
                 matplotlib.patches.Rectangle(
-                    (margins[0], margins[1]), F.shape[1] - margins[2] - margins[0], F.shape[0] - margins[3] - margins[1], linewidth=2, edgecolor="r", facecolor="none"
+                    (margins[0], margins[1]), F.shape[0] - margins[2] - margins[0], F.shape[1] - margins[3] - margins[1], linewidth=2, edgecolor="r", facecolor="none"
                 )
             )
-            textRes = "output size: " + str(F.shape[1] - margins[2] - margins[0]) + "x" + str(F.shape[0] - margins[3] - margins[1])
+            textRes = "output size: " + str(F.shape[0] - margins[2] - margins[0]) + "x" + str(F.shape[1] - margins[3] - margins[1])
             if slice_length:
                 textRes += "     length [A] =" + f"{slice_length[0]:03.4f}, {slice_length[1]:03.4f}"
             self.axes.set_xlabel(textRes)
@@ -202,8 +202,8 @@ class FigImshow(FigCanvas):
             F = F * (1 - alpha) + big_len_image * alpha
         self.img = self.axes.imshow(F, origin="lower", cmap="viridis", interpolation="bicubic")
 
-        j_min, i_min = np.unravel_index(F.argmin(), F.shape)
-        j_max, i_max = np.unravel_index(F.argmax(), F.shape)
+        i_min, j_min = np.unravel_index(F.argmin(), F.shape)
+        i_max, j_max = np.unravel_index(F.argmax(), F.shape)
 
         if margins:
             self.axes.add_patch(matplotlib.patches.Rectangle((margins[0], margins[1]), margins[2], margins[3], linewidth=2, edgecolor="r", facecolor="none"))
@@ -212,8 +212,8 @@ class FigImshow(FigCanvas):
                 textRes += "     length [A] =" + f"{slice_length[0]:03.4f}, {slice_length[1]:03.4f}"
             self.axes.set_xlabel(textRes)
 
-        self.axes.set_xlim(0, F.shape[1])
-        self.axes.set_ylim(0, F.shape[0])
+        self.axes.set_xlim(0, F.shape[0])
+        self.axes.set_ylim(0, F.shape[1])
         self.axes.set_title(title)
         if grid_selector > 0:
             self.axes.grid(True, linestyle="dotted", color="blue")

--- a/ppafm/GridUtils.py
+++ b/ppafm/GridUtils.py
@@ -156,6 +156,6 @@ lib.ReadNumsUpTo_C.restype = c_int
 
 
 def readNumsUpTo(filename, dimensions, noline):
-    N_arry = np.zeros((dimensions[0] * dimensions[1] * dimensions[2]), dtype=np.double)
-    lib.ReadNumsUpTo_C(filename.encode(), N_arry, dimensions, noline)
-    return N_arry
+    N_array = np.zeros((dimensions[0] * dimensions[1] * dimensions[2]), dtype=np.double)
+    lib.ReadNumsUpTo_C(filename.encode(), N_array, dimensions, noline)
+    return N_array

--- a/ppafm/PPPlot.py
+++ b/ppafm/PPPlot.py
@@ -69,7 +69,7 @@ def write_plotting_slice(i):
 def plotImages(
     prefix,
     F,
-    slices,
+    slices=[],
     extent=None,
     zs=None,
     figsize=default_figsize,
@@ -84,7 +84,14 @@ def plotImages(
     symmetric_map=False,
     V0=0.0,
     cbar_label=None,
+    reversed_ind=False,
 ):
+    if not reversed_ind:  # unless the order of indices is already reversed
+        F = F.transpose()  # slices in z will be the first index, rows (y) the second and columns (x) the third index
+    if (slices is None) or (len(slices) == 0):
+        # if no slices are specified, plot all slices
+        slices = list(range(0, len(F)))
+
     for ii, i in enumerate(slices):
         # print(" plotting ", i)
         write_plotting_slice(i)
@@ -114,8 +121,29 @@ def plotImages(
 
 
 def plotVecFieldRG(
-    prefix, dXs, dYs, slices, extent=None, zs=None, figsize=default_figsize, interpolation=default_interpolation, atoms=None, bonds=None, atomSize=default_atom_size
+    prefix,
+    dXs,
+    dYs,
+    slices=None,
+    extent=None,
+    zs=None,
+    figsize=default_figsize,
+    interpolation=default_interpolation,
+    atoms=None,
+    bonds=None,
+    atomSize=default_atom_size,
+    reversed_ind=False,
 ):
+
+    if not reversed_ind:
+        # Unless the order of indices is already reversed, transpose arrays for plotting:
+        # slices in z will be the first index, rows (y) the second and columns (x) the third index
+        dXs = dXs.transpose()
+        dYs = dYs.transpose()
+    if (slices is None) or (len(slices) == 0):
+        # if no slices are specified, plot all slices
+        slices = list(range(0, min(len(dXs), len(dYs))))
+
     for ii, i in enumerate(slices):
         # print(" plotting ", i)
         write_plotting_slice(i)
@@ -137,7 +165,7 @@ def plotDistortions(
     prefix,
     X,
     Y,
-    slices,
+    slices=None,
     BG=None,
     by=2,
     extent=None,
@@ -152,7 +180,20 @@ def plotDistortions(
     atoms=None,
     bonds=None,
     atomSize=default_atom_size,
+    reversed_ind=False,
 ):
+
+    if not reversed_ind:
+        # Unless the order of indices is already reversed, transpose arrays for plotting:
+        # slices in z will be the first index, rows (y) the second and columns (x) the third index
+        X = X.transpose()
+        Y = Y.transpose()
+        if BG is not None:
+            BG = BG.transpose()
+    if (slices is None) or (len(slices) == 0):
+        # if no slices are specified, plot all slices
+        slices = list(range(0, min(len(X), len(Y))))
+
     for ii, i in enumerate(slices):
         # print(" plotting ", i)
         write_plotting_slice(i)
@@ -180,7 +221,7 @@ def plotArrows(
     dY,
     X,
     Y,
-    slices,
+    slices=None,
     BG=None,
     C=None,
     extent=None,
@@ -195,14 +236,28 @@ def plotArrows(
     atoms=None,
     bonds=None,
     atomSize=default_atom_size,
+    reversed_ind=False,
 ):
+    if not reversed_ind:
+        # Unless the order of indices is already reversed, transpose arrays for plotting:
+        # slices in z will be the first index, rows (y) the second and columns (x) the third index
+        X = X.transpose()
+        Y = Y.transpose()
+        dX = dX.transpose()
+        dY = dY.transpose()
+        if BG is not None:
+            BG = BG.transpose()
+    if (slices is None) or (len(slices) == 0):
+        # if no slices specified, plot all slices
+        slices = list(range(0, min(len(X), len(Y), len(dX), len(dY))))
+
     for ii, i in enumerate(slices):
         # print(" plotting ", i)
         write_plotting_slice(i)
         plt.figure(figsize=figsize)
-        plt.quiver(Xs[::by, ::by], Ys[::by, ::by], dX[::by, ::by], dY[::by, ::by], color="k", headlength=10, headwidth=10, scale=15)
+        plt.quiver(X[::by, ::by, i], Y[::by, ::by, i], dX[::by, ::by, i], dY[::by, ::by, i], color="k", headlength=10, headwidth=10, scale=15)
         if BG is not None:
-            plt.imshow(BG[i, :, :], origin="lower", interpolation=interpolation, cmap=cmap, extent=extent, vmin=vmin, vmax=vmax)
+            plt.imshow(BG[:, :, i], origin="lower", interpolation=interpolation, cmap=cmap, extent=extent, vmin=vmin, vmax=vmax)
             if cbar:
                 plt.colorbar()
         plotGeom(atoms, bonds, atomSize=atomSize)
@@ -219,46 +274,46 @@ def plotArrows(
 def checkField(F):
     plt.figure(figsize=(15, 5))
     plt.subplot(1, 3, 1)
-    plt.imshow(F[F.shape[0] / 2, :, :], interpolation="nearest")
-    plt.title("F(y,x)")
+    plt.imshow(F[:, :, F.shape[2] / 2], interpolation="nearest")
+    plt.title("F(x,y)")
     plt.subplot(1, 3, 2)
     plt.imshow(F[:, F.shape[1] / 2, :], interpolation="nearest")
-    plt.title("F(z,x)")
+    plt.title("F(x,z)")
     plt.subplot(1, 3, 3)
-    plt.imshow(F[:, :, F.shape[2] / 2], interpolation="nearest")
-    plt.title("F(z,y)")
+    plt.imshow(F[F.shape[0] / 2, :, :], interpolation="nearest")
+    plt.title("F(y,z)")
     plt.show()
 
 
 def checkVecField(FF):
     plt.figure(figsize=(15, 15))
     plt.subplot(3, 3, 1)
-    plt.imshow(FF[FF.shape[0] / 2, :, :, 0], interpolation="nearest")
-    plt.title("FF_x(y,x)")
+    plt.imshow(FF[:, :, FF.shape[2] / 2, 0], interpolation="nearest")
+    plt.title("FF_x(x,y)")
     plt.subplot(3, 3, 2)
-    plt.imshow(FF[FF.shape[0] / 2, :, :, 1], interpolation="nearest")
-    plt.title("FF_y(y,x)")
+    plt.imshow(FF[:, :, FF.shape[2] / 2, 1], interpolation="nearest")
+    plt.title("FF_y(x,y)")
     plt.subplot(3, 3, 3)
-    plt.imshow(FF[FF.shape[0] / 2, :, :, 2], interpolation="nearest")
-    plt.title("FF_z(y,x)")
+    plt.imshow(FF[:, :, FF.shape[2] / 2, 2], interpolation="nearest")
+    plt.title("FF_z(x,y)")
     plt.subplot(3, 3, 4)
     plt.imshow(FF[:, FF.shape[1] / 2, :, 0], interpolation="nearest")
-    plt.title("FF_x(z,x)")
+    plt.title("FF_x(x,z)")
     plt.subplot(3, 3, 5)
     plt.imshow(FF[:, FF.shape[1] / 2, :, 1], interpolation="nearest")
-    plt.title("FF_y(z,x)")
+    plt.title("FF_y(x,z)")
     plt.subplot(3, 3, 6)
     plt.imshow(FF[:, FF.shape[1] / 2, :, 2], interpolation="nearest")
-    plt.title("FF_z(z,x)")
+    plt.title("FF_z(x,z)")
     plt.subplot(3, 3, 7)
-    plt.imshow(FF[:, :, FF.shape[2] / 2, 0], interpolation="nearest")
-    plt.title("FF_x(z,y)")
+    plt.imshow(FF[FF.shape[0] / 2, :, :, 0], interpolation="nearest")
+    plt.title("FF_x(y,z)")
     plt.subplot(3, 3, 8)
-    plt.imshow(FF[:, :, FF.shape[2] / 2, 1], interpolation="nearest")
-    plt.title("FF_y(z,y)")
+    plt.imshow(FF[FF.shape[0] / 2, :, :, 1], interpolation="nearest")
+    plt.title("FF_y(y,z)")
     plt.subplot(3, 3, 9)
-    plt.imshow(FF[:, :, FF.shape[2] / 2, 2], interpolation="nearest")
-    plt.title("FF_z(z,y)")
+    plt.imshow(FF[FF.shape[0] / 2, :, :, 2], interpolation="nearest")
+    plt.title("FF_z(y,z)")
     plt.savefig("checkfield.png", bbox_inches="tight")
 
 

--- a/ppafm/PPPlot.py
+++ b/ppafm/PPPlot.py
@@ -47,7 +47,7 @@ def plotGeom(atoms=None, bonds=None, atomSize=default_atom_size):
         plotAtoms(atoms, atomSize=atomSize)
 
 
-def colorize_XY2RG(Xs, Ys):
+def colorize_XY2RGB(Xs, Ys):
     r = np.sqrt(Xs**2 + Ys**2)
     vmax = r[5:-5, 5:-5].max()
     Red = 0.5 * Xs / vmax + 0.5
@@ -120,7 +120,7 @@ def plotImages(
         plt.close()
 
 
-def plotVecFieldRG(
+def plotVecFieldRGB(
     prefix,
     dXs,
     dYs,
@@ -148,7 +148,7 @@ def plotVecFieldRG(
         # print(" plotting ", i)
         write_plotting_slice(i)
         plt.figure(figsize=(10, 10))
-        HSBs, vmax = colorize_XY2RG(dXs[i], dYs[i])
+        HSBs, vmax = colorize_XY2RGB(dXs[i], dYs[i])
         plt.imshow(HSBs, extent=extent, origin="lower", interpolation=interpolation)
         plotGeom(atoms, bonds, atomSize=atomSize)
         plt.xlabel(r" Tip_x $\AA$")

--- a/ppafm/cli/generateElFF.py
+++ b/ppafm/cli/generateElFF.py
@@ -140,14 +140,14 @@ def main(argv=None):
         ff_kpfm_tvs0, _ = computeElFF(electrostatic_potential, lvec, n_dim, drho_kpfm, computeVpot=args.energy, tilt=args.tilt, sigma=sigma, deleteV=False, parameters=parameters)
 
         print("Linear E to V")
-        zpos = np.linspace(lvec[0, 2] - args.z0, lvec[0, 2] + lvec[3, 2] - args.z0, n_dim[0])
-        for i in range(n_dim[0]):
+        zpos = np.linspace(lvec[0, 2] - args.z0, lvec[0, 2] + lvec[3, 2] - args.z0, n_dim[2])
+        for i in range(n_dim[2]):
             # z position of the KPFM tip with respect to the sample must not be zero or negative
             # Should that happen, use periodicity in z to get zpos>0
             zpos[i] %= lvec[3, 2]
 
-            ff_kpfm_t0sv[i, :, :] = ff_kpfm_t0sv[i, :, :] / ((v_ref_s) * (zpos[i] + 0.1))
-            ff_kpfm_tvs0[i, :, :] = ff_kpfm_tvs0[i, :, :] / ((v_ref_t) * (zpos[i] + 0.1))
+            ff_kpfm_t0sv[:, :, i] = ff_kpfm_t0sv[:, :, i] / ((v_ref_s) * (zpos[i] + 0.1))
+            ff_kpfm_tvs0[:, :, i] = ff_kpfm_tvs0[:, :, i] / ((v_ref_t) * (zpos[i] + 0.1))
 
         print(">>> Saving electrostatic forcefield ... ")
         io.save_vec_field("FFkpfm_t0sV", ff_kpfm_t0sv, lvec_samp, data_format=args.output_format, head=head_samp)

--- a/ppafm/cli/generateTraining_PVE.py
+++ b/ppafm/cli/generateTraining_PVE.py
@@ -9,7 +9,7 @@ import ppafm.fieldFFT as fFFT
 from ppafm import io
 
 from .. import common, core
-from ..HighLevel import prepareArrays, relaxedScan3D
+from ..HighLevel import relaxedScan3D, setFF
 
 file_format = "xsf"
 
@@ -34,10 +34,8 @@ parameters.gridB = lvec_t[2]
 parameters.gridC = lvec_t[3]  # must be before parseAtoms
 print(parameters.gridN, parameters.gridA, parameters.gridB, parameters.gridC)
 
-force_field, _ = prepareArrays(None, False)
-
+force_field, _ = setFF(None, False, lvec=lvec_t, parameters=parameters)
 print("FFLJ.shape", force_field.shape)
-core.setFF_shape(np.shape(force_field), lvec_t, parameters=parameters)
 
 base_dir = os.getcwd()
 paths = ["out1", "out2"]

--- a/ppafm/cli/plot_results.py
+++ b/ppafm/cli/plot_results.py
@@ -141,7 +141,6 @@ def main(argv=None):
                     dirname + "/xy" + atoms_str + cbar_str,
                     pp_positions[:, :, :, 0],
                     pp_positions[:, :, :, 1],
-                    slices=list(range(0, pp_positions.shape[2])),
                     BG=pp_positions[:, :, :, 2],
                     extent=extent,
                     atoms=atoms,
@@ -164,7 +163,6 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/IETS" + atoms_str + cbar_str,
                     iets,
-                    slices=list(range(0, iets.shape[2])),
                     zs=tip_positions_z,
                     extent=extent,
                     atoms=atoms,
@@ -177,7 +175,6 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/Evib" + atoms_str + cbar_str,
                     e_vib[:, :, :, 0],
-                    slices=list(range(0, iets.shape[2])),
                     zs=tip_positions_z,
                     extent=extent,
                     atoms=atoms,
@@ -190,7 +187,6 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/Kvib" + atoms_str + cbar_str,
                     16.0217662 * eigenvalue_k[:, :, :, 0],
-                    slices=(range(0, iets.shape[2])),
                     zs=tip_positions_z,
                     extent=extent,
                     atoms=atoms,
@@ -206,7 +202,6 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/OutI" + atoms_str + cbar_str,
                     current,
-                    slices=(range(0, current.shape[2])),
                     zs=tip_positions_z,
                     extent=extent,
                     atoms=atoms,
@@ -344,7 +339,6 @@ def main(argv=None):
                         PPPlot.plotImages(
                             dir_name_amplitude + "/df" + atoms_str + cbar_str,
                             dfs,
-                            slices=list(range(0, dfs.shape[2])),
                             zs=tip_positions_z + parameters.Amplitude / 2.0,
                             extent=extent,
                             cmap=parameters.colorscale,
@@ -371,7 +365,6 @@ def main(argv=None):
                         PPPlot.plotImages(
                             dir_name_amplitude + "/df_laplace" + atoms_str + cbar_str,
                             df_laplace_filtered,
-                            slices=list(range(0, len(dfs))),
                             zs=tip_positions_z + parameters.Amplitude / 2.0,
                             extent=extent,
                             cmap=parameters.colorscale,
@@ -405,7 +398,6 @@ def main(argv=None):
                     PPPlot.plotImages(
                         dir_name_lcpd + "/LCPD" + atoms_str + cbar_str,
                         lcpd,
-                        slices=list(range(0, lcpd.shape[2])),
                         zs=tip_positions_z + parameters.Amplitude / 2.0,
                         extent=extent,
                         cmap=parameters.colorscale_kpfm,
@@ -422,7 +414,6 @@ def main(argv=None):
                     PPPlot.plotImages(
                         dir_name_lcpd + "/_Asym-LCPD" + atoms_str + cbar_str,
                         lcpd,
-                        slices=list(range(0, lcpd.shape[2])),
                         zs=tip_positions_z + parameters.Amplitude / 2.0,
                         extent=extent,
                         cmap=parameters.colorscale_kpfm,
@@ -459,7 +450,6 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/Fz" + atoms_str + cbar_str,
                     fzs,
-                    slices=listlist(range(0, fzs.shape[2])),
                     zs=tip_positions_z,  # + parameters.Amplitude / 2.0, # no oscillation to the force
                     extent=extent,
                     cmap=parameters.colorscale,

--- a/ppafm/cli/plot_results.py
+++ b/ppafm/cli/plot_results.py
@@ -141,7 +141,7 @@ def main(argv=None):
                     dirname + "/xy" + atoms_str + cbar_str,
                     pp_positions[:, :, :, 0],
                     pp_positions[:, :, :, 1],
-                    slices=list(range(0, len(pp_positions))),
+                    slices=list(range(0, pp_positions.shape[2])),
                     BG=pp_positions[:, :, :, 2],
                     extent=extent,
                     atoms=atoms,
@@ -164,7 +164,7 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/IETS" + atoms_str + cbar_str,
                     iets,
-                    slices=list(range(0, len(iets))),
+                    slices=list(range(0, iets.shape[2])),
                     zs=tip_positions_z,
                     extent=extent,
                     atoms=atoms,
@@ -177,7 +177,7 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/Evib" + atoms_str + cbar_str,
                     e_vib[:, :, :, 0],
-                    slices=list(range(0, len(iets))),
+                    slices=list(range(0, iets.shape[2])),
                     zs=tip_positions_z,
                     extent=extent,
                     atoms=atoms,
@@ -190,7 +190,7 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/Kvib" + atoms_str + cbar_str,
                     16.0217662 * eigenvalue_k[:, :, :, 0],
-                    slices=list(range(0, len(iets))),
+                    slices=(range(0, iets.shape[2])),
                     zs=tip_positions_z,
                     extent=extent,
                     atoms=atoms,
@@ -206,7 +206,7 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/OutI" + atoms_str + cbar_str,
                     current,
-                    slices=list(range(0, len(current))),
+                    slices=(range(0, current.shape[2])),
                     zs=tip_positions_z,
                     extent=extent,
                     atoms=atoms,
@@ -344,7 +344,7 @@ def main(argv=None):
                         PPPlot.plotImages(
                             dir_name_amplitude + "/df" + atoms_str + cbar_str,
                             dfs,
-                            slices=list(range(0, len(dfs))),
+                            slices=list(range(0, dfs.shape[2])),
                             zs=tip_positions_z + parameters.Amplitude / 2.0,
                             extent=extent,
                             cmap=parameters.colorscale,
@@ -405,7 +405,7 @@ def main(argv=None):
                     PPPlot.plotImages(
                         dir_name_lcpd + "/LCPD" + atoms_str + cbar_str,
                         lcpd,
-                        slices=list(range(0, len(lcpd))),
+                        slices=list(range(0, lcpd.shape[2])),
                         zs=tip_positions_z + parameters.Amplitude / 2.0,
                         extent=extent,
                         cmap=parameters.colorscale_kpfm,
@@ -422,7 +422,7 @@ def main(argv=None):
                     PPPlot.plotImages(
                         dir_name_lcpd + "/_Asym-LCPD" + atoms_str + cbar_str,
                         lcpd,
-                        slices=list(range(0, len(lcpd))),
+                        slices=list(range(0, lcpd.shape[2])),
                         zs=tip_positions_z + parameters.Amplitude / 2.0,
                         extent=extent,
                         cmap=parameters.colorscale_kpfm,
@@ -459,7 +459,7 @@ def main(argv=None):
                 PPPlot.plotImages(
                     dirname + "/Fz" + atoms_str + cbar_str,
                     fzs,
-                    slices=list(range(0, len(fzs))),
+                    slices=listlist(range(0, fzs.shape[2])),
                     zs=tip_positions_z,  # + parameters.Amplitude / 2.0, # no oscillation to the force
                     extent=extent,
                     cmap=parameters.colorscale,

--- a/ppafm/cli/plot_results.py
+++ b/ppafm/cli/plot_results.py
@@ -224,14 +224,14 @@ def main(argv=None):
             else:
                 # Prepare to calculate KPFM/LCPD
                 # For each pixel, find a,b,c such that df = aV^2 + bV + c
-                # This is done as polynomial (2nd order) regression, the above equality need not be exact
+                # This is done as polynomial (2nd order) regression, the above equality needs not be exact
                 # but the least-square criterion will be used.
                 # The coefficients a,b,c are going to be determined as linar combinations of df(V) at different biases:
                 #   a = Sum_i w_KPFM_a (V_i)
                 #   b = Sum_i w_KPFM_b (V_i)
                 #   c = Sum_i w_KPFM_c (V_i)
                 # Now, the coefficients (weights) w_KPFM have to be determined.
-                # This will be done with the help of Gram-sSchmidt ortogonalization:
+                # This will be done with the help of Gram-Schmidt ortogonalization:
                 # Create vectors v0, v1, v2,
                 #   v0 = [1]_(i=1..N),
                 #   v1 = [V_i]_(i=1..N,)
@@ -316,7 +316,7 @@ def main(argv=None):
                         if applied_bias:
                             r_tip = parameters.Rtip
                             for iz, z in enumerate(tip_positions_z):
-                                fzs[iz, :, :] = fzs[iz, :, :] - np.pi * parameters.permit * ((r_tip * r_tip) / ((z - args.z0) * (z + r_tip))) * (voltage - args.V0) * (
+                                fzs[:, :, iz] = fzs[:, :, iz] - np.pi * parameters.permit * ((r_tip * r_tip) / ((z - args.z0) * (z + r_tip))) * (voltage - args.V0) * (
                                     voltage - args.V0
                                 )
                         dfs = common.Fz2df(

--- a/ppafm/cli/relaxed_scan.py
+++ b/ppafm/cli/relaxed_scan.py
@@ -104,7 +104,7 @@ def main(argv=None):
 
         print("Loading Pauli force field from FFpauli_{x,y,z}")
         ff_pauli, lvec, _, atomic_info_or_head = io.load_vec_field("FFpauli", data_format=args.output_format)
-        ff_pauli[:, :, :, 0], ff_pauli[1, :, :, :, 1] = rotate_ff(ff_pauli[:, :, :, 0], ff_pauli[:, :, :, 1], opt_dict["rotate"])
+        ff_pauli[:, :, :, 0], ff_pauli[:, :, :, 1] = rotate_ff(ff_pauli[:, :, :, 0], ff_pauli[:, :, :, 1], opt_dict["rotate"])
 
         print("Loading vdW force field from FFvdW_{x,y,z}")
         ff_vdw, lvec, _, atomic_info_or_head = io.load_vec_field("FFvdW", data_format=args.output_format)

--- a/ppafm/common.py
+++ b/ppafm/common.py
@@ -433,7 +433,7 @@ def Fz2df(F, dz, k0, f0, amplitude=1.0, units=16.0217656):
     Internal force units are eV/A the 16.021... converts stifness eV/A**2 to N/m
     """
     W = get_df_weight(amplitude, dz=dz)
-    dFconv = np.apply_along_axis(lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F)
+    dFconv = np.apply_along_axis(lambda m: np.convolve(m, W, mode="valid"), axis=2, arr=F)
     return dFconv * units * f0 / k0
 
 
@@ -446,9 +446,9 @@ def Fz2df_tilt(F, d, k0, f0, amplitude=1.0, units=16.0217656):
     """
     dr = np.sqrt(d[0] ** 2 + d[1] ** 2 + d[2] ** 2)
     W = get_df_weight(amplitude, dz=dr)
-    dFconv_x = np.apply_along_axis(lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F[:, :, :, 0])
-    dFconv_y = np.apply_along_axis(lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F[:, :, :, 1])
-    dFconv_z = np.apply_along_axis(lambda m: np.convolve(m, W, mode="valid"), axis=0, arr=F[:, :, :, 2])
+    dFconv_x = np.apply_along_axis(lambda m: np.convolve(m, W, mode="valid"), axis=2, arr=F[:, :, :, 0])
+    dFconv_y = np.apply_along_axis(lambda m: np.convolve(m, W, mode="valid"), axis=2, arr=F[:, :, :, 1])
+    dFconv_z = np.apply_along_axis(lambda m: np.convolve(m, W, mode="valid"), axis=2, arr=F[:, :, :, 2])
     return (dFconv_x * d[0] + dFconv_y * d[1] + dFconv_z * d[2]) * units * f0 / k0
 
 
@@ -1000,11 +1000,11 @@ def genFFSampling(lvec, pixPerAngstrome=10):
 def getPos(lvec, nDim=None, pixPerAngstrome=10):
     if nDim is None:
         nDim = genFFSampling(lvec, pixPerAngstrome=pixPerAngstrome)
-    dCell = np.array((lvec[1, :] / nDim[2], lvec[2, :] / nDim[1], lvec[3, :] / nDim[0]))
+    dCell = np.array((lvec[1, :] / nDim[0], lvec[2, :] / nDim[1], lvec[3, :] / nDim[2]))
     ABC = np.mgrid[0 : nDim[0], 0 : nDim[1], 0 : nDim[2]]
-    X = lvec[0, 0] + ABC[2] * dCell[0, 0] + ABC[1] * dCell[1, 0] + ABC[0] * dCell[2, 0]
-    Y = lvec[0, 1] + ABC[2] * dCell[0, 1] + ABC[1] * dCell[1, 1] + ABC[0] * dCell[2, 1]
-    Z = lvec[0, 2] + ABC[2] * dCell[0, 2] + ABC[1] * dCell[1, 2] + ABC[0] * dCell[2, 2]
+    X = lvec[0, 0] + ABC[0] * dCell[0, 0] + ABC[1] * dCell[1, 0] + ABC[2] * dCell[2, 0]
+    Y = lvec[0, 1] + ABC[0] * dCell[0, 1] + ABC[1] * dCell[1, 1] + ABC[2] * dCell[2, 1]
+    Z = lvec[0, 2] + ABC[0] * dCell[0, 2] + ABC[1] * dCell[1, 2] + ABC[2] * dCell[2, 2]
     return X, Y, Z
 
 

--- a/ppafm/core.py
+++ b/ppafm/core.py
@@ -42,32 +42,9 @@ lib.setGridCell.argtypes = [array2d]
 lib.setGridCell.restype = None
 
 
-def setGridCell(cell=None, parameters=None):
-    if cell is None:
-        cell = np.array(
-            [
-                parameters.gridA,
-                parameters.gridB,
-                parameters.gridC,
-            ],
-            dtype=np.float64,
-        ).copy()
-    cell = np.array(cell, dtype=np.float64)
-    if cell.shape == (3, 3):
-        cell = cell.copy()
-    elif cell.shape == (4, 3):
-        cell = cell[1:, :].copy()
-    else:
-        raise ValueError("cell has wrong format")
-        exit()
-    print("cell", cell)
+def setGridCell(cell):
+    cell = np.array(cell[-3:, 0:3], copy=True, dtype=np.float64)
     lib.setGridCell(cell)
-
-
-def setFF_shape(n_, cell, parameters=None):
-    n = np.array(n_).astype(np.int32)
-    lib.setGridN(n)
-    setGridCell(cell, parameters=parameters)
 
 
 # void setFF_pointer( double * gridF, double * gridE  )
@@ -106,29 +83,6 @@ lib.deleteFF_Epointer.restype = None
 
 def deleteFF_Epointer():
     lib.deleteFF_Epointer()
-
-
-def setFF(cell=None, gridF=None, gridE=None, parameters=None):
-    n_ = None
-    if gridF is not None:
-        setFF_Fpointer(gridF)
-        n_ = np.shape(gridF)
-    if gridE is not None:
-        setFF_Epointer(gridE)
-        n_ = np.shape(gridF)
-    if cell is None:
-        cell = np.array(
-            [
-                parameters.gridA,
-                parameters.gridB,
-                parameters.gridC,
-            ]
-        ).copy()
-    if n_ is not None:
-        print("setFF() n_ : ", n_)
-        setFF_shape(n_, cell, parameters=parameters)
-    else:
-        "Warrning : setFF shape not set !!!"
 
 
 # void setRelax( int maxIters, double convF2, double dt, double damping )

--- a/ppafm/cpp/Grid.h
+++ b/ppafm/cpp/Grid.h
@@ -15,7 +15,7 @@
 
 #define fast_floor_offset  1000
 #define fast_floor( x )    ( ( (int)( x + fast_floor_offset ) ) - fast_floor_offset )
-#define i3D( ix, iy, iz )  ( iz*nxy + iy*nx + ix  )
+#define i3D( ix, iy, iz )  ( (ix*ny + iy)*nz + iz  )
 
 // ================= CONSTANTS
 
@@ -73,11 +73,21 @@ inline double interpolate3DWrap( double * grid, const Vec3i& n, const Vec3d& r )
 	int xoff = n.x<<3; int imx = r.x +xoff;	double tx = r.x - imx +xoff;	double mx = 1 - tx;		int itx = (imx+1)%n.x;  imx=imx%n.x;
 	int yoff = n.y<<3; int imy = r.y +yoff;	double ty = r.y - imy +yoff;	double my = 1 - ty;		int ity = (imy+1)%n.y;  imy=imy%n.y;
 	int zoff = n.z<<3; int imz = r.z +zoff;	double tz = r.z - imz +zoff;	double mz = 1 - tz;		int itz = (imz+1)%n.z;  imz=imz%n.z;
-	int nxy = n.x * n.y; int nx = n.x;
-	//double out = grid[ i3D( imx, imy, imz ) ];
+	int nx = n.x; int ny = n.y; int nz = n.z;
 
-	//double out = mz * my * (  ( mx * grid[ i3D( imx, imy, imz ) ] ) +  ( tx * grid[ i3D( itx, imy, imz ) ] );
-	//ty * ( mx * grid[ i3D( imx, ity, imz ) ] ) +  ( tx * grid[ i3D( itx, ity, imz ) ] ) );
+	/*
+	  int imx, imy, imz, itx, ity, itz;
+	  doulble mx, my, mz, tx, ty, tz;
+	  if(r.x >= 0) {imx = r.x; tx = r.x - imx; mx = 1 - tx; imx = imx % nx;}
+	  else {itx = r.x; mx = itx - r.x; tx = 1 - mx; imx = itx % nx + n.x-1;}
+	  itx = (imx+1) % nx;
+	  if(r.y >= 0) {imy = r.y; ty = r.y - imy; my = 1 - ty; imy = imy % ny;}
+	  else {ity = r.y; my = ity - r.y; ty = 1 - my; imy = ity % ny + n.y-1;}
+	  ity = (imy+1) % ny;
+	  if(r.z >= 0) {imz = r.z; tz = r.z - imz; mz = 1 - tz; imz = imz % nz;}
+	  else {itz = r.z; mz = itz - r.z; tz = 1 - mz; imz = itz % nz + n.z-1;}
+	  itz = (imz+1) % nz;
+	 */
 
 	double out = mz * (
 	my * ( ( mx * grid[ i3D( imx, imy, imz ) ] ) +  ( tx * grid[ i3D( itx, imy, imz ) ] ) ) +
@@ -96,7 +106,22 @@ inline Vec3d interpolate3DvecWrap( Vec3d * grid, const Vec3i& n, const Vec3d& r 
 	int xoff = n.x<<3; int imx = r.x +xoff;	double tx = r.x - imx +xoff;	double mx = 1 - tx;		int itx = (imx+1)%n.x;  imx=imx%n.x;
 	int yoff = n.y<<3; int imy = r.y +yoff;	double ty = r.y - imy +yoff;	double my = 1 - ty;		int ity = (imy+1)%n.y;  imy=imy%n.y;
 	int zoff = n.z<<3; int imz = r.z +zoff;	double tz = r.z - imz +zoff;	double mz = 1 - tz;		int itz = (imz+1)%n.z;  imz=imz%n.z;
-	int nxy = n.x * n.y; int nx = n.x;
+
+	int nx = n.x; int ny = n.y; int nz = n.z;
+	/*
+	  int imx, imy, imz, itx, ity, itz;
+	  doulble mx, my, mz, tx, ty, tz;
+	  if(r.x >= 0) {imx = r.x; tx = r.x - imx; mx = 1 - tx; imx = imx % nx;}
+	  else {itx = r.x; mx = itx - r.x; tx = 1 - mx; imx = itx % nx + n.x-1;}
+	  itx = (imx+1) % nx;
+	  if(r.y >= 0) {imy = r.y; ty = r.y - imy; my = 1 - ty; imy = imy % ny;}
+	  else {ity = r.y; my = ity - r.y; ty = 1 - my; imy = ity % ny + n.y-1;}
+	  ity = (imy+1) % ny;
+	  if(r.z >= 0) {imz = r.z; tz = r.z - imz; mz = 1 - tz; imz = imz % nz;}
+	  else {itz = r.z; mz = itz - r.z; tz = 1 - mz; imz = itz % nz + n.z-1;}
+	  itz = (imz+1) % nz;
+	 */
+
 	double mymx = my*mx; double mytx = my*tx; double tymx = ty*mx; double tytx = ty*tx;
 	Vec3d out;
 	out.set_mul( grid[ i3D( imx, imy, imz ) ], mz*mymx );   out.add_mul( grid[ i3D( itx, imy, imz ) ], mz*mytx );
@@ -110,48 +135,45 @@ inline Vec3d interpolate3DvecWrap( Vec3d * grid, const Vec3i& n, const Vec3d& r 
 
 // iterate over field
 template< void FUNC( int ibuff, const Vec3d& pos_, void * args ) >
-void interateGrid3D( const Vec3d& pos0, const Vec3i& n, const Mat3d& dCell, void * args ){
+void iterateGrid3D( const Vec3d& pos0, const Vec3i& n, const Mat3d& dCell, void * args ){
 	int nx  = n.x; 	int ny  = n.y; 	int nz  = n.z;
-	//int nx  = n.z; 	int ny  = n.y; 	int nz  = n.x;
-	int nxy = ny * nx;
-	printf( "interateGrid3D nx,y,z (%i,%i,%i) nxy %i\n", nx,ny,nz, nxy );
+	printf( "iterateGrid3D nx,y,z (%i,%i,%i)\n", nx, ny, nz);
 	Vec3d pos;  pos.set( pos0 );
-	//printf(" interateGrid3D : args %i \n", args );
-	for ( int ic=0; ic<nz; ic++ ){
-        std::cout << "ic " << ic;
-        std::cout.flush();
-        std::cout << '\r';
-		for ( int ib=0; ib<ny; ib++ ){
-	        for ( int ia=0; ia<nx; ia++ ){
-			    int ibuff = i3D( ia, ib, ic );
-                //FUNC( ibuff, {ia,ib,ic}, pos );
-                //pos = pos0 + dCell.c*ic + dCell.b*ib + dCell.a*ia;
-                FUNC( ibuff, pos, args );
-                //printf("(%i,%i,%i)(%3.3f,%3.3f,%3.3f)\n",ia,ib,ic,pos.x,pos.y,pos.z);
-				pos.add( dCell.a );
-			}
-			pos.add_mul( dCell.a, -nx );
-			pos.add( dCell.b );
-		}
-		//exit(0);
-		pos.add_mul( dCell.b, -ny );
-		pos.add( dCell.c );
+	//printf(" iterateGrid3D : args %i \n", args );
+	int ibuff = 0;
+	for ( int ia=0; ia<nx; ia++ ){
+	  std::cout << "ia " << ia;
+	  std::cout.flush();
+	  std::cout << '\r';
+	  for ( int ib=0; ib<ny; ib++ ){
+	    for ( int ic=0; ic<nz; ic++ ){
+	      //ibuff = i3D( ia, ib, ic );
+	      //pos = pos0 + dCell.c*ic + dCell.b*ib + dCell.a*ia;
+	      FUNC( ++ibuff, pos, args );
+	      //printf("(%i,%i,%i)(%3.3f,%3.3f,%3.3f)\n",ia,ib,ic,pos.x,pos.y,pos.z);
+	      pos.add( dCell.c );
+	    }
+	    pos.add_mul( dCell.c, -nz );
+	    pos.add( dCell.b );
+	  }
+	  //exit(0);
+	  pos.add_mul( dCell.b, -ny );
+	  pos.add( dCell.a );
 	}
     printf ("\n");
 }
 
 template< void FUNC( int ibuff, const Vec3d& pos_, void * args ) >
-void interateGrid3D_omp( const Vec3d& pos0, const Vec3i& n, const Mat3d& dCell, void * args ){
+void iterateGrid3D_omp( const Vec3d& pos0, const Vec3i& n, const Mat3d& dCell, void * args ){
     int ntot = n.x*n.y*n.z;
-    int ncpu = omp_get_num_threads(); printf( "interateGrid3D_omp nx,y,z (%i,%i,%i) nxy %i ncpu %i \n",  n.x,n.y,n.z, ntot, ncpu );
+    int ncpu = omp_get_num_threads(); printf( "iterateGrid3D_omp nx,y,z (%i,%i,%i) ntot %i ncpu %i \n",  n.x,n.y,n.z, ntot, ncpu );
     int ndone=0;
     #pragma omp parallel for collapse(3) shared(pos0,n,dCell,args,ndone)
-    for ( int ic=0; ic<n.z; ic++ ){
+    for ( int ia=0; ia<n.x; ia++ ){
         for ( int ib=0; ib<n.y; ib++ ){
-            for ( int ia=0; ia<n.x; ia++ ){
-                Vec3d pos = pos0 + dCell.c*ic + dCell.b*ib + dCell.a*ia;
-                //int ibuff = i3D( ia, ib, ic );
-                int ibuff = ic*(n.x*n.y) + ib*n.x + ia;
+            for ( int ic=0; ic<n.z; ic++ ){
+                Vec3d pos = pos0 + dCell.a*ia + dCell.b*ib + dCell.c*ic;
+                int ibuff = (ia*n.y + ib)*n.z + ic;
                 //ndone[ omp_get_thread_num() ]++;
                 if( omp_get_thread_num()==0 ){
                     ndone++;

--- a/ppafm/cpp/Grid.h
+++ b/ppafm/cpp/Grid.h
@@ -68,69 +68,65 @@ class GridShape {
 
 // interpolation of vector force-field Vec3d[ix,iy,iz] in periodic boundary condition
 inline double interpolate3DWrap( double * grid, const Vec3i& n, const Vec3d& r ){
-    //#pragma omp simd
-    //{
-	int xoff = n.x<<3; int imx = r.x +xoff;	double tx = r.x - imx +xoff;	double mx = 1 - tx;		int itx = (imx+1)%n.x;  imx=imx%n.x;
-	int yoff = n.y<<3; int imy = r.y +yoff;	double ty = r.y - imy +yoff;	double my = 1 - ty;		int ity = (imy+1)%n.y;  imy=imy%n.y;
-	int zoff = n.z<<3; int imz = r.z +zoff;	double tz = r.z - imz +zoff;	double mz = 1 - tz;		int itz = (imz+1)%n.z;  imz=imz%n.z;
-	int nx = n.x; int ny = n.y; int nz = n.z;
+  //#pragma omp simd
+  //{
+  //int xoff = n.x<<3; int imx = r.x +xoff;	double tx = r.x - imx +xoff;	double mx = 1 - tx;		int itx = (imx+1)%n.x;  imx=imx%n.x;
+  //int yoff = n.y<<3; int imy = r.y +yoff;	double ty = r.y - imy +yoff;	double my = 1 - ty;		int ity = (imy+1)%n.y;  imy=imy%n.y;
+  //int zoff = n.z<<3; int imz = r.z +zoff;	double tz = r.z - imz +zoff;	double mz = 1 - tz;		int itz = (imz+1)%n.z;  imz=imz%n.z;
+  int nx = n.x; int ny = n.y; int nz = n.z;
 
-	/*
-	  int imx, imy, imz, itx, ity, itz;
-	  doulble mx, my, mz, tx, ty, tz;
-	  if(r.x >= 0) {imx = r.x; tx = r.x - imx; mx = 1 - tx; imx = imx % nx;}
-	  else {itx = r.x; mx = itx - r.x; tx = 1 - mx; imx = itx % nx + n.x-1;}
-	  itx = (imx+1) % nx;
-	  if(r.y >= 0) {imy = r.y; ty = r.y - imy; my = 1 - ty; imy = imy % ny;}
-	  else {ity = r.y; my = ity - r.y; ty = 1 - my; imy = ity % ny + n.y-1;}
-	  ity = (imy+1) % ny;
-	  if(r.z >= 0) {imz = r.z; tz = r.z - imz; mz = 1 - tz; imz = imz % nz;}
-	  else {itz = r.z; mz = itz - r.z; tz = 1 - mz; imz = itz % nz + n.z-1;}
-	  itz = (imz+1) % nz;
-	 */
+  int imx, imy, imz, itx, ity, itz;
+  double mx, my, mz, tx, ty, tz;
+  if(r.x >= 0) {imx = r.x; tx = r.x - imx; mx = 1 - tx; imx = imx % nx;}
+  else {itx = r.x; mx = itx - r.x; tx = 1 - mx; imx = itx % nx + n.x-1;}
+  itx = (imx+1) % nx;
+  if(r.y >= 0) {imy = r.y; ty = r.y - imy; my = 1 - ty; imy = imy % ny;}
+  else {ity = r.y; my = ity - r.y; ty = 1 - my; imy = ity % ny + n.y-1;}
+  ity = (imy+1) % ny;
+  if(r.z >= 0) {imz = r.z; tz = r.z - imz; mz = 1 - tz; imz = imz % nz;}
+  else {itz = r.z; mz = itz - r.z; tz = 1 - mz; imz = itz % nz + n.z-1;}
+  itz = (imz+1) % nz;
 
-	double out = mz * (
-	my * ( ( mx * grid[ i3D( imx, imy, imz ) ] ) +  ( tx * grid[ i3D( itx, imy, imz ) ] ) ) +
-	ty * ( ( mx * grid[ i3D( imx, ity, imz ) ] ) +  ( tx * grid[ i3D( itx, ity, imz ) ] ) ) )
-               + tz * (
-	my * ( ( mx * grid[ i3D( imx, imy, itz ) ] ) +  ( tx * grid[ i3D( itx, imy, itz ) ] ) ) +
-	ty * ( ( mx * grid[ i3D( imx, ity, itz ) ] ) +  ( tx * grid[ i3D( itx, ity, itz ) ] ) ) );
-    //}
-	return out;
+  double out = mz * (
+		     my * ( ( mx * grid[ i3D( imx, imy, imz ) ] ) +  ( tx * grid[ i3D( itx, imy, imz ) ] ) ) +
+		     ty * ( ( mx * grid[ i3D( imx, ity, imz ) ] ) +  ( tx * grid[ i3D( itx, ity, imz ) ] ) ) )
+    + tz * (
+	    my * ( ( mx * grid[ i3D( imx, imy, itz ) ] ) +  ( tx * grid[ i3D( itx, imy, itz ) ] ) ) +
+	    ty * ( ( mx * grid[ i3D( imx, ity, itz ) ] ) +  ( tx * grid[ i3D( itx, ity, itz ) ] ) ) );
+  //}
+  return out;
 }
 
 // interpolation of vector force-field Vec3d[ix,iy,iz] in periodic boundary condition
 inline Vec3d interpolate3DvecWrap( Vec3d * grid, const Vec3i& n, const Vec3d& r ){
-    //#pragma omp simd
-    //{
-	int xoff = n.x<<3; int imx = r.x +xoff;	double tx = r.x - imx +xoff;	double mx = 1 - tx;		int itx = (imx+1)%n.x;  imx=imx%n.x;
-	int yoff = n.y<<3; int imy = r.y +yoff;	double ty = r.y - imy +yoff;	double my = 1 - ty;		int ity = (imy+1)%n.y;  imy=imy%n.y;
-	int zoff = n.z<<3; int imz = r.z +zoff;	double tz = r.z - imz +zoff;	double mz = 1 - tz;		int itz = (imz+1)%n.z;  imz=imz%n.z;
+  //#pragma omp simd
+  //{
+  //int xoff = n.x<<3; int imx = r.x +xoff;	double tx = r.x - imx +xoff;	double mx = 1 - tx;		int itx = (imx+1)%n.x;  imx=imx%n.x;
+  //int yoff = n.y<<3; int imy = r.y +yoff;	double ty = r.y - imy +yoff;	double my = 1 - ty;		int ity = (imy+1)%n.y;  imy=imy%n.y;
+  //int zoff = n.z<<3; int imz = r.z +zoff;	double tz = r.z - imz +zoff;	double mz = 1 - tz;		int itz = (imz+1)%n.z;  imz=imz%n.z;
 
-	int nx = n.x; int ny = n.y; int nz = n.z;
-	/*
-	  int imx, imy, imz, itx, ity, itz;
-	  doulble mx, my, mz, tx, ty, tz;
-	  if(r.x >= 0) {imx = r.x; tx = r.x - imx; mx = 1 - tx; imx = imx % nx;}
-	  else {itx = r.x; mx = itx - r.x; tx = 1 - mx; imx = itx % nx + n.x-1;}
-	  itx = (imx+1) % nx;
-	  if(r.y >= 0) {imy = r.y; ty = r.y - imy; my = 1 - ty; imy = imy % ny;}
-	  else {ity = r.y; my = ity - r.y; ty = 1 - my; imy = ity % ny + n.y-1;}
-	  ity = (imy+1) % ny;
-	  if(r.z >= 0) {imz = r.z; tz = r.z - imz; mz = 1 - tz; imz = imz % nz;}
-	  else {itz = r.z; mz = itz - r.z; tz = 1 - mz; imz = itz % nz + n.z-1;}
-	  itz = (imz+1) % nz;
-	 */
+  int nx = n.x; int ny = n.y; int nz = n.z;
+  int imx, imy, imz, itx, ity, itz;
+  double mx, my, mz, tx, ty, tz;
+  if(r.x >= 0) {imx = r.x; tx = r.x - imx; mx = 1 - tx; imx = imx % nx;}
+  else {itx = r.x; mx = itx - r.x; tx = 1 - mx; imx = itx % nx + n.x-1;}
+  itx = (imx+1) % nx;
+  if(r.y >= 0) {imy = r.y; ty = r.y - imy; my = 1 - ty; imy = imy % ny;}
+  else {ity = r.y; my = ity - r.y; ty = 1 - my; imy = ity % ny + n.y-1;}
+  ity = (imy+1) % ny;
+  if(r.z >= 0) {imz = r.z; tz = r.z - imz; mz = 1 - tz; imz = imz % nz;}
+  else {itz = r.z; mz = itz - r.z; tz = 1 - mz; imz = itz % nz + n.z-1;}
+  itz = (imz+1) % nz;
 
-	double mymx = my*mx; double mytx = my*tx; double tymx = ty*mx; double tytx = ty*tx;
-	Vec3d out;
-	out.set_mul( grid[ i3D( imx, imy, imz ) ], mz*mymx );   out.add_mul( grid[ i3D( itx, imy, imz ) ], mz*mytx );
-	out.add_mul( grid[ i3D( imx, ity, imz ) ], mz*tymx );   out.add_mul( grid[ i3D( itx, ity, imz ) ], mz*tytx );
-	out.add_mul( grid[ i3D( imx, ity, itz ) ], tz*tymx );   out.add_mul( grid[ i3D( itx, ity, itz ) ], tz*tytx );
-	out.add_mul( grid[ i3D( imx, imy, itz ) ], tz*mymx );   out.add_mul( grid[ i3D( itx, imy, itz ) ], tz*mytx );
-	//printf( "DEBUG interpolate3DvecWrap gp(%g,%g,%g) igp(%i,%i,%i)/(%i,%i,%i) %i->%g out(%g,%g,%g) \n", r.x, r.y, r.z, imx, imy, imz, n.x,n.y,n.z, i3D( imx, imy, imz ), grid[ i3D( imx, imy, imz ) ], out.x,out.y,out.z );
-    //}
-	return out;
+  double mymx = my*mx; double mytx = my*tx; double tymx = ty*mx; double tytx = ty*tx;
+  Vec3d out;
+  out.set_mul( grid[ i3D( imx, imy, imz ) ], mz*mymx );   out.add_mul( grid[ i3D( itx, imy, imz ) ], mz*mytx );
+  out.add_mul( grid[ i3D( imx, ity, imz ) ], mz*tymx );   out.add_mul( grid[ i3D( itx, ity, imz ) ], mz*tytx );
+  out.add_mul( grid[ i3D( imx, ity, itz ) ], tz*tymx );   out.add_mul( grid[ i3D( itx, ity, itz ) ], tz*tytx );
+  out.add_mul( grid[ i3D( imx, imy, itz ) ], tz*mymx );   out.add_mul( grid[ i3D( itx, imy, itz ) ], tz*mytx );
+  //printf( "DEBUG interpolate3DvecWrap gp(%g,%g,%g) igp(%i,%i,%i)/(%i,%i,%i) %i->%g out(%g,%g,%g) \n", r.x, r.y, r.z, imx, imy, imz, n.x,n.y,n.z, i3D( imx, imy, imz ), grid[ i3D( imx, imy, imz ) ], out.x,out.y,out.z );
+  //}
+  return out;
 }
 
 // iterate over field

--- a/ppafm/cpp/GridUtils.cpp
+++ b/ppafm/cpp/GridUtils.cpp
@@ -36,8 +36,6 @@ extern "C" {
 
         FILE *f;
         char line[5000]; // define a length which is long enough to store a line
-        char *waste;
-        int waste2;
         long i=0, j=0, k=0, tot=0;
         int nx=dims[0];
         int ny=dims[1];
@@ -49,14 +47,12 @@ extern "C" {
             fprintf(stderr, "Can't open the file %s", fname);
             exit (1);
         }
-        for (i=0; i<noline; i++) {
-            waste=fgets(line,5000, f);
-        }
+        for (i=0; i<noline; i++) fgets(line,5000, f);
 //       printf ("Line: %s", line);
         for  (tot=0, k=0; k<dims[2]; k++){
             for (j=0; j<dims[1]; j++){
                 for (i=0; i<dims[0]; i++){
-                    waste2=fscanf(f,"%lf",&numbers[tot]);
+                    fscanf(f,"%lf",&numbers[tot]);
                     //printf ("%20.20lf ", numbers[tot]);
                     //printf ("%i %i %i %f \n", k, j, i, numbers[tot] );
                     tot++;
@@ -151,7 +147,7 @@ extern "C" {
 	DLLEXPORT void sphericalHist( double * data_, double* center, double dr, int n, double* Hs, double* Ws ){
 	    data = data_; Histogram::n = n; Histogram::Hs=Hs; Histogram::Ws=Ws; Histogram::dx = dr; Histogram::center.set(center[0],center[1],center[2]);
         Vec3d r0; r0.set(0.0,0.0,0.0);
-        interateGrid3D<acum_sphere_hist>( r0, gridShape.n, gridShape.dCell, NULL );
+        iterateGrid3D<acum_sphere_hist>( r0, gridShape.n, gridShape.dCell, NULL );
 	}
 
 	// ---------  find center of mass
@@ -165,7 +161,7 @@ extern "C" {
 	DLLEXPORT double cog( double * data_, double* center ){
 	    data = data_; Histogram::Htot += 0;  Histogram::center.set(0.0);
         Vec3d r0; r0.set(0.0,0.0,0.0);
-        interateGrid3D<acum_cog>( r0, gridShape.n, gridShape.dCell, NULL );
+        iterateGrid3D<acum_cog>( r0, gridShape.n, gridShape.dCell, NULL );
         Histogram::center.mul( 1/Histogram::Htot  );
         ((Vec3d*)center)->set(Histogram::center);
         return Histogram::Htot;
@@ -181,7 +177,7 @@ extern "C" {
 
 	DLLEXPORT void setGridN( int * n ){
 		//gridShape.n.set( *(Vec3i*)n );
-		gridShape.n.set( n[2], n[1], n[0] );
+		gridShape.n.set( n[0], n[1], n[2] );
 		printf( " nxyz  %i %i %i \n", gridShape.n.x, gridShape.n.y, gridShape.n.z );
 	}
 

--- a/ppafm/cpp/ProbeParticle.cpp
+++ b/ppafm/cpp/ProbeParticle.cpp
@@ -357,7 +357,7 @@ DLLEXPORT void deleteFF_Epointer(){
 // set forcefield grid dimension "n"
 DLLEXPORT void setGridN( int * n ){
     //gridShape.n.set( *(Vec3i*)n );
-    gridShape.n.set( n[2], n[1], n[0] );
+    gridShape.n.set( n[0], n[1], n[2] );
     printf( " nxyz  %i %i %i \n", gridShape.n.x, gridShape.n.y, gridShape.n.z );
 }
 
@@ -508,31 +508,31 @@ DLLEXPORT void computeD3Coeffs(
 DLLEXPORT void getLennardJonesFF( int natoms_, double * Ratoms_, double * cLJs ){
     natoms=natoms_; Ratoms=(Vec3d*)Ratoms_; nCoefPerAtom = 2;
     Vec3d r0; r0.set(0.0,0.0,0.0);
-    //interateGrid3D < evalCell < addAtom_LJ  > >( r0, gridShape.n, gridShape.dCell, cLJs );
-    interateGrid3D_omp < evalCell < addAtom_LJ  > >( r0, gridShape.n, gridShape.dCell, cLJs );
+    //iterateGrid3D < evalCell < addAtom_LJ  > >( r0, gridShape.n, gridShape.dCell, cLJs );
+    iterateGrid3D_omp < evalCell < addAtom_LJ  > >( r0, gridShape.n, gridShape.dCell, cLJs );
 }
 
 DLLEXPORT void getVdWFF( int natoms_, double * Ratoms_, double * cLJs ){
     natoms=natoms_; Ratoms=(Vec3d*)Ratoms_; nCoefPerAtom = 2;
     Vec3d r0; r0.set(0.0,0.0,0.0);
-    //interateGrid3D < evalCell < addAtom_VdW  > >( r0, gridShape.n, gridShape.dCell, cLJs );
-    interateGrid3D_omp < evalCell < addAtom_VdW  > >( r0, gridShape.n, gridShape.dCell, cLJs );
+    //iterateGrid3D < evalCell < addAtom_VdW  > >( r0, gridShape.n, gridShape.dCell, cLJs );
+    iterateGrid3D_omp < evalCell < addAtom_VdW  > >( r0, gridShape.n, gridShape.dCell, cLJs );
 
 }
 
 DLLEXPORT void getDFTD3FF(int natoms_, double * Ratoms_, double *d3_coeffs){
     natoms = natoms_; Ratoms = (Vec3d*)Ratoms_; nCoefPerAtom = 4;
     Vec3d r0; r0.set(0.0,0.0,0.0);
-    //interateGrid3D < evalCell < addAtom_DFTD3  > >( r0, gridShape.n, gridShape.dCell, d3_coeffs );
-    interateGrid3D_omp < evalCell < addAtom_DFTD3  > >( r0, gridShape.n, gridShape.dCell, d3_coeffs );
+    //iterateGrid3D < evalCell < addAtom_DFTD3  > >( r0, gridShape.n, gridShape.dCell, d3_coeffs );
+    iterateGrid3D_omp < evalCell < addAtom_DFTD3  > >( r0, gridShape.n, gridShape.dCell, d3_coeffs );
 
 }
 
 DLLEXPORT void getMorseFF( int natoms_, double * Ratoms_, double * REs, double alpha ){
     natoms=natoms_; Ratoms=(Vec3d*)Ratoms_; nCoefPerAtom = 2; Morse_alpha = alpha;
     Vec3d r0; r0.set(0.0,0.0,0.0);
-    //interateGrid3D < evalCell < addAtom_Morse > >( r0, gridShape.n, gridShape.dCell, REs );
-    interateGrid3D_omp < evalCell < addAtom_Morse > >( r0, gridShape.n, gridShape.dCell, REs );
+    //iterateGrid3D < evalCell < addAtom_Morse > >( r0, gridShape.n, gridShape.dCell, REs );
+    iterateGrid3D_omp < evalCell < addAtom_Morse > >( r0, gridShape.n, gridShape.dCell, REs );
 }
 
 // sample Coulomb Force-field on 3D mesh over provided set of atoms with positions Rs_[i] with constant kQQs  =  - k_coulomb * Q_ProbeParticle * Q[i]
@@ -542,14 +542,14 @@ DLLEXPORT void getCoulombFF( int natoms_, double * Ratoms_, double * kQQs, int k
     Vec3d r0; r0.set(0.0,0.0,0.0);
     //printf(" kind %i \n", kind );
     switch(kind){
-        //case 0: interateGrid3D < evalCell < foo  > >( r0, gridShape.n, gridShape.dCell, kQQs_ );
-        //case 0: interateGrid3D < evalCell < addAtom_Coulomb_s   > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
-        //case 1: interateGrid3D < evalCell < addAtom_Coulomb_pz  > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
-        //case 2: interateGrid3D < evalCell < addAtom_Coulomb_dz2 > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
+        //case 0: iterateGrid3D < evalCell < foo  > >( r0, gridShape.n, gridShape.dCell, kQQs_ );
+        //case 0: iterateGrid3D < evalCell < addAtom_Coulomb_s   > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
+        //case 1: iterateGrid3D < evalCell < addAtom_Coulomb_pz  > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
+        //case 2: iterateGrid3D < evalCell < addAtom_Coulomb_dz2 > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
 
-        case 0: interateGrid3D_omp < evalCell < addAtom_Coulomb_s   > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
-        case 1: interateGrid3D_omp < evalCell < addAtom_Coulomb_pz  > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
-        case 2: interateGrid3D_omp < evalCell < addAtom_Coulomb_dz2 > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
+        case 0: iterateGrid3D_omp < evalCell < addAtom_Coulomb_s   > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
+        case 1: iterateGrid3D_omp < evalCell < addAtom_Coulomb_pz  > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
+        case 2: iterateGrid3D_omp < evalCell < addAtom_Coulomb_dz2 > >( r0, gridShape.n, gridShape.dCell, kQQs ); break;
     }
 }
 
@@ -581,20 +581,20 @@ DLLEXPORT void getVdWFF_RE( int natoms_, double * Ratoms_, double * REs, int kin
     //if(ADamp>0){ ADamp = ADamp_; }
     switch(kind){
         //case 0: if(ADamp_>0){ ADamp_Const = ADamp_; }; E=addAtom_VdW      ( dR, fout, coefs ); break;
-        //case 1: if(ADamp_>0){ ADamp_R2    = ADamp_; } interateGrid3D<evalCell<addAtom_VdW_R2   >>( r0, gridShape.n, gridShape.dCell, REs ); break;
-        //case 2: if(ADamp_>0){ ADamp_R4    = ADamp_; } interateGrid3D<evalCell<addAtom_VdW_R4   >>( r0, gridShape.n, gridShape.dCell, REs ); break;
-        //case 3: if(ADamp_>0){ ADamp_invR4 = ADamp_; } interateGrid3D<evalCell<addAtom_VdW_invR4>>( r0, gridShape.n, gridShape.dCell, REs ); break;
-        //case 4: if(ADamp_>0){ ADamp_invR8 = ADamp_; } interateGrid3D<evalCell<addAtom_VdW_invR8>>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        //case 1: if(ADamp_>0){ ADamp_R2    = ADamp_; } iterateGrid3D<evalCell<addAtom_VdW_R2   >>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        //case 2: if(ADamp_>0){ ADamp_R4    = ADamp_; } iterateGrid3D<evalCell<addAtom_VdW_R4   >>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        //case 3: if(ADamp_>0){ ADamp_invR4 = ADamp_; } iterateGrid3D<evalCell<addAtom_VdW_invR4>>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        //case 4: if(ADamp_>0){ ADamp_invR8 = ADamp_; } iterateGrid3D<evalCell<addAtom_VdW_invR8>>( r0, gridShape.n, gridShape.dCell, REs ); break;
 
-        case 1: if(ADamp_>0){ ADamp_R2    = ADamp_; } interateGrid3D_omp<evalCell<addAtom_VdW_R2   >>( r0, gridShape.n, gridShape.dCell, REs ); break;
-        case 2: if(ADamp_>0){ ADamp_R4    = ADamp_; } interateGrid3D_omp<evalCell<addAtom_VdW_R4   >>( r0, gridShape.n, gridShape.dCell, REs ); break;
-        case 3: if(ADamp_>0){ ADamp_invR4 = ADamp_; } interateGrid3D_omp<evalCell<addAtom_VdW_invR4>>( r0, gridShape.n, gridShape.dCell, REs ); break;
-        case 4: if(ADamp_>0){ ADamp_invR8 = ADamp_; } interateGrid3D_omp<evalCell<addAtom_VdW_invR8>>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        case 1: if(ADamp_>0){ ADamp_R2    = ADamp_; } iterateGrid3D_omp<evalCell<addAtom_VdW_R2   >>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        case 2: if(ADamp_>0){ ADamp_R4    = ADamp_; } iterateGrid3D_omp<evalCell<addAtom_VdW_R4   >>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        case 3: if(ADamp_>0){ ADamp_invR4 = ADamp_; } iterateGrid3D_omp<evalCell<addAtom_VdW_invR4>>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        case 4: if(ADamp_>0){ ADamp_invR8 = ADamp_; } iterateGrid3D_omp<evalCell<addAtom_VdW_invR8>>( r0, gridShape.n, gridShape.dCell, REs ); break;
 
-        // case 0: interateGrid3D<evalCell<addAtomVdW_addDamp<R2_func>  >>>( r0, gridShape.n, gridShape.dCell, REs ); break;
-        // case 1: interateGrid3D<evalCell<addAtomVdW_addDamp<R4_func>  >>>( r0, gridShape.n, gridShape.dCell, REs ); break;
-        // case 2: interateGrid3D<evalCell<addAtomVdW_addDamp<invr4_func>>>( r0, gridShape.n, gridShape.dCell, REs ); break;
-        // case 2: interateGrid3D<evalCell<addAtomVdW_addDamp<invr8_func>>>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        // case 0: iterateGrid3D<evalCell<addAtomVdW_addDamp<R2_func>  >>>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        // case 1: iterateGrid3D<evalCell<addAtomVdW_addDamp<R4_func>  >>>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        // case 2: iterateGrid3D<evalCell<addAtomVdW_addDamp<invr4_func>>>( r0, gridShape.n, gridShape.dCell, REs ); break;
+        // case 2: iterateGrid3D<evalCell<addAtomVdW_addDamp<invr8_func>>>( r0, gridShape.n, gridShape.dCell, REs ); break;
     }
 }
 
@@ -602,8 +602,8 @@ DLLEXPORT void getGaussDensity( int natoms_, double * Ratoms_, double * cRAs ){
     natoms=natoms_; Ratoms=(Vec3d*)Ratoms_; nCoefPerAtom = 2;
     Vec3d r0; r0.set(0.0,0.0,0.0);
     Vec3d* gridF_=gridF; gridF=0;
-    //interateGrid3D < evalCell < addAtom_Gauss  > >( r0, gridShape.n, gridShape.dCell, cRAs );
-    interateGrid3D_omp < evalCell < addAtom_Gauss  > >( r0, gridShape.n, gridShape.dCell, cRAs );
+    //iterateGrid3D < evalCell < addAtom_Gauss  > >( r0, gridShape.n, gridShape.dCell, cRAs );
+    iterateGrid3D_omp < evalCell < addAtom_Gauss  > >( r0, gridShape.n, gridShape.dCell, cRAs );
     gridF=gridF_;
 }
 
@@ -611,8 +611,8 @@ DLLEXPORT void getSlaterDensity( int natoms_, double * Ratoms_, double * cRAs ){
     natoms=natoms_; Ratoms=(Vec3d*)Ratoms_; nCoefPerAtom = 2;
     Vec3d r0; r0.set(0.0,0.0,0.0);
     Vec3d* gridF_=gridF; gridF=0;
-    //interateGrid3D < evalCell < addAtom_Slater > >( r0, gridShape.n, gridShape.dCell, cRAs );
-    interateGrid3D_omp < evalCell < addAtom_Slater > >( r0, gridShape.n, gridShape.dCell, cRAs );
+    //iterateGrid3D < evalCell < addAtom_Slater > >( r0, gridShape.n, gridShape.dCell, cRAs );
+    iterateGrid3D_omp < evalCell < addAtom_Slater > >( r0, gridShape.n, gridShape.dCell, cRAs );
     gridF=gridF_;
 }
 
@@ -620,8 +620,8 @@ DLLEXPORT void getDensityR4spline( int natoms_, double * Ratoms_, double * cRAs 
     natoms=natoms_; Ratoms=(Vec3d*)Ratoms_; nCoefPerAtom = 2;
     Vec3d r0; r0.set(0.0,0.0,0.0);
     Vec3d* gridF_=gridF; gridF=0;
-    //interateGrid3D < evalCell < addAtom_splineR4 > >( r0, gridShape.n, gridShape.dCell, cRAs );
-    interateGrid3D_omp < evalCell < addAtom_splineR4 > >( r0, gridShape.n, gridShape.dCell, cRAs );
+    //iterateGrid3D < evalCell < addAtom_splineR4 > >( r0, gridShape.n, gridShape.dCell, cRAs );
+    iterateGrid3D_omp < evalCell < addAtom_splineR4 > >( r0, gridShape.n, gridShape.dCell, cRAs );
     gridF=gridF_;
 }
 
@@ -684,7 +684,7 @@ DLLEXPORT int relaxTipStrokes_omp( int nx, int ny, int probeStart, int relaxAlg,
     #pragma omp parallel for collapse(2) shared( nx, ny, probeStart, relaxAlg, nstep, rTips_, rs_, fs_, ndone )
     for (int ix=0; ix<nx; ix++){
         for (int iy=0; iy<ny; iy++){
-            int ioff = (ix + iy*nx)*nstep;
+            int ioff = (ix*ny + iy)*nstep;
             relaxTipStroke( probeStart, relaxAlg, nstep, rTips_+ioff*3, rs_+ioff*3, fs_+ioff*3, splineParams );
             if( omp_get_thread_num()==0 ){
                 ndone++;

--- a/ppafm/cpp/integerOps.h
+++ b/ppafm/cpp/integerOps.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-// ========= index poerations and modulo-math ===========
+// ========= index operations and modulo-math ===========
 
 inline int wrap_index_fast( int i, int n){
     if(i<0){ return n+i; }else if (i>=n){ return i-n; };

--- a/ppafm/fieldFFT.py
+++ b/ppafm/fieldFFT.py
@@ -42,9 +42,9 @@ def getMGrid(dims, dd):
     if( nDim[1]%2 != 0 ):  yshift_ += 1.0
     if( nDim[2]%2 != 0 ):  zshift_ += 1.0
 
-    X = dx*np.roll( XYZ[0] - xshift_, xshift, axis=2)
+    X = dx*np.roll( XYZ[0] - xshift_, xshift, axis=0)
     Y = dy*np.roll( XYZ[1] - yshift_, yshift, axis=1)
-    Z = dz*np.roll( XYZ[2] - zshift_, zshift, axis=0)
+    Z = dz*np.roll( XYZ[2] - zshift_, zshift, axis=2)
     # fmt: on
     return X, Y, Z
 

--- a/ppafm/fieldFFT.py
+++ b/ppafm/fieldFFT.py
@@ -31,20 +31,20 @@ def getSize(inp_axis, dims, sampleSize):
 def getMGrid(dims, dd):
     "returns coordinate arrays X, Y, Z"
     (dx, dy, dz) = dd
-    nDim = [dims[2], dims[1], dims[0]]
+    nDim = [dims[0], dims[1], dims[2]]
     XYZ = np.mgrid[0 : nDim[0], 0 : nDim[1], 0 : nDim[2]].astype(float)
     # fmt: off
-    xshift = nDim[2]//2;  xshift_ = xshift;
+    xshift = nDim[0]//2;  xshift_ = xshift;
     yshift = nDim[1]//2;  yshift_ = yshift;
-    zshift = nDim[0]//2;  zshift_ = zshift;
+    zshift = nDim[2]//2;  zshift_ = zshift;
 
-    if( nDim[2]%2 != 0 ):  xshift_ += 1.0
+    if( nDim[0]%2 != 0 ):  xshift_ += 1.0
     if( nDim[1]%2 != 0 ):  yshift_ += 1.0
-    if( nDim[0]%2 != 0 ):  zshift_ += 1.0
+    if( nDim[2]%2 != 0 ):  zshift_ += 1.0
 
-    X = dx*np.roll( XYZ[2] - xshift_, xshift, axis=2)
+    X = dx*np.roll( XYZ[0] - xshift_, xshift, axis=2)
     Y = dy*np.roll( XYZ[1] - yshift_, yshift, axis=1)
-    Z = dz*np.roll( XYZ[0] - zshift_, zshift, axis=0)
+    Z = dz*np.roll( XYZ[2] - zshift_, zshift, axis=0)
     # fmt: on
     return X, Y, Z
 
@@ -142,7 +142,7 @@ def addCoreDensity(rho, val, x, y, z, sigma=0.1):
 def addCoreDensities(atoms, valElDict, rho, lvec, sigma=0.1):
     sampleSize = getSampleDimensions(lvec)
     nDim = rho.shape
-    dims = (nDim[2], nDim[1], nDim[0])
+    dims = (nDim[0], nDim[1], nDim[2])
     xsize, dx = getSize("x", dims, sampleSize)
     ysize, dy = getSize("y", dims, sampleSize)
     zsize, dz = getSize("z", dims, sampleSize)
@@ -261,7 +261,7 @@ def potential2forces(V, lvec, nDim, sigma=0.7, rho=None, multipole=None, tilt=0.
     if verbose > 0:
         print("--- Preprocessing ---")
     sampleSize = getSampleDimensions(lvec)
-    dims = (nDim[2], nDim[1], nDim[0])
+    dims = (nDim[0], nDim[1], nDim[2])
     xsize, dx = getSize("x", dims, sampleSize)
     ysize, dy = getSize("y", dims, sampleSize)
     zsize, dz = getSize("z", dims, sampleSize)
@@ -287,7 +287,7 @@ def potential2forces(V, lvec, nDim, sigma=0.7, rho=None, multipole=None, tilt=0.
 def potential2forces_mem(V, lvec, nDim, sigma=0.7, rho=None, multipole=None, doForce=True, doPot=False, deleteV=True, tilt=0.0):
     print("--- Preprocessing ---")
     sampleSize = getSampleDimensions(lvec)
-    dims = (nDim[2], nDim[1], nDim[0])
+    dims = (nDim[0], nDim[1], nDim[2])
 
     xsize, dx = getSize("x", dims, sampleSize)
     ysize, dy = getSize("y", dims, sampleSize)

--- a/ppafm/io.py
+++ b/ppafm/io.py
@@ -691,10 +691,10 @@ def loadCUBE(fname, verbose=True):
 
 
 def saveWSxM_2D(name_file, data, Xs, Ys):
-    tmp_data = data.flatten()
+    tmp_data = data.flatten(order="F")
     out_data = np.zeros((len(tmp_data), 3))
-    out_data[:, 0] = Xs.flatten()
-    out_data[:, 1] = Ys.flatten()
+    out_data[:, 0] = Xs.flatten(order="F")
+    out_data[:, 1] = Ys.flatten(order="F")
     out_data[:, 2] = tmp_data  # .copy()
     f = open(name_file, "w")
     print("WSxM file copyright Nanotec Electronica", file=f)
@@ -715,7 +715,7 @@ def saveWSxM_3D(prefix, data, extent, slices=None):
     for i in slices:
         print("slice no: ", i)
         fname = prefix + "_%03d.xyz" % i
-        saveWSxM_2D(fname, data[i], Xs, Ys)
+        saveWSxM_2D(fname, data[:, :, i], Xs, Ys)
 
 
 # ================ Npy

--- a/ppafm/ocl/AFMulator.py
+++ b/ppafm/ocl/AFMulator.py
@@ -659,6 +659,7 @@ class AFMulator:
             zs=zTips,
             extent=extent,
             cmap=self.colorscale,
+            reversed_ind=True,
         )
 
 
@@ -844,4 +845,4 @@ def quick_afm(
         scan_window[1][1],
     ]
     zs = np.linspace(scan_window[0][2], scan_window[1][2], scan_dim[2] + 1)[:num_heights]
-    plotImages(os.path.join(out_dir, "df"), X, range(len(X)), extent=extent, zs=zs)
+    plotImages(os.path.join(out_dir, "df"), X, range(len(X)), extent=extent, zs=zs, reversed_ind=True)

--- a/ppafm/ocl/field.py
+++ b/ppafm/ocl/field.py
@@ -227,10 +227,10 @@ class DataGrid:
 
         file_path = str(file_path)
         if file_path.endswith(".cube"):
-            data, lvec, _, _ = io.loadCUBE(file_path, xyz_order=True, verbose=False)
+            data, lvec, _, _ = io.loadCUBE(file_path, verbose=False)
             Zs, x, y, z, _ = io.loadAtomsCUBE(file_path)
         elif file_path.endswith(".xsf"):
-            data, lvec, _, _ = io.loadXSF(file_path, xyz_order=True, verbose=False)
+            data, lvec, _, _ = io.loadXSF(file_path, verbose=False)
             try:
                 (Zs, x, y, z, _), _, _ = io.loadXSFGeom(file_path)
             except ValueError:


### PR DESCRIPTION
Partial step to address #198. Introduces the *xyz* order of numpy indices of arrays that represent fields in the CLI version. Unifies the functions that set the fields to be passed from a `numpy` array to the C++ code under one new function, `setFF` in `ppafm/HighLevel.py`.