### PR TITLE
delete $ symbol, fix #353

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Python package is named as `ppafm`.
 The standard way of installing `ppafm` is:
 
 ```bash
-$ pip install ppafm
+pip install ppafm
 ```
 
 This should install the package and all its dependencies.
@@ -48,8 +48,8 @@ To run them, navigate to the directory and run the `run.sh` script.
 For example:
 
 ```bash
-$ cd examples/PTCDA_single
-$ ./run.sh
+cd examples/PTCDA_single
+./run.sh
 ```
 
 You can study the script to see how to run the simulation.


### PR DESCRIPTION
I find it more convenient to copy the code without these `$ ` symbols, and it also helps maintain consistency. I also think it might be a good idea to update these two wiki pages, though I couldn’t find the source documents in the repository.

1. https://github.com/Probe-Particle/ppafm/wiki/Install-ppafm#enable-gpugui-support
2. https://github.com/Probe-Particle/ppafm/wiki/For-Developers